### PR TITLE
tests directory clean-up 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,16 +272,6 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/drivers/builtin/src
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/core
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/include)
-
-    file(GLOB PSA_CRYPTO_TEST_HELPER_FILES
-         ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_helpers/*.c)
-    add_library(psa_crypto_test_helpers OBJECT ${PSA_CRYPTO_TEST_HELPER_FILES})
-    target_include_directories(psa_crypto_test_helpers
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/drivers/builtin/include
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/drivers/builtin/src
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/core
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/include)
 endif()
 
 if(ENABLE_PROGRAMS)

--- a/scripts/psa_crypto.py
+++ b/scripts/psa_crypto.py
@@ -167,10 +167,28 @@ def copy_from_tests(mbedtls_root_path, psa_crypto_root_path):
         shutil.copy2(os.path.join(scripts_source_path, file_),
                      os.path.join(scripts_destination_path, file_))
 
-    shutil.copytree(os.path.join(source_path, "src"),
-                    os.path.join(destination_path, "src"),
+    ## tests/src
+    src_source_path = os.path.join(source_path, "src")
+    src_destination_path = os.path.join(destination_path, "src")
+    if not os.path.exists(src_destination_path):
+        os.mkdir(src_destination_path)
+
+    src_files = filter(lambda file_: not re.match(
+                       ".*cert.*|"\
+                       "drivers|"\
+                       ".*ssl.*|"\
+                       "test_helpers",
+                       file_), os.listdir(src_source_path))
+    for file_ in src_files:
+        shutil.copy2(os.path.join(src_source_path, file_),
+                     os.path.join(src_destination_path, file_))
+
+    ## tests/src/drivers
+    shutil.copytree(os.path.join(src_source_path, "drivers"),
+                    os.path.join(src_destination_path, "drivers"),
                     dirs_exist_ok=True)
 
+    ## tests/suites
     suites_files = filter(lambda file_: not re.match(
                           "test_suite_x509.*|"\
                           "test_suite_net.*|"\
@@ -189,6 +207,7 @@ def copy_from_tests(mbedtls_root_path, psa_crypto_root_path):
         shutil.copy2(os.path.join(source_path, "suites", file_),
                      os.path.join(destination_path, "suites", file_))
 
+    ## tests/data_files
     shutil.copytree(os.path.join(source_path, "data_files"),
                     os.path.join(destination_path, "data_files"))
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -240,8 +240,7 @@ function(add_test_suite suite_name)
     )
 
     add_executable(test_suite_${data_name} test_suite_${data_name}.c
-                   $<TARGET_OBJECTS:psa_crypto_test>
-                   $<TARGET_OBJECTS:psa_crypto_test_helpers>)
+                   $<TARGET_OBJECTS:psa_crypto_test>)
     add_dependencies(test_suite_${data_name} ${dependency})
     target_link_libraries(test_suite_${data_name} ${libs})
     # Include test-specific header files from ./include and private header


### PR DESCRIPTION
Restrict what we import into the tests directory to what we need. No restrictions on data files as it seems reasonable for them to be in the yet to come test framework and thus be imported as a whole in mbedtls and psa-crypto.