### PR TITLE
Add check recursion and check test cases all.sh components

### DIFF
--- a/scripts/psa_crypto.py
+++ b/scripts/psa_crypto.py
@@ -153,7 +153,8 @@ def copy_from_tests(mbedtls_root_path, psa_crypto_root_path):
                            "generate_test_code.py|"\
                            "scripts_path.py|"\
                            "test_generate_test_code.py|"\
-                           "test_psa_compliance.py",
+                           "test_psa_compliance.py|",\
+                           "recursion.pl",
                            file_), os.listdir(scripts_source_path))
     for file_ in scripts_files:
         shutil.copy2(os.path.join(scripts_source_path, file_),

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -210,6 +210,7 @@ component_test_cmake_shared () {
 component_check_recursion () {
     msg "Check: recursion.pl" # < 1s
     tests/scripts/recursion.pl core/*.c
+    tests/scripts/recursion.pl drivers/builtin/src/*.c
 }
 
 component_check_test_cases () {

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -206,3 +206,19 @@ component_test_cmake_shared () {
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
 }
+
+component_check_recursion () {
+    msg "Check: recursion.pl" # < 1s
+    tests/scripts/recursion.pl library/*.c
+}
+
+component_check_test_cases () {
+    msg "Check: test case descriptions" # < 1s
+    if [ $QUIET -eq 1 ]; then
+        opt='--quiet'
+    else
+        opt=''
+    fi
+    tests/scripts/check_test_cases.py -q $opt
+    unset opt
+}

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -209,7 +209,7 @@ component_test_cmake_shared () {
 
 component_check_recursion () {
     msg "Check: recursion.pl" # < 1s
-    tests/scripts/recursion.pl library/*.c
+    tests/scripts/recursion.pl core/*.c
 }
 
 component_check_test_cases () {


### PR DESCRIPTION
Fixes #53 

This PR adds the all.sh components for `check_recursion` and `check_test_cases` and adds `recursion.pl` to the list of scripts to copy in `psa_crypto.py`.