### PR TITLE
Add name checks

### DIFF
--- a/scripts/psa_crypto.py
+++ b/scripts/psa_crypto.py
@@ -147,6 +147,7 @@ def copy_from_tests(mbedtls_root_path, psa_crypto_root_path):
     scripts_files = filter(lambda file_: re.match(
                            "all.sh|"\
                            "analyze_outcomes.py|"\
+                           "check_names.py|"\
                            "check_test_cases.py|"\
                            "generate_bignum_tests.py|"\
                            "generate_ecp_tests.py|"\

--- a/tests/all_sh_components.txt
+++ b/tests/all_sh_components.txt
@@ -10,6 +10,11 @@ component_check_changelog () {
     fi
 }
 
+component_check_names () {
+    msg "Check: declared and exported names (builds the library)" # < 3s
+    tests/scripts/check_names.py -v
+}
+
 component_test_default_cmake_gcc_asan () {
     msg "build: default, gcc, ASan"
 


### PR DESCRIPTION
Adapt tests/scripts/check_names.py to work for both mbedtls and psa-crypto.
Add component_check_names all.sh component.

Resolve #52

Depends on #58, Mbed-TLS/mbedtls#8651
