### PR TITLE
Add mbedtls ecp check framework

### DIFF
--- a/drivers/builtin/src/ecp.c
+++ b/drivers/builtin/src/ecp.c
@@ -2913,7 +2913,7 @@ int mbedtls_ecp_check_privkey(const mbedtls_ecp_group *grp,
         /* see RFC 7748 sec. 5 para. 5 */
         if (mbedtls_mpi_get_bit(d, 0) != 0 ||
             mbedtls_mpi_get_bit(d, 1) != 0 ||
-            mbedtls_mpi_bitlen(d) - 1 != grp->nbits) {  /* mbedtls_mpi_bitlen is one-based! */
+            mbedtls_mpi_bitlen(d) != grp->nbits + 1) {  /* mbedtls_mpi_bitlen is one-based! */
             return MBEDTLS_ERR_ECP_INVALID_KEY;
         }
 


### PR DESCRIPTION
## Description

Added a comment based on an investigation we did at the functional behaviour of a check.  

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: is a minor non functional change.
- [x] **development PR** provided
- [x] **framework PR** not required
- [x] **3.6 PR** provided [#9495](https://github.com/Mbed-TLS/mbedtls/pull/9495)
- [x] **2.28 PR** provided [#9496](https://github.com/Mbed-TLS/mbedtls/pull/9496)
- **tests**  not required because:  is a minor non functional change.