### PR TITLE
pk: Enable RSASSA-PSS key parsing

### DIFF
--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -510,6 +510,10 @@ static const oid_pk_alg_t oid_pk_alg[] =
         MBEDTLS_PK_RSA,
     },
     {
+        OID_DESCRIPTOR(MBEDTLS_OID_RSASSA_PSS,          "rsassaPss",        "RSASSA-PSS"),
+        MBEDTLS_PK_RSASSA_PSS,
+    },
+    {
         OID_DESCRIPTOR(MBEDTLS_OID_EC_ALG_UNRESTRICTED, "id-ecPublicKey",   "Generic EC key"),
         MBEDTLS_PK_ECKEY,
     },

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -111,6 +111,8 @@ const mbedtls_pk_info_t *mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type)
 {
     switch (pk_type) {
 #if defined(MBEDTLS_RSA_C)
+        case MBEDTLS_PK_RSASSA_PSS:
+            return &mbedtls_rsa_info;
         case MBEDTLS_PK_RSA:
             return &mbedtls_rsa_info;
 #endif /* MBEDTLS_RSA_C */

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -553,7 +553,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
     }
 
 #if defined(MBEDTLS_RSA_C)
-    if (pk_alg == MBEDTLS_PK_RSA) {
+    if (pk_alg == MBEDTLS_PK_RSA || pk_alg == MBEDTLS_PK_RSASSA_PSS) {
         ret = mbedtls_rsa_parse_pubkey(mbedtls_pk_rsa(*pk), *p, (size_t) (end - *p));
         if (ret == 0) {
             /* On success all the input has been consumed by the parsing function. */
@@ -811,7 +811,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
     }
 
 #if defined(MBEDTLS_RSA_C)
-    if (pk_alg == MBEDTLS_PK_RSA) {
+    if (pk_alg == MBEDTLS_PK_RSA || pk_alg == MBEDTLS_PK_RSASSA_PSS) {
         if ((ret = mbedtls_rsa_parse_key(mbedtls_pk_rsa(*pk), p, len)) != 0) {
             mbedtls_pk_free(pk);
             return ret;


### PR DESCRIPTION
## Description

mbedtls_pk_parse_key() and mbedtls_pk_parse_public_key() would not load RSASSA-PSS keys generated by OpenSSL (PEM or DER).

This patch adds the OID needed for asn1 matching and a few other tweaks to let the key get loaded.

I've confirmed that this produces correct signature in LibJWT by doing:

- Generate RSASSA-PSS sig in OpenSSL
  * Verify in MbedTLS

- Generate RSASSA-PSS sig in GnuTLS
  * Verify in MbedTLS

- Generate RSASSA-PSS sig in MbedTLS
  * Verify in OpenSSL
  * Verify in GnuTLS

Note, you obviously have to use:

    mbedtls_rsa_set_padding()
    mbedtls_rsa_rsassa_pss_sign()
    mbedtls_rsa_rsassa_pss_verify()

To get the correct RSASSA-PSS signatures and verification done.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#122
- **tests**  provided