### PR TITLE
Switch generate_psa_test.py to automatic dependencies for negative test cases

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -8085,6 +8085,13 @@ psa_status_t psa_key_agreement_iop_setup(
         return PSA_ERROR_BAD_STATE;
     }
 
+    /* We only support raw key agreement here, not combined with a key
+     * derivation. Also, for the time being, we only allow ECDH, not
+     * other key agreement algorithms. */
+    if (alg != PSA_ALG_ECDH) {
+        operation->error_occurred = 1;
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
     status = validate_key_agreement_params(attributes, alg);
     if (status != PSA_SUCCESS) {
         operation->error_occurred = 1;

--- a/drivers/builtin/src/psa_crypto_ecp.c
+++ b/drivers/builtin/src/psa_crypto_ecp.c
@@ -764,6 +764,12 @@ psa_status_t mbedtls_psa_key_agreement_iop_setup(
        complete operation which doesn't reset it after finsishing. */
     operation->num_ops = 0;
 
+    psa_key_type_t private_key_type = psa_get_key_type(private_key_attributes);
+    if (!PSA_KEY_TYPE_IS_ECC_KEY_PAIR(private_key_type)) {
+        status = PSA_ERROR_INVALID_ARGUMENT;
+        goto exit;
+    }
+
     status = mbedtls_psa_ecp_load_representation(
         psa_get_key_type(private_key_attributes),
         psa_get_key_bits(private_key_attributes),
@@ -785,7 +791,7 @@ psa_status_t mbedtls_psa_key_agreement_iop_setup(
     our_key = NULL;
 
     status = mbedtls_psa_ecp_load_representation(
-        PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(psa_get_key_type(private_key_attributes)),
+        PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(private_key_type),
         psa_get_key_bits(private_key_attributes),
         peer_key,
         peer_key_length,


### PR DESCRIPTION
This completes the forward port of https://github.com/Mbed-TLS/mbedtls/pull/9025. This is mostly happening in the framework, but a follow-up to #144 is also needed here.

The CI is expected to fail here due to needing an updated framework in mbedtls. The CI should pass in the [consuming PR](https://github.com/Mbed-TLS/mbedtls/pull/9909).

## PR checklist

- [x] **changelog** not required because: changes only in exactly where an error is reported
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9909
- [x] **crypto PR** here
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#104
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9857
- [x] **2.28 PR** partial forward port from https://github.com/Mbed-TLS/mbedtls/pull/9025, nothing new now
- **tests**  provided
