### PR TITLE
Make legacy declarations private: macro guard

### DIFF
--- a/docs/4.0-migration-guide/private-decls.md
+++ b/docs/4.0-migration-guide/private-decls.md
@@ -1,0 +1,34 @@
+## Low-level crypto functions are no longer part of the public API
+
+Low-level crypto functions, that is, all non-PSA crypto functions except a few
+that don't have a proper PSA replacement yet, have been removed from the public
+API.
+
+If your application was using those functions, please see
+`docs/psa-transition.md` (currently in the Mbed TLS repo) for ways to migrate to
+the PSA API instead.
+
+Some of the associated types (for example, `mbedtls_aes_context`) still need to
+be visible to the compiler, so the headers declaring them (for example, `aes.h`)
+are still on the default include path, but we recommend you no longer include
+them directly.
+
+Sample programs have not been fully updated yet and some of them might still
+use APIs that are no longer public. You can recognize them by the fact that they
+define the macro `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS` (or
+`MBEDTLS_ALLOW_PRIVATE_ACCESS`) at the very top (before including headers). When
+you see one of these two macros in a sample program, be aware it has not been
+updating and parts of it do not demonstrate current practice.
+
+We strongly recommend against defining `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS` or
+`MBEDTLS_ALLOW_PRIVATE_ACCESS` in your own application. If you do so, you code
+may not compile or work with future minor releases. If there's something you
+want to do that you feel can only be achieved by using one of these two macros,
+please reach out on github or the mailing list.
+
+The following modules had functions removed from the public API:
+- see private-decls/ subdirectory for now - one file per header, to avoid
+  conflicts caused by all PRs editing the same place in this file, to be merged
+  at the end as part of https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/232
+- also do one brief ChangeLog entry per PR, with a name starting with privatize
+  (eg privatize-aes.txt), also to be merged at the end as part of 232.

--- a/docs/4.0-migration-guide/private-decls.md
+++ b/docs/4.0-migration-guide/private-decls.md
@@ -18,10 +18,10 @@ use APIs that are no longer public. You can recognize them by the fact that they
 define the macro `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS` (or
 `MBEDTLS_ALLOW_PRIVATE_ACCESS`) at the very top (before including headers). When
 you see one of these two macros in a sample program, be aware it has not been
-updating and parts of it do not demonstrate current practice.
+updated and parts of it do not demonstrate current practice.
 
 We strongly recommend against defining `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS` or
-`MBEDTLS_ALLOW_PRIVATE_ACCESS` in your own application. If you do so, you code
+`MBEDTLS_ALLOW_PRIVATE_ACCESS` in your own application. If you do so, your code
 may not compile or work with future minor releases. If there's something you
 want to do that you feel can only be achieved by using one of these two macros,
 please reach out on github or the mailing list.

--- a/docs/4.0-migration-guide/private-decls/00README
+++ b/docs/4.0-migration-guide/private-decls/00README
@@ -1,0 +1,5 @@
+Temporary sub-directory to avoid conflicts in private-decls.md.
+Will be merged back to private-decls.md as part of
+https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/232
+
+One file per header, with .md extension (and valid markdown content).

--- a/drivers/builtin/include/mbedtls/private_access.h
+++ b/drivers/builtin/include/mbedtls/private_access.h
@@ -1,7 +1,10 @@
 /**
  * \file private_access.h
  *
- * \brief Macro wrapper for struct's members.
+ * \brief Optionally activate declarations of private identifiers
+ *        in public headers.
+ *
+ * This header is reserved for internal use in TF-PSA-Crypto and Mbed TLS.
  */
 /*
  *  Copyright The Mbed TLS Contributors
@@ -12,9 +15,27 @@
 #define MBEDTLS_PRIVATE_ACCESS_H
 
 #ifndef MBEDTLS_ALLOW_PRIVATE_ACCESS
+/* Public use: do not declare private identifiers. */
+
+/* Pseudo-hide an identifier (typically a struct or union member) by giving
+ * it the prefix `private_`.
+ *
+ * Typical usage:
+ * ```
+ * typedef struct {
+ *     int MBEDTLS_PRIVATE(foo); // private member (not part of the public API,
+ *                               // but part of the ABI)
+ *     int bar; // public member (covered by API stability guarantees)
+ * } mbedtls_some_type_t;
+ * ```
+ */
 #define MBEDTLS_PRIVATE(member) private_##member
+
 #else
+/* Private use: declare private identifiers. */
+
 #define MBEDTLS_PRIVATE(member) member
+
 #endif
 
 #endif /* MBEDTLS_PRIVATE_ACCESS_H */

--- a/drivers/builtin/include/mbedtls/private_access.h
+++ b/drivers/builtin/include/mbedtls/private_access.h
@@ -37,15 +37,15 @@
 #define MBEDTLS_PRIVATE(member) member
 
 /* Activate declarations guarded by this macro.
-*
-* Typical usage:
-* ```
-* typedef ... mbedtls_some_type_t; // built-in crypto type
-* #if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
-* int mbedtls_some_function(...); // built-in crypto function
-* #endif // MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
-* ```
-*/
+ *
+ * Typical usage:
+ * ```
+ * typedef ... mbedtls_some_type_t; // built-in crypto type
+ * #if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+ * int mbedtls_some_function(...); // built-in crypto function
+ * #endif // MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+ * ```
+ */
 #define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 
 #endif

--- a/drivers/builtin/include/mbedtls/private_access.h
+++ b/drivers/builtin/include/mbedtls/private_access.h
@@ -36,6 +36,18 @@
 
 #define MBEDTLS_PRIVATE(member) member
 
+/* Activate declarations guarded by this macro.
+*
+* Typical usage:
+* ```
+* typedef ... mbedtls_some_type_t; // built-in crypto type
+* #if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+* int mbedtls_some_function(...); // built-in crypto function
+* #endif // MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+* ```
+*/
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+
 #endif
 
 #endif /* MBEDTLS_PRIVATE_ACCESS_H */

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -5,6 +5,8 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+
 #include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"


### PR DESCRIPTION
Make legacy functions private by guarding their declaration with a macro.

As an example, do `cipher.h` (functions only, I didn't check if some macros and types should become private).

This is up for design review. There is no update to documentation yet. Some open questions:

* Is this approach ok? It's a quick win for not having legacy functions declared .
* Whether we want to update documentation at the same time we make things private, or later.
* Whether we want to add changelog entries, and whether to do it incrementally or all at once at the end.

Resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/219, ~https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/220~ (scope restricted to 219).

~Prerequisite: https://github.com/Mbed-TLS/mbedtls/pull/9868 to avoid breaking mbedtls.~ (Was only a prerequisite for the part addressing 220.)

## PR checklist

- [x] **changelog** not required because: no user-visible change in this PR
- [x] **framework PR** not required
- [x] **mbedtls PR** not required, but see https://github.com/Mbed-TLS/mbedtls/pull/10089 though
- **tests**  provided
