### PR TITLE
PSA interruptible sign/verify: detect invalid curve family in start

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -4110,8 +4110,12 @@ psa_status_t mbedtls_psa_sign_hash_start(
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     size_t required_hash_length;
 
-    if (!PSA_KEY_TYPE_IS_ECC(attributes->type)) {
+    if (!PSA_KEY_TYPE_IS_ECC_KEY_PAIR(attributes->type)) {
         return PSA_ERROR_NOT_SUPPORTED;
+    }
+    psa_ecc_family_t curve = PSA_KEY_TYPE_ECC_GET_FAMILY(attributes->type);
+    if (!PSA_ECC_FAMILY_IS_WEIERSTRASS(curve)) {
+        return PSA_ERROR_INVALID_ARGUMENT;
     }
 
     if (!can_do_interruptible_sign_verify(alg)) {
@@ -4328,6 +4332,10 @@ psa_status_t mbedtls_psa_verify_hash_start(
 
     if (!PSA_KEY_TYPE_IS_ECC(attributes->type)) {
         return PSA_ERROR_NOT_SUPPORTED;
+    }
+    psa_ecc_family_t curve = PSA_KEY_TYPE_ECC_GET_FAMILY(attributes->type);
+    if (!PSA_ECC_FAMILY_IS_WEIERSTRASS(curve)) {
+        return PSA_ERROR_INVALID_ARGUMENT;
     }
 
     if (!can_do_interruptible_sign_verify(alg)) {


### PR DESCRIPTION
https://github.com/Mbed-TLS/mbedtls-framework/pull/104 fixes a bug whereby some negative tests were always skipped (because they were generated with incorrect dependencies). These test cases fail because the test code is more strict about error behavior than the library. Make the library detect some errors earlier to reconcile it with the test code.

Once this is merged, the CI on https://github.com/Mbed-TLS/mbedtls-framework/pull/104 should pass.

## PR checklist

- [x] **changelog** not required because: no change in behavior guarantees
- [x] **crypto PR** here
- [x] **development PR** provided # | not required because: crypto only
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9890
- [x] **2.28 PR** not required because: this part of 2.28 won't change anymore
- **tests**  provided | not required because: 
