### PR TITLE
Restore zeroize memset configuration files

### DIFF
--- a/tests/configs/user-config-zeroize-memset.h
+++ b/tests/configs/user-config-zeroize-memset.h
@@ -1,0 +1,17 @@
+/* crypto_config.h modifier that defines mbedtls_platform_zeroize() to be
+ * memset(), so that the compile can check arguments for us.
+ * Used for testing.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include <string.h>
+
+/* Define _ALT so we don't get the built-in implementation. The test code will
+ * also need to define MBEDTLS_TEST_DEFINES_ZEROIZE so we don't get the
+ * declaration. */
+#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+
+#define mbedtls_platform_zeroize(buf, len) memset(buf, 0, len)


### PR DESCRIPTION
Restore zeroize memset crypto configuration files in the state they were in Mbed TLS just before the split as in the merge of PR 9809, commit 8ef9323.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided | not required because: 
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **mbedtls PR** provided Mbed-TLS/mbedtls: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
