### PR TITLE
Add component for check_generated_files testing

### DIFF
--- a/scripts/psa_crypto.py
+++ b/scripts/psa_crypto.py
@@ -153,6 +153,7 @@ def copy_from_tests(mbedtls_root_path, psa_crypto_root_path):
                            "generate_test_code.py|"\
                            "scripts_path.py|"\
                            "test_generate_test_code.py|"\
+                           "check_generated_files.sh|"\
                            "test_psa_compliance.py",
                            file_), os.listdir(scripts_source_path))
     for file_ in scripts_files:

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -164,13 +164,8 @@ component_test_psa_drivers () {
 
 component_check_generated_files () {
     msg "Check: check-generated-files, files generated with cmake" # ~2min
-    TF_PSA_CRYPTO_ROOT_DIR="$PWD"
-    mkdir "$OUT_OF_SOURCE_DIR"
-    cd "$OUT_OF_SOURCE_DIR"
-
-    cmake -DGEN_FILES=On ..
+    cmake -DGEN_FILES=On .
     cmake --build .
-    cd -
     tests/scripts/check-generated-files.sh
 
     msg "Check: check-generated-files -u, files present" # 2s
@@ -179,23 +174,13 @@ component_check_generated_files () {
     tests/scripts/check-generated-files.sh
 
     # msg "Check: check-generated-files -u, files absent" # 2s
-    # #command make neat
-    cd "$TF_PSA_CRYPTO_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
 
-    mkdir "$OUT_OF_SOURCE_DIR"
-    cd "$OUT_OF_SOURCE_DIR"
-
-    cmake -DGEN_FILES=Off ..
-    cmake --build .
-    cd -
+    cmake -DGEN_FILES=Off .
+    cmake --build . --clean-first
 
     tests/scripts/check-generated-files.sh -u
     # Check that the generated files are considered up to date.
     tests/scripts/check-generated-files.sh
-
-    cd "$TF_PSA_CRYPTO_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
 
     # This component ends with the generated files present in the source tree.
     # This is necessary for subsequent components!

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -161,3 +161,42 @@ component_test_psa_drivers () {
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
 }
+
+component_check_generated_files () {
+    msg "Check: check-generated-files, files generated with cmake" # ~2min
+    TF_PSA_CRYPTO_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    cmake -DGEN_FILES=On ..
+    cmake --build .
+    cd -
+    tests/scripts/check-generated-files.sh
+
+    msg "Check: check-generated-files -u, files present" # 2s
+    tests/scripts/check-generated-files.sh -u
+    # Check that the generated files are considered up to date.
+    tests/scripts/check-generated-files.sh
+
+    # msg "Check: check-generated-files -u, files absent" # 2s
+    # #command make neat
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    cmake -DGEN_FILES=Off ..
+    cmake --build .
+    cd -
+
+    tests/scripts/check-generated-files.sh -u
+    # Check that the generated files are considered up to date.
+    tests/scripts/check-generated-files.sh
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+
+    # This component ends with the generated files present in the source tree.
+    # This is necessary for subsequent components!
+}


### PR DESCRIPTION
Fixes #50 (partially) along with [Mbed TLS PR 8523.](https://github.com/Mbed-TLS/mbedtls/pull/8523).

This PR adds an all.sh component that is designed to replicate the same level of testing that `component_check_generated_files` achieves in Mbed TLS.

Note to reviewers:- I don't think this PR is quite complete, but I would appreciate some feedback on what might need to happen to get it there. Thanks.