### PR TITLE
Add change log support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,4 @@
+= TF-PSA-Crypto 0.0.0 branch released 2023-11-22
+
+Features
+   * Add initial changelog

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-= TF-PSA-Crypto 0.0.0 branch released 2023-11-22
+= TF-PSA-Crypto 0.1.0 branch released 2023-10-12
 
 Features
    * Add initial changelog

--- a/ChangeLog.d/00README.md
+++ b/ChangeLog.d/00README.md
@@ -1,0 +1,90 @@
+# Pending changelog entry directory
+
+This directory contains changelog entries that have not yet been merged
+to the changelog file ([`../ChangeLog`](../ChangeLog)).
+
+## What requires a changelog entry?
+
+Write a changelog entry if there is a user-visible change. This includes:
+
+* Bug fixes in the library or in sample programs: fixing a security hole,
+  fixing broken behavior, fixing the build in some configuration or on some
+  platform, etc.
+* New features in the library, new sample programs, or new platform support.
+* Changes in existing behavior. These should be rare. Changes in features
+  that are documented as experimental may or may not be announced, depending
+  on the extent of the change and how widely we expect the feature to be used.
+
+We generally don't include changelog entries for:
+
+* Documentation improvements.
+* Performance improvements, unless they are particularly significant.
+* Changes to parts of the code base that users don't interact with directly,
+  such as test code and test data.
+* Fixes for compiler warnings. Releases typically contain a number of fixes
+  of this kind, so we will only mention them in the Changelog if they are
+  particularly significant.
+
+Looking at older changelog entries is good practice for how to write a
+changelog entry, but not for deciding whether to write one.
+
+## Changelog entry file format
+
+A changelog entry file must have the extension `*.txt` and must have the
+following format:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Security
+   * Change description.
+   * Another change description.
+
+Features
+   * Yet another change description. This is a long change description that
+     spans multiple lines.
+   * Yet again another change description.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The permitted changelog entry categories are as follows:
+<!-- Keep this synchronized with STANDARD_CATEGORIES in assemble_changelog.py! -->
+
+    API changes
+    Default behavior changes
+    Requirement changes
+    New deprecations
+    Removals
+    Features
+    Security
+    Bugfix
+    Changes
+
+Use “Changes” for anything that doesn't fit in the other categories.
+
+## How to write a changelog entry
+
+Each entry starts with three spaces, an asterisk and a space. Continuation
+lines start with 5 spaces. Lines wrap at 79 characters.
+
+Write full English sentences with proper capitalization and punctuation. Use
+the present tense. Use the imperative where applicable. For example: “Fix a
+bug in mbedtls_xxx() ….”
+
+Include GitHub issue numbers where relevant. Use the format “#1234” for a
+TF-PSA-Crypto issue. Add other external references such as CVE numbers where
+applicable.
+
+Credit bug reporters where applicable.
+
+**Explain why, not how**. Remember that the audience is the users of the
+library, not its developers. In particular, for a bug fix, explain the
+consequences of the bug, not how the bug was fixed. For a new feature, explain
+why one might be interested in the feature. For an API change or a deprecation,
+explain how to update existing applications.
+
+See [existing entries](../ChangeLog) for examples.
+
+## How `ChangeLog` is updated
+
+Run [`../scripts/assemble_changelog.py`](../scripts/assemble_changelog.py)
+from a Git working copy
+to move the entries from files in `ChangeLog.d` to the main `ChangeLog` file.

--- a/scripts/psa_crypto.py
+++ b/scripts/psa_crypto.py
@@ -95,6 +95,7 @@ def copy_from_scripts(mbedtls_root_path, psa_crypto_root_path):
     shutil.copy2(os.path.join(source_path, "config.py"), destination_path)
     shutil.copy2(os.path.join(source_path, "min_requirements.py"), destination_path)
     shutil.copy2(os.path.join(source_path, "lcov.sh"), destination_path)
+    shutil.copy2(os.path.join(source_path, "assemble_changelog.py"), destination_path)
 
     for path in pathlib.Path(source_path).glob("*.requirements.txt"):
         shutil.copy2(str(path), destination_path)

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -1,3 +1,15 @@
+component_check_changelog () {
+    msg "Check: changelog entries" # < 1s
+    rm -f ChangeLog.new
+    scripts/assemble_changelog.py -o ChangeLog.new
+    if [ -e ChangeLog.new ]; then
+        # Show the diff for information. It isn't an error if the diff is
+        # non-empty.
+        diff -u ChangeLog ChangeLog.new || true
+        rm ChangeLog.new
+    fi
+}
+
 component_test_default_cmake_gcc_asan () {
     msg "build: default, gcc, ASan"
 


### PR DESCRIPTION
## Description

Add support to create an initial changelog entry if no entries found and specify the name of the project from the previous entries.

Resolve #47 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required, only internal change
- [x] **backport** not required, new feature
- [x] **tests** not required, already exists
