### PR TITLE
Register Name Constraints extension and BPv7 OIDs

### DIFF
--- a/ChangeLog.d/register-name-constraints.txt
+++ b/ChangeLog.d/register-name-constraints.txt
@@ -1,0 +1,3 @@
+Features
+   * Register Name Constraints extension.
+   * Add OIDs for BPv7 from RFC 9174.

--- a/drivers/builtin/include/mbedtls/oid.h
+++ b/drivers/builtin/include/mbedtls/oid.h
@@ -202,6 +202,7 @@
 #define MBEDTLS_OID_EMAIL_PROTECTION            MBEDTLS_OID_KP "\x04" /**< id-kp-emailProtection OBJECT IDENTIFIER ::= { id-kp 4 } */
 #define MBEDTLS_OID_TIME_STAMPING               MBEDTLS_OID_KP "\x08" /**< id-kp-timeStamping OBJECT IDENTIFIER ::= { id-kp 8 } */
 #define MBEDTLS_OID_OCSP_SIGNING                MBEDTLS_OID_KP "\x09" /**< id-kp-OCSPSigning OBJECT IDENTIFIER ::= { id-kp 9 } */
+#define MBEDTLS_OID_BUNDLE_SECURITY             MBEDTLS_OID_KP "\x23" /**< id-kp-bundleSecurity OBJECT IDENTIFIER ::= { id-kp 35 } */
 
 /**
  * Wi-SUN Alliance Field Area Network
@@ -212,6 +213,7 @@
 
 #define MBEDTLS_OID_ON                          MBEDTLS_OID_PKIX "\x08" /**< id-on OBJECT IDENTIFIER ::= { id-pkix 8 } */
 #define MBEDTLS_OID_ON_HW_MODULE_NAME           MBEDTLS_OID_ON "\x04" /**< id-on-hardwareModuleName OBJECT IDENTIFIER ::= { id-on 4 } */
+#define MBEDTLS_OID_ON_BUNDLE_EID               MBEDTLS_OID_ON "\x0b" /**< id-on-bundleEID OBJECT IDENTIFIER ::= { id-on 11 } */
 
 /*
  * PKCS definition OIDs

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -279,7 +279,15 @@ static const oid_x509_ext_t oid_x509_ext[] =
         MBEDTLS_OID_X509_EXT_BASIC_CONSTRAINTS,
     },
     {
-        OID_DESCRIPTOR(MBEDTLS_OID_KEY_USAGE,            "id-ce-keyUsage",            "Key Usage"),
+        OID_DESCRIPTOR(MBEDTLS_OID_NAME_CONSTRAINTS,
+                       "id-ce-nameConstraints",
+                       "Name Constraints"),
+        MBEDTLS_OID_X509_EXT_NAME_CONSTRAINTS,
+    },
+    {
+        OID_DESCRIPTOR(MBEDTLS_OID_KEY_USAGE,
+                       "id-ce-keyUsage",
+                       "Key Usage"),
         MBEDTLS_OID_X509_EXT_KEY_USAGE,
     },
     {
@@ -343,6 +351,9 @@ static const mbedtls_oid_descriptor_t oid_ext_key_usage[] =
     OID_DESCRIPTOR(MBEDTLS_OID_WISUN_FAN,
                    "id-kp-wisun-fan-device",
                    "Wi-SUN Alliance Field Area Network (FAN)"),
+    OID_DESCRIPTOR(MBEDTLS_OID_BUNDLE_SECURITY,
+                   "id-kp-bundleSecurity",
+                   "Bundle Protocol Security"),
     NULL_OID_DESCRIPTOR,
 };
 

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -28,6 +28,9 @@ oid_get_extended_key_usage:"2B06010505070309":"OCSP Signing"
 OID get Ext Key Usage - id-kp-wisun-fan-device
 oid_get_extended_key_usage:"2B0601040182E42501":"Wi-SUN Alliance Field Area Network (FAN)"
 
+OID get Ext Key Usage - id-kp-bundleSecurity
+oid_get_extended_key_usage:"2B06010505070323":"Bundle Protocol Security"
+
 OID get Ext Key Usage invalid oid
 oid_get_extended_key_usage:"5533445566":""
 


### PR DESCRIPTION
## Description

This registers the Name Constraints extension OID and adds OIDs related to BPv7 in [RFC 9174](https://www.rfc-editor.org/rfc/rfc9174.html).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **framework PR** not required
- [ ] **mbedtls PR** provided Mbed-TLS/mbedtls#9894
- [x] **tests**  provided

Closes #146 