### PR TITLE
[TF-PSA-Crypto] Move most of min_requirements.py to the framework

### DIFF
--- a/scripts/basic.requirements.txt
+++ b/scripts/basic.requirements.txt
@@ -1,0 +1,5 @@
+# Python modules required to build Mbed TLS in ordinary conditions.
+
+# Required to (re-)generate source files. Not needed if the generated source
+# files are already present and up-to-date.
+-r driver.requirements.txt

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -1,0 +1,28 @@
+# Python package requirements for Mbed TLS testing.
+
+-r driver.requirements.txt
+
+# Use a known version of Pylint, because new versions tend to add warnings
+# that could start rejecting our code.
+# 2.4.4 is the version in Ubuntu 20.04. It supports Python >=3.5.
+pylint == 2.4.4
+
+# Use a version of mypy that is compatible with our code base.
+# mypy <0.940 is known not to work: see commit
+#  :/Upgrade mypy to the last version supporting Python 3.6
+# mypy >=0.960 is known not to work:
+#   https://github.com/Mbed-TLS/mbedtls-framework/issues/50
+# mypy 0.942 is the version in Ubuntu 22.04.
+mypy == 0.942
+
+# At the time of writing, only needed for tests/scripts/audit-validity-dates.py.
+# It needs >=35.0.0 for correct operation, and that requires Python >=3.6,
+# but our CI has Python 3.5. So let pip install the newest version that's
+# compatible with the running Python: this way we get something good enough
+# for mypy and pylint under Python 3.5, and we also get something good enough
+# to run audit-validity-dates.py on Python >=3.6.
+cryptography # >= 35.0.0
+
+# For building `framework/data_files/server9-bad-saltlen.crt` and check python
+# files.
+asn1crypto

--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -1,0 +1,19 @@
+# Python package requirements for driver implementers.
+
+# Jinja2 <3.0 needs an older version of markupsafe, but does not
+# declare it.
+#   https://github.com/pallets/markupsafe/issues/282
+#   https://github.com/pallets/jinja/issues/1585
+markupsafe < 2.1
+
+# Use the version of Jinja that's in Ubuntu 20.04.
+# See https://github.com/Mbed-TLS/mbedtls/pull/5067#discussion_r738794607 .
+# Note that Jinja 3.0 drops support for Python 3.5, so we need to support
+# Jinja 2.x as long as we're still using Python 3.5 anywhere.
+# Jinja 2.10.1 doesn't support Python 3.10+
+Jinja2 >= 2.10.1; python_version <  '3.10'
+Jinja2 >= 2.10.3; python_version >= '3.10'
+# Jinja2 >=2.10, <3.0 needs a separate package for type annotations
+types-Jinja2 >= 2.11.9
+jsonschema >= 3.2.0
+types-jsonschema >= 3.2.0

--- a/scripts/maintainer.requirements.txt
+++ b/scripts/maintainer.requirements.txt
@@ -1,0 +1,10 @@
+# Python packages that are only useful to Mbed TLS maintainers.
+
+-r ci.requirements.txt
+
+# For source code analyses
+clang
+
+# For building some test vectors
+pycryptodomex
+pycryptodome-test-vectors

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Install all the required Python packages, with the minimum Python version.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+import os
+import framework_scripts_path # pylint: disable=unused-import
+from mbedtls_framework import min_requirements
+
+# The default file is located in the same folder as this script.
+DEFAULT_REQUIREMENTS_FILE = 'ci.requirements.txt'
+
+min_requirements.main(os.path.join(os.path.dirname(__file__),
+                                   DEFAULT_REQUIREMENTS_FILE))


### PR DESCRIPTION
As a part of solving https://github.com/Mbed-TLS/mbedtls-framework/issues/86 and as requested [here](https://github.com/Mbed-TLS/mbedtls/pull/9863#pullrequestreview-2542726294) this PR copies `min_requirements.py` (the new version implemented in https://github.com/Mbed-TLS/mbedtls/pull/9863) and `*.requirements.txt` files from the Mbed TLS repo to this one.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls PR** provided Mbed-TLS/mbedtls# | not required
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
