### PR TITLE
Introduce project_name.txt file

### DIFF
--- a/scripts/project_name.txt
+++ b/scripts/project_name.txt
@@ -1,0 +1,1 @@
+TF-PSA-Crypto


### PR DESCRIPTION
In TF-PSA-Crypto this file contains the string "TF-PSA-Crypto". It will be used by scripts as a
robust method for checking which project the script is being called from.

This is part of the work being done to address [Mbed TLS issue #8524](https://github.com/Mbed-TLS/mbedtls/issues/8524). The modifications to the shell scripts to use this new file will be done on the Mbed TLS side, hence just the text file itself is needed here on TF-PSA-Crypto.

Related [Mbed TLS PR](https://github.com/Mbed-TLS/mbedtls/pull/8609).