### PR TITLE
Add various configuration components

### DIFF
--- a/tests/configs/user-config-for-test.h
+++ b/tests/configs/user-config-for-test.h
@@ -1,0 +1,29 @@
+/* TF_PSA_CRYPTO_USER_CONFIG_FILE for testing.
+ * Only used for a few test configurations.
+ *
+ * Typical usage (note multiple levels of quoting):
+ *     make CFLAGS="'-DTF_PSA_CRYPTO_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
+ */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#if defined(MBEDTLS_PSA_INJECT_ENTROPY)
+/* The #MBEDTLS_PSA_INJECT_ENTROPY feature requires two extra platform
+ * functions, which must be configured as #MBEDTLS_PLATFORM_NV_SEED_READ_MACRO
+ * and #MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO. The job of these functions
+ * is to read and write from the entropy seed file, which is located
+ * in the PSA ITS file whose uid is #PSA_CRYPTO_ITS_RANDOM_SEED_UID.
+ * (These could have been provided as library functions, but for historical
+ * reasons, they weren't, and so each integrator has to provide a copy
+ * of these functions.)
+ *
+ * Provide implementations of these functions for testing. */
+#include <stddef.h>
+int mbedtls_test_inject_entropy_seed_read(unsigned char *buf, size_t len);
+int mbedtls_test_inject_entropy_seed_write(unsigned char *buf, size_t len);
+#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbedtls_test_inject_entropy_seed_read
+#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbedtls_test_inject_entropy_seed_write
+#endif /* MBEDTLS_PSA_INJECT_ENTROPY */

--- a/tests/configs/user-config-for-test.h
+++ b/tests/configs/user-config-for-test.h
@@ -2,7 +2,7 @@
  * Only used for a few test configurations.
  *
  * Typical usage (note multiple levels of quoting):
- *     make CFLAGS="'-DTF_PSA_CRYPTO_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
+ *     cmake -DTF_PSA_CRYPTO_USER_CONFIG_FILE="./tests/configs/user-config-for-test.h\"
  */
 
 /*

--- a/tests/configs/user-config-malloc-0-null.h
+++ b/tests/configs/user-config-malloc-0-null.h
@@ -1,0 +1,22 @@
+/* crypto_config.h modifier that forces calloc(0) to return NULL.
+ * Used for testing.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include <stdlib.h>
+
+#ifndef MBEDTLS_PLATFORM_STD_CALLOC
+static inline void *custom_calloc(size_t nmemb, size_t size)
+{
+    if (nmemb == 0 || size == 0) {
+        return NULL;
+    }
+    return calloc(nmemb, size);
+}
+
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_STD_CALLOC custom_calloc
+#endif

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -12,7 +12,7 @@
 component_tf_psa_crypto_test_default_out_of_box () {
     msg "build: cmake, default config (out-of-box)" # ~1min
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_BUILD_TYPE:String=Check -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_BUILD_TYPE:String=Check "$TF_PSA_CRYPTO_ROOT_DIR"
     make
     # Disable fancy stuff
     unset MBEDTLS_TEST_OUTCOME_FILE
@@ -21,55 +21,55 @@ component_tf_psa_crypto_test_default_out_of_box () {
     make test
 }
 
-component_tf_psa_crypto_test_default_cmake_gcc_asan () {
+component_tf_psa_crypto_test_default_gcc_asan () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
 }
 
-component_tf_psa_crypto_test_default_cmake_gcc_asan_new_bignum () {
+component_tf_psa_crypto_test_default_gcc_asan_new_bignum () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
     scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
 }
 
-component_tf_psa_crypto_test_full_cmake_gcc_asan () {
+component_tf_psa_crypto_test_full_gcc_asan () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: main suites (inc. selftests) (full config, ASan build)"
     make test
 }
 
-component_tf_psa_crypto_test_full_cmake_gcc_asan_new_bignum () {
+component_tf_psa_crypto_test_full_gcc_asan_new_bignum () {
     msg "build: full config, cmake, gcc, ASan"
     scripts/config.py full
     scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: main suites (inc. selftests) (full config, new bignum, ASan)"
     make test
 }
 
-component_tf_psa_crypto_test_full_cmake_clang () {
+component_tf_psa_crypto_test_full_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
     scripts/config.py full
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DCMAKE_BUILD_TYPE:String=Release -DENABLE_TESTING=ON -DTEST_CPP=1 -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DCMAKE_BUILD_TYPE:String=Release -DTEST_CPP=1 "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: main suites (full config, clang)" # ~ 5s
@@ -83,19 +83,16 @@ component_tf_psa_crypto_build_tfm () {
     cd $OUT_OF_SOURCE_DIR
     msg "build: TF-M config, clang, armv7-m thumb2"
     cmake -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_C_FLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe" \
+        -DCMAKE_C_FLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -Werror -Wasm-operand-widths -Wunused -I../framework/tests/include/spe" \
         -DCMAKE_C_COMPILER_WORKS=TRUE \
         -DENABLE_TESTING=OFF \
         -DENABLE_PROGRAMS=OFF \
         "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
-    cd $TF_PSA_CRYPTO_ROOT_DIR
-    rm -rf $OUT_OF_SOURCE_DIR
-    mkdir $OUT_OF_SOURCE_DIR
-    cd $OUT_OF_SOURCE_DIR
+    rm -rf *
     msg "build: TF-M config, gcc native build"
-    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wlogical-op -I../framework/tests/include/spe" "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Os -I../framework/tests/include/spe" "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 }
 
@@ -103,7 +100,7 @@ component_tf_psa_crypto_test_malloc_0_null () {
     msg "build: malloc(0) returns NULL (ASan+UBSan build)"
     scripts/config.py full
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_C_COMPILER="$ASAN_CC" -DTF_PSA_CRYPTO_USER_CONFIG_FILE="$TF_PSA_CRYPTO_ROOT_DIR/tests/configs/user-config-malloc-0-null.h" -DCMAKE_C_FLAGS="$ASAN_CFLAGS" -DCMAKE_EXE_LINKER_FLAGS="$ASAN_CFLAGS" "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_BUILD_TYPE:String=Asan -DTF_PSA_CRYPTO_USER_CONFIG_FILE="$TF_PSA_CRYPTO_ROOT_DIR/tests/configs/user-config-malloc-0-null.h" "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: malloc(0) returns NULL (ASan+UBSan build)"
@@ -117,7 +114,7 @@ component_tf_psa_crypto_test_memory_buffer_allocator_backtrace () {
     scripts/config.py set MBEDTLS_MEMORY_BACKTRACE
     scripts/config.py set MBEDTLS_MEMORY_DEBUG
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_BUILD_TYPE:String=Release -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_BUILD_TYPE:String=Release "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C and MBEDTLS_MEMORY_BACKTRACE"
@@ -129,7 +126,7 @@ component_tf_psa_crypto_test_memory_buffer_allocator () {
     scripts/config.py set MBEDTLS_MEMORY_BUFFER_ALLOC_C
     scripts/config.py set MBEDTLS_PLATFORM_MEMORY
     cd $OUT_OF_SOURCE_DIR
-    cmake -DCMAKE_BUILD_TYPE:String=Release -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake -DCMAKE_BUILD_TYPE:String=Release "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
     msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C"

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -1,0 +1,136 @@
+# components-configuration.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Configuration Testing
+################################################################
+
+component_tf_psa_crypto_test_default_out_of_box () {
+    msg "build: cmake, default config (out-of-box)" # ~1min
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_BUILD_TYPE:String=Check -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+    # Disable fancy stuff
+    unset MBEDTLS_TEST_OUTCOME_FILE
+
+    msg "test: main suites make, default config (out-of-box)" # ~10s
+    make test
+}
+
+component_tf_psa_crypto_test_default_cmake_gcc_asan () {
+    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
+}
+
+component_tf_psa_crypto_test_default_cmake_gcc_asan_new_bignum () {
+    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
+}
+
+component_tf_psa_crypto_test_full_cmake_gcc_asan () {
+    msg "build: full config, cmake, gcc, ASan"
+    scripts/config.py full
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: main suites (inc. selftests) (full config, ASan build)"
+    make test
+}
+
+component_tf_psa_crypto_test_full_cmake_gcc_asan_new_bignum () {
+    msg "build: full config, cmake, gcc, ASan"
+    scripts/config.py full
+    scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: main suites (inc. selftests) (full config, new bignum, ASan)"
+    make test
+}
+
+component_tf_psa_crypto_test_full_cmake_clang () {
+    msg "build: cmake, full config, clang" # ~ 50s
+    scripts/config.py full
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DCMAKE_BUILD_TYPE:String=Release -DENABLE_TESTING=ON -DTEST_CPP=1 -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: main suites (full config, clang)" # ~ 5s
+    make test
+}
+
+component_tf_psa_crypto_build_tfm () {
+    # TF-M configuration needs a TF-M platform.
+    cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
+
+    cd $OUT_OF_SOURCE_DIR
+    msg "build: TF-M config, clang, armv7-m thumb2"
+    cmake -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_C_FLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe" \
+        -DENABLE_TESTING=OFF \
+        -DENABLE_PROGRAMS=OFF \
+        "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    cd $TF_PSA_CRYPTO_ROOT_DIR
+    rm -rf $OUT_OF_SOURCE_DIR
+    mkdir $OUT_OF_SOURCE_DIR
+    cd $OUT_OF_SOURCE_DIR
+    msg "build: TF-M config, gcc native build"
+    cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wlogical-op -I../framework/tests/include/spe" "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+}
+
+component_tf_psa_crypto_test_malloc_0_null () {
+    msg "build: malloc(0) returns NULL (ASan+UBSan build)"
+    scripts/config.py full
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER="$ASAN_CC" -DTF_PSA_CRYPTO_USER_CONFIG_FILE="$TF_PSA_CRYPTO_ROOT_DIR/tests/configs/user-config-malloc-0-null.h" -DCMAKE_C_FLAGS="$ASAN_CFLAGS" -DCMAKE_EXE_LINKER_FLAGS="$ASAN_CFLAGS" "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: malloc(0) returns NULL (ASan+UBSan build)"
+    make test
+}
+
+component_tf_psa_crypto_test_memory_buffer_allocator_backtrace () {
+    msg "build: default config with memory buffer allocator and backtrace enabled"
+    scripts/config.py set MBEDTLS_MEMORY_BUFFER_ALLOC_C
+    scripts/config.py set MBEDTLS_PLATFORM_MEMORY
+    scripts/config.py set MBEDTLS_MEMORY_BACKTRACE
+    scripts/config.py set MBEDTLS_MEMORY_DEBUG
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_BUILD_TYPE:String=Release -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C and MBEDTLS_MEMORY_BACKTRACE"
+    make test
+}
+
+component_tf_psa_crypto_test_memory_buffer_allocator () {
+    msg "build: default config with memory buffer allocator"
+    scripts/config.py set MBEDTLS_MEMORY_BUFFER_ALLOC_C
+    scripts/config.py set MBEDTLS_PLATFORM_MEMORY
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_BUILD_TYPE:String=Release -DGEN_FILES=ON "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C"
+    make test
+}

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -84,6 +84,7 @@ component_tf_psa_crypto_build_tfm () {
     msg "build: TF-M config, clang, armv7-m thumb2"
     cmake -DCMAKE_C_COMPILER=clang \
         -DCMAKE_C_FLAGS="--target=arm-linux-gnueabihf -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe" \
+        -DCMAKE_C_COMPILER_WORKS=TRUE \
         -DENABLE_TESTING=OFF \
         -DENABLE_PROGRAMS=OFF \
         "$TF_PSA_CRYPTO_ROOT_DIR"

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -76,6 +76,20 @@ component_tf_psa_crypto_test_full_clang () {
     make test
 }
 
+component_tf_psa_crypto_test_default_no_deprecated () {
+    # Test that removing the deprecated features from the default
+    # configuration leaves something consistent.
+    msg "build: make, default + MBEDTLS_DEPRECATED_REMOVED" # ~ 30s
+    scripts/config.py set MBEDTLS_DEPRECATED_REMOVED
+
+    cd $OUT_OF_SOURCE_DIR
+    cmake "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: make, default + MBEDTLS_DEPRECATED_REMOVED" # ~ 5s
+    make test
+}
+
 component_tf_psa_crypto_build_tfm () {
     # TF-M configuration needs a TF-M platform.
     cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"

--- a/tests/scripts/components-configuration.sh
+++ b/tests/scripts/components-configuration.sh
@@ -10,19 +10,19 @@
 ################################################################
 
 component_tf_psa_crypto_test_default_out_of_box () {
-    msg "build: cmake, default config (out-of-box)" # ~1min
+    msg "build: default config (out-of-box)" # ~1min
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_BUILD_TYPE:String=Check "$TF_PSA_CRYPTO_ROOT_DIR"
     make
     # Disable fancy stuff
     unset MBEDTLS_TEST_OUTCOME_FILE
 
-    msg "test: main suites make, default config (out-of-box)" # ~10s
+    msg "test: main suites, default config (out-of-box)" # ~10s
     make test
 }
 
 component_tf_psa_crypto_test_default_gcc_asan () {
-    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    msg "build: gcc, ASan" # ~ 1 min 50s
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
@@ -32,7 +32,7 @@ component_tf_psa_crypto_test_default_gcc_asan () {
 }
 
 component_tf_psa_crypto_test_default_gcc_asan_new_bignum () {
-    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    msg "build: gcc, ASan" # ~ 1 min 50s
     scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
@@ -43,7 +43,7 @@ component_tf_psa_crypto_test_default_gcc_asan_new_bignum () {
 }
 
 component_tf_psa_crypto_test_full_gcc_asan () {
-    msg "build: full config, cmake, gcc, ASan"
+    msg "build: full config, gcc, ASan"
     scripts/config.py full
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE:String=Asan "$TF_PSA_CRYPTO_ROOT_DIR"
@@ -54,7 +54,7 @@ component_tf_psa_crypto_test_full_gcc_asan () {
 }
 
 component_tf_psa_crypto_test_full_gcc_asan_new_bignum () {
-    msg "build: full config, cmake, gcc, ASan"
+    msg "build: full config, gcc, ASan"
     scripts/config.py full
     scripts/config.py set MBEDTLS_ECP_WITH_MPI_UINT
     cd $OUT_OF_SOURCE_DIR
@@ -66,7 +66,7 @@ component_tf_psa_crypto_test_full_gcc_asan_new_bignum () {
 }
 
 component_tf_psa_crypto_test_full_clang () {
-    msg "build: cmake, full config, clang" # ~ 50s
+    msg "build: full config, clang" # ~ 50s
     scripts/config.py full
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DCMAKE_BUILD_TYPE:String=Release -DTEST_CPP=1 "$TF_PSA_CRYPTO_ROOT_DIR"
@@ -79,14 +79,14 @@ component_tf_psa_crypto_test_full_clang () {
 component_tf_psa_crypto_test_default_no_deprecated () {
     # Test that removing the deprecated features from the default
     # configuration leaves something consistent.
-    msg "build: make, default + MBEDTLS_DEPRECATED_REMOVED" # ~ 30s
+    msg "build: default + MBEDTLS_DEPRECATED_REMOVED" # ~ 30s
     scripts/config.py set MBEDTLS_DEPRECATED_REMOVED
 
     cd $OUT_OF_SOURCE_DIR
     cmake "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
-    msg "test: make, default + MBEDTLS_DEPRECATED_REMOVED" # ~ 5s
+    msg "test: default + MBEDTLS_DEPRECATED_REMOVED" # ~ 5s
     make test
 }
 


### PR DESCRIPTION
This commit adds various configuration components to TF-PSA-Crypto. These components have been adapted from Mbed TLS to use CMake. Closes #125.

This pull request has a dependency on: [#164](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/164)

## PR checklist
- [x] **changelog** not required because: testing enhancement.
- [x] **framework PR** not required.
- [x] **mbedtls PR** not required.
- **tests**  provided. 