### PR TITLE
Remove USE_PSA from standalone documentation

### DIFF
--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -200,7 +200,8 @@ consequence these are not supported in builds without `MBEDTLS_ECDSA_C`.
 
 Similarly, there is no PSA support for interruptible ECDH operations so these
 are not supported without `ECDH_C`. See also limitations regarding
-restartable operations in [the documentation about using PSA Crypto](use-psa-crypto.md).
+restartable operations in [the documentation about PSA Crypto
+limitations](docs/architecture/psa-migration/psa-limitations.md).
 
 Again, we have plans to support this in the future but not with an established
 timeline, please let us know if you're interested.

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -14,10 +14,7 @@ Otherwise, please see the [PSA driver example and
 guide](psa-driver-example-and-guide.md) for information on writing a
 driver.
 
-In order to have some mechanism provided only by a driver, you'll want
-the `MBEDTLS_PSA_CRYPTO_C` option enabled (enabled by default).
-
-In addition, for each mechanism you want provided only by your driver:
+For each mechanism you want provided only by your driver:
 
 - Define the corresponding `PSA_WANT` macro in `psa/crypto_config.h` - this
   means the algorithm will be available in the PSA Crypto API.
@@ -32,11 +29,8 @@ For example, if you want SHA-256 to be provided only by a driver, you'll want
 `PSA_WANT_ALG_SHA_256` and `MBEDTLS_PSA_ACCEL_SHA_256` defined, and
 `MBEDTLS_SHA256_C` undefined.
 
-In addition to these compile-time considerations, at runtime you'll need to
-make sure you call `psa_crypto_init()` before any function that uses the
-driver-only mechanisms. Note that this is already a requirement for any use of
-the PSA Crypto API, as well as for use of the PK, X.509 and TLS modules, so in
-most cases your application will already be doing this.
+Recall that applications must call `psa_crypto_init()` prior to performing any
+cryptographic or key management operation.
 
 Mechanisms covered
 ------------------
@@ -206,7 +200,7 @@ consequence these are not supported in builds without `MBEDTLS_ECDSA_C`.
 
 Similarly, there is no PSA support for interruptible ECDH operations so these
 are not supported without `ECDH_C`. See also limitations regarding
-restartable operations in [its documentation](use-psa-crypto.md).
+restartable operations in [the documentation about using PSA Crypto](use-psa-crypto.md).
 
 Again, we have plans to support this in the future but not with an established
 timeline, please let us know if you're interested.
@@ -254,8 +248,8 @@ The same holds for the associated algorithm:
 removing builtin support (i.e. `MBEDTLS_DHM_C`).
 
 Note that the PSA API only supports FFDH with RFC 7919 groups, whereas the
-Mbed TLS legacy API supports custom groups. As a consequence, the TLS layer
-of Mbed TLS only supports DHE cipher suites if built-in FFDH (`MBEDTLS_DHM_C`)
+Mbed TLS legacy API supports custom groups. As a consequence, the TLS 1.2
+in Mbed TLS only supports DHE cipher suites if built-in FFDH (`MBEDTLS_DHM_C`)
 is present.
 
 RSA

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -199,9 +199,9 @@ At the moment, there is no driver support for interruptible operations
 consequence these are not supported in builds without `MBEDTLS_ECDSA_C`.
 
 Similarly, there is no PSA support for interruptible ECDH operations so these
-are not supported without `ECDH_C`. See also limitations regarding
-restartable operations in [the documentation about PSA Crypto
-limitations](docs/architecture/psa-migration/psa-limitations.md).
+are not supported without `ECDH_C`. See also limitations regarding restartable
+operations in [the documentation of
+MBEDTLS_ECP_RESTARTABLE](include/psa/crypto_config.h).
 
 Again, we have plans to support this in the future but not with an established
 timeline, please let us know if you're interested.

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -15,13 +15,7 @@ guide](psa-driver-example-and-guide.md) for information on writing a
 driver.
 
 In order to have some mechanism provided only by a driver, you'll want
-the following compile-time configuration options enabled:
-
-- `MBEDTLS_PSA_CRYPTO_C` (enabled by default) - this enables PSA Crypto.
-- `MBEDTLS_USE_PSA_CRYPTO` (disabled by default) - this makes PK, X.509 and
-  TLS use PSA Crypto. You need to enable this if you're using PK, X.509 or TLS
-and want them to have access to the algorithms provided by your driver. (See
-[the dedicated document](use-psa-crypto.md) for details.)
+the `MBEDTLS_PSA_CRYPTO_C` option enabled (enabled by default).
 
 In addition, for each mechanism you want provided only by your driver:
 
@@ -41,9 +35,8 @@ For example, if you want SHA-256 to be provided only by a driver, you'll want
 In addition to these compile-time considerations, at runtime you'll need to
 make sure you call `psa_crypto_init()` before any function that uses the
 driver-only mechanisms. Note that this is already a requirement for any use of
-the PSA Crypto API, as well as for use of the PK, X.509 and TLS modules when
-`MBEDTLS_USE_PSA_CRYPTO` is enabled, so in most cases your application will
-already be doing this.
+the PSA Crypto API, as well as for use of the PK, X.509 and TLS modules, so in
+most cases your application will already be doing this.
 
 Mechanisms covered
 ------------------
@@ -66,10 +59,9 @@ For each family listed above, all the mentioned alorithms/key types are also
 all the mechanisms that exist in PSA API.
 
 Supported means that when those are provided only by drivers, everything
-(including PK, X.509 and TLS if `MBEDTLS_USE_PSA_CRYPTO` is enabled) should
-work in the same way as if the mechanisms where built-in, except as documented
-in the "Limitations" sub-sections of the sections dedicated to each family
-below.
+(including PK, X.509 and TLS) should work in the same way as if the mechanisms
+where built-in, except as documented in the "Limitations" sub-sections of the
+sections dedicated to each family below.
 
 Hashes
 ------
@@ -168,8 +160,7 @@ In addition, if:
 then you can also disable `MBEDTLS_BIGNUM_C`.
 
 In such builds, all crypto operations via the PSA Crypto API will work as
-usual, as well as the PK, X.509 and TLS modules if `MBEDTLS_USE_PSA_CRYPTO` is
-enabled, with the following exceptions:
+usual, as well as the PK, X.509 and TLS modules, with the following exceptions:
 
 - direct calls to APIs from the disabled modules are not possible;
 - PK, X.509 and TLS will not support restartable ECC operations (see
@@ -215,8 +206,7 @@ consequence these are not supported in builds without `MBEDTLS_ECDSA_C`.
 
 Similarly, there is no PSA support for interruptible ECDH operations so these
 are not supported without `ECDH_C`. See also limitations regarding
-restartable operations with `MBEDTLS_USE_PSA_CRYPTO` in [its
-documentation](use-psa-crypto.md).
+restartable operations in [its documentation](use-psa-crypto.md).
 
 Again, we have plans to support this in the future but not with an established
 timeline, please let us know if you're interested.
@@ -265,8 +255,8 @@ removing builtin support (i.e. `MBEDTLS_DHM_C`).
 
 Note that the PSA API only supports FFDH with RFC 7919 groups, whereas the
 Mbed TLS legacy API supports custom groups. As a consequence, the TLS layer
-of Mbed TLS only supports DHE cipher suites if built-in FFDH
-(`MBEDTLS_DHM_C`) is present, even when `MBEDTLS_USE_PSA_CRYPTO` is enabled.
+of Mbed TLS only supports DHE cipher suites if built-in FFDH (`MBEDTLS_DHM_C`)
+is present.
 
 RSA
 ---
@@ -287,7 +277,7 @@ then you can disable `MBEDTLS_RSA_C`, `MBEDTLS_PKCS1_V15` and
 
 Unlike other mechanisms, for now in configurations with driver-only RSA, only
 PSA Crypto works. In particular, PK, X.509 and TLS will _not_ work with
-driver-only RSA even if `MBEDTLS_USE_PSA_CRYPTO` is enabled.
+driver-only RSA.
 
 Currently (early 2024) we don't have plans to extend this support. If you're
 interested in wider driver-only support for RSA, please let us know.
@@ -339,9 +329,8 @@ algorithm/mode you can:
   - `MBEDTLS_NULL_CIPHER`.
 
 Once a key type and related algorithm are accelerated, all the PSA Crypto APIs
-will work, as well as X.509 and TLS (with `MBEDTLS_USE_PSA_CRYPTO` enabled) but
-some non-PSA APIs will be absent or have reduced functionality, see
-[Restrictions](#restrictions) for details.
+will work, as well as X.509 and TLS but some non-PSA APIs will be absent or
+have reduced functionality, see [Restrictions](#restrictions) for details.
 
 ### Restrictions
 
@@ -424,13 +413,12 @@ from PSA acceleration if both of the following conditions are met:
 
 ### Disabling `MBEDTLS_CIPHER_C`
 
-It is possible to save code size by disabling MBEDTLS_CIPHER_C when all of the 
+It is possible to save code size by disabling MBEDTLS_CIPHER_C when all of the
 following conditions are met:
 
 - The application is not using the `mbedtls_cipher_` API.
 - In PSA, all unauthenticated (that is, non-AEAD) ciphers are either disabled or
   fully accelerated (that is, all compatible key types are accelerated too).
-- Either TLS is disabled, or `MBEDTLS_USE_PSA_CRYPTO` is enabled.
 - `MBEDTLS_NIST_KW` is disabled.
 - `MBEDTLS_CMAC_C` is disabled. (Note: support for CMAC in PSA can be provided by
   a driver.)

--- a/docs/driver-only-builds.md
+++ b/docs/driver-only-builds.md
@@ -249,8 +249,10 @@ removing builtin support (i.e. `MBEDTLS_DHM_C`).
 
 Note that the PSA API only supports FFDH with RFC 7919 groups, whereas the
 Mbed TLS legacy API supports custom groups. As a consequence, the TLS 1.2
-in Mbed TLS only supports DHE cipher suites if built-in FFDH (`MBEDTLS_DHM_C`)
-is present.
+layer of Mbed TLS only supports DHE cipher suites if built-in FFDH
+(`MBEDTLS_DHM_C`) is present, even when `MBEDTLS_USE_PSA_CRYPTO` is enabled.
+(The TLS 1.3 layer uses PSA, and this is not a limitation because the
+protocol does not allow custom FFDH groups.)
 
 RSA
 ---

--- a/docs/proposed/psa-conditional-inclusion-c.md
+++ b/docs/proposed/psa-conditional-inclusion-c.md
@@ -67,7 +67,7 @@ A PSA Crypto configuration symbol is a C preprocessor symbol whose name starts w
 The presence of a symbol `PSA_WANT_xxx` in the Mbed TLS configuration determines whether a feature is available through the PSA API. These symbols should be used in any place that requires conditional compilation based on the availability of a cryptographic mechanism through the PSA API, including:
 
 * In Mbed TLS test code.
-* In Mbed TLS library code using `MBEDTLS_USE_PSA_CRYPTO`, for example in TLS to determine which cipher suites to enable.
+* In Mbed TLS library code, for example in TLS to determine which cipher suites to enable.
 * In application code that provides additional features based on cryptographic capabilities, for example additional key parsing and formatting functions, or cipher suite availability for network protocols.
 
 #### Configuration symbol semantics


### PR DESCRIPTION
This is the crypto part of https://github.com/Mbed-TLS/mbedtls/pull/9818. The last commit is the only new commit, the rest is a result of rebasing the original PR.

I checked for broken references like this:
```
grep -r -ho '[a-zA-Z\_-]*\.md' docs | sort | uniq > filelist.txt
cat filelist.txt | xargs -I filename find . -name filename
<manually check that every file is found>
```