### PR TITLE
Add compiler components to TF-PSA-Crypto

### DIFF
--- a/tests/configs/user-config-for-test.h
+++ b/tests/configs/user-config-for-test.h
@@ -1,0 +1,29 @@
+/* TF_PSA_CRYPTO_USER_CONFIG_FILE for testing.
+ * Only used for a few test configurations.
+ *
+ * Typical usage (note multiple levels of quoting):
+ *     make CFLAGS="'-DTF_PSA_CRYPTO_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
+ */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#if defined(MBEDTLS_PSA_INJECT_ENTROPY)
+/* The #MBEDTLS_PSA_INJECT_ENTROPY feature requires two extra platform
+ * functions, which must be configured as #MBEDTLS_PLATFORM_NV_SEED_READ_MACRO
+ * and #MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO. The job of these functions
+ * is to read and write from the entropy seed file, which is located
+ * in the PSA ITS file whose uid is #PSA_CRYPTO_ITS_RANDOM_SEED_UID.
+ * (These could have been provided as library functions, but for historical
+ * reasons, they weren't, and so each integrator has to provide a copy
+ * of these functions.)
+ *
+ * Provide implementations of these functions for testing. */
+#include <stddef.h>
+int mbedtls_test_inject_entropy_seed_read(unsigned char *buf, size_t len);
+int mbedtls_test_inject_entropy_seed_write(unsigned char *buf, size_t len);
+#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbedtls_test_inject_entropy_seed_read
+#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbedtls_test_inject_entropy_seed_write
+#endif /* MBEDTLS_PSA_INJECT_ENTROPY */

--- a/tests/configs/user-config-for-test.h
+++ b/tests/configs/user-config-for-test.h
@@ -2,7 +2,7 @@
  * Only used for a few test configurations.
  *
  * Typical usage (note multiple levels of quoting):
- *     make CFLAGS="'-DTF_PSA_CRYPTO_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
+ *     cmake -DTF_PSA_CRYPTO_USER_CONFIG_FILE="./tests/configs/user-config-for-test.h\"
  */
 
 /*

--- a/tests/configs/user-config-malloc-0-null.h
+++ b/tests/configs/user-config-malloc-0-null.h
@@ -1,0 +1,22 @@
+/* crypto_config.h modifier that forces calloc(0) to return NULL.
+ * Used for testing.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include <stdlib.h>
+
+#ifndef MBEDTLS_PLATFORM_STD_CALLOC
+static inline void *custom_calloc(size_t nmemb, size_t size)
+{
+    if (nmemb == 0 || size == 0) {
+        return NULL;
+    }
+    return calloc(nmemb, size);
+}
+
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_STD_CALLOC custom_calloc
+#endif

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -10,7 +10,7 @@
 ################################################################
 
 support_build_tf_psa_crypto_tfm_armcc () {
-    support_build_armcc
+    support_build_tf_psa_crypto_armcc
 }
 
 component_build_tf_psa_crypto_tfm_armcc () {
@@ -18,7 +18,7 @@ component_build_tf_psa_crypto_tfm_armcc () {
     cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
 
     msg "build: TF-M config, armclang armv7-m thumb2"
-    helper_armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe"
+    helper_armc6_build_test "--target=arm-arm-none-eabi -mcpu=cortex-m0 -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe"
 }
 
 test_build_opt () {

--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -1,0 +1,94 @@
+# components-compiler.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Compiler Testing
+################################################################
+
+support_build_tf_psa_crypto_tfm_armcc () {
+    support_build_armcc
+}
+
+component_build_tf_psa_crypto_tfm_armcc () {
+    # test the TF-M configuration can build cleanly with various warning flags enabled
+    cp configs/ext/crypto_config_profile_medium.h "$CRYPTO_CONFIG_H"
+
+    msg "build: TF-M config, armclang armv7-m thumb2"
+    helper_armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m -mthumb -Os -std=c99 -Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunused -I../framework/tests/include/spe"
+}
+
+test_build_opt () {
+    info=$1 cc=$2; shift 2
+    $cc --version
+    for opt in "$@"; do
+          cd $OUT_OF_SOURCE_DIR
+          msg "build/test: $cc $opt, $info" # ~ 30s
+          cmake -DCMAKE_C_COMPILER="$cc" -DCMAKE_C_FLAGS="$opt -std=c99 -pedantic -Wall -Wextra -Werror" "$TF_PSA_CRYPTO_ROOT_DIR"
+          make
+          # We're confident enough in compilers to not run _all_ the tests,
+          # but at least run the unit tests. In particular, runs with
+          # optimizations use inline assembly whereas runs with -O0
+          # skip inline assembly.
+          make test # ~30s
+    done
+}
+
+# For FreeBSD we invoke the function by name so this condition is added
+# to disable the existing test_clang_opt function for linux.
+if [[ $(uname) != "Linux" ]]; then
+    component_test_tf_psa_crypto_clang_opt () {
+        scripts/config.py full
+        test_build_opt 'full config' clang -O0 -Os -O2
+    }
+fi
+
+component_test_tf_psa_crypto_clang_latest_opt () {
+    scripts/config.py full
+    test_build_opt 'full config' "$CLANG_LATEST" -O0 -Os -O2
+}
+
+support_test_tf_psa_crypto_clang_latest_opt () {
+    type "$CLANG_LATEST" >/dev/null 2>/dev/null
+}
+
+component_test_tf_psa_crypto_clang_earliest_opt () {
+    scripts/config.py full
+    test_build_opt 'full config' "$CLANG_EARLIEST" -O2
+}
+
+support_test_tf_psa_crypto_clang_earliest_opt () {
+    type "$CLANG_EARLIEST" >/dev/null 2>/dev/null
+}
+
+component_test_tf_psa_crypto_gcc_latest_opt () {
+    scripts/config.py full
+    test_build_opt 'full config' "$GCC_LATEST" -O0 -Os -O2
+}
+
+support_test_tf_psa_crypto_gcc_latest_opt () {
+    type "$GCC_LATEST" >/dev/null 2>/dev/null
+}
+
+component_test_tf_psa_crypto_gcc_earliest_opt () {
+    scripts/config.py full
+    test_build_opt 'full config' "$GCC_EARLIEST" -O2
+}
+
+support_test_tf_psa_crypto_gcc_earliest_opt () {
+    type "$GCC_EARLIEST" >/dev/null 2>/dev/null
+}
+
+component_build_tf_psa_crypto_zeroize_checks () {
+    msg "build: check for obviously wrong calls to mbedtls_platform_zeroize()"
+
+    scripts/config.py full
+    cd $OUT_OF_SOURCE_DIR
+
+    # Only compile - we're looking for sizeof-pointer-memaccess warnings
+    cmake -DTF_PSA_CRYPTO_USER_CONFIG_FILE="$TF_PSA_CRYPTO_ROOT_DIR/tests/configs/user-config-zeroize-memset.h" -DCMAKE_C_FLAGS="-DMBEDTLS_TEST_DEFINES_ZEROIZE -Werror -Wsizeof-pointer-memaccess" "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+}

--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -1,0 +1,15 @@
+# components-platform.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Platform Testing
+################################################################
+
+support_build_tf_psa_crypto_armcc () {
+    armc6_cc="$ARMC6_BIN_DIR/armclang"
+    (check_tools "$armc6_cc" > /dev/null 2>&1)
+}


### PR DESCRIPTION
This commit adds multiple compiler configurations to TF-PSA-Crypto similar to those found in Mbed TLS. Partially closes: #60.

## PR checklist
- [x] **changelog** not required because: testing enhancement.
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework: https://github.com/Mbed-TLS/mbedtls-framework/pull/123
- [ ] **mbedtls PR** provided Mbed-TLS/mbedtls not required.
- **tests**  provided.
