### PR TITLE
CMake Generated files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,3 +524,14 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
         export(PACKAGE TF-PSA-Crypto)
     endif()
 endif()
+
+add_custom_target(
+    generated_files
+    COMMAND echo "  Gen   ./core/psa_crypto_driver_wrappers.h ./core/psa_crypto_driver_wrappers.c"
+    COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_driver_wrappers.py ${TF_PSA_CRYPTO_DIR}/core
+    COMMAND echo "  Gen   ./programs/psa/psa_constant_names_generated.c"
+    COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_psa_constants.py
+    COMMAND echo "  Gen   ./tests/suites/test_suite_bignum.generated.data ./tests/suites/test_suite_bignum_core.generated.data ./tests/suites/test_suite_bignum_mod.generated.data ./tests/suites/test_suite_bignum_mod_raw.generated.data"
+    COMMAND echo "  Gen   ./tests/suites/test_suite_ecp.generated.data ./tests/suites/test_suite_psa_crypto_generate_key.generated.data ./tests/suites/test_suite_psa_crypto_low_hash.generated.data ./tests/suites/test_suite_psa_crypto_not_supported.generated.data ./tests/suites/test_suite_psa_crypto_op_fail.generated.data ./tests/suites/test_suite_psa_crypto_storage_format.current.data ./tests/suites/test_suite_psa_crypto_storage_format.v0.data ..."
+    COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_bignum_tests.py --directory ${TF_PSA_CRYPTO_DIR}/tests/suites
+)


### PR DESCRIPTION
Enable CMake to pregenerate generated files required for testing purposes.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls PR** provided Mbed-TLS/mbedtls# | not required
- **tests**  provided | not required because: 

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
