### PR TITLE
Switch generate_psa_test.py to automatic dependencies for positive test cases

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/macro_collector.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_information.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_storage.py
+            ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_data_generation.py
             ${CMAKE_CURRENT_SOURCE_DIR}/../include/psa/crypto_config.h


### PR DESCRIPTION
Mostly happening in the framework, see Mbed-TLS/mbedtls-framework#83.

Ready for review if the CI agrees.

## PR checklist

- [x] **changelog** not required because: mostly test stuff, also undocumented  makefile usage
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9841
- [x] **crypto PR** here
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#83
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9796
- [x] **2.28 PR** partial forward port from https://github.com/Mbed-TLS/mbedtls/pull/9025, nothing new now
- **tests**  provided
