### PR TITLE
Remove RNG parameters from LMS

### DIFF
--- a/ChangeLog.d/168.txt
+++ b/ChangeLog.d/168.txt
@@ -1,3 +1,0 @@
-API changes
-   * Remove the rng parameters from lms.* and lmots.*
-

--- a/ChangeLog.d/168.txt
+++ b/ChangeLog.d/168.txt
@@ -1,0 +1,3 @@
+API changes
+   * Remove the rng parameters from lms.* and lmots.*
+

--- a/drivers/builtin/include/mbedtls/lms.h
+++ b/drivers/builtin/include/mbedtls/lms.h
@@ -352,8 +352,6 @@ void mbedtls_lms_private_free(mbedtls_lms_private_t *ctx);
  *                           into.
  * \param type               The LMS parameter set identifier.
  * \param otstype            The LMOTS parameter set identifier.
- * \param f_rng              The RNG function to be used to generate the key ID.
- * \param p_rng              The RNG context to be passed to f_rng
  * \param seed               The seed used to deterministically generate the
  *                           key.
  * \param seed_size          The length of the seed.
@@ -364,8 +362,7 @@ void mbedtls_lms_private_free(mbedtls_lms_private_t *ctx);
 int mbedtls_lms_generate_private_key(mbedtls_lms_private_t *ctx,
                                      mbedtls_lms_algorithm_type_t type,
                                      mbedtls_lmots_algorithm_type_t otstype,
-                                     int (*f_rng)(void *, unsigned char *, size_t),
-                                     void *p_rng, const unsigned char *seed,
+                                     const unsigned char *seed,
                                      size_t seed_size);
 
 /**
@@ -411,9 +408,6 @@ int mbedtls_lms_calculate_public_key(mbedtls_lms_public_t *ctx,
  *
  * \param ctx                The initialized LMS private context from which the
  *                           private key will be read.
- * \param f_rng              The RNG function to be used for signature
- *                           generation.
- * \param p_rng              The RNG context to be passed to f_rng
  * \param msg                The buffer from which the message will be read.
  * \param msg_size           The size of the message that will be read.
  * \param sig                The buf into which the signature will be stored.
@@ -427,8 +421,7 @@ int mbedtls_lms_calculate_public_key(mbedtls_lms_public_t *ctx,
  * \return         A non-zero error code on failure.
  */
 int mbedtls_lms_sign(mbedtls_lms_private_t *ctx,
-                     int (*f_rng)(void *, unsigned char *, size_t),
-                     void *p_rng, const unsigned char *msg,
+                      const unsigned char *msg,
                      unsigned int msg_size, unsigned char *sig, size_t sig_size,
                      size_t *sig_len);
 #endif /* defined(MBEDTLS_LMS_PRIVATE) */

--- a/drivers/builtin/src/lmots.c
+++ b/drivers/builtin/src/lmots.c
@@ -692,8 +692,7 @@ exit:
 }
 
 int mbedtls_lmots_sign(mbedtls_lmots_private_t *ctx,
-                       int (*f_rng)(void *, unsigned char *, size_t),
-                       void *p_rng, const unsigned char *msg, size_t msg_size,
+                       const unsigned char *msg, size_t msg_size,
                        unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
     unsigned char tmp_digit_array[MBEDTLS_LMOTS_P_SIG_DIGIT_COUNT_MAX];
@@ -721,7 +720,7 @@ int mbedtls_lmots_sign(mbedtls_lmots_private_t *ctx,
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
     }
 
-    ret = f_rng(p_rng, tmp_c_random,
+    ret = psa_generate_random(tmp_c_random,
                 MBEDTLS_LMOTS_N_HASH_LEN(ctx->params.type));
     if (ret) {
         return ret;

--- a/drivers/builtin/src/lmots.h
+++ b/drivers/builtin/src/lmots.h
@@ -263,9 +263,6 @@ int mbedtls_lmots_calculate_public_key(mbedtls_lmots_public_t *ctx,
  *
  * \param ctx                The initialized LMOTS context from which the
  *                           private key will be read.
- * \param f_rng              The RNG function to be used for signature
- *                           generation.
- * \param p_rng              The RNG context to be passed to f_rng
  * \param msg                The buffer from which the message will be read.
  * \param msg_size           The size of the message that will be read.
  * \param sig                The buf into which the signature will be stored.
@@ -275,8 +272,7 @@ int mbedtls_lmots_calculate_public_key(mbedtls_lmots_public_t *ctx,
  * \return         A non-zero error code on failure.
  */
 int mbedtls_lmots_sign(mbedtls_lmots_private_t *ctx,
-                       int (*f_rng)(void *, unsigned char *, size_t),
-                       void *p_rng, const unsigned char *msg, size_t msg_size,
+                       const unsigned char *msg, size_t msg_size,
                        unsigned char *sig, size_t sig_size, size_t *sig_len);
 
 #endif /* defined(MBEDTLS_LMS_PRIVATE) */

--- a/drivers/builtin/src/lms.c
+++ b/drivers/builtin/src/lms.c
@@ -562,8 +562,7 @@ void mbedtls_lms_private_free(mbedtls_lms_private_t *ctx)
 int mbedtls_lms_generate_private_key(mbedtls_lms_private_t *ctx,
                                      mbedtls_lms_algorithm_type_t type,
                                      mbedtls_lmots_algorithm_type_t otstype,
-                                     int (*f_rng)(void *, unsigned char *, size_t),
-                                     void *p_rng, const unsigned char *seed,
+                                     const unsigned char *seed,
                                      size_t seed_size)
 {
     unsigned int idx = 0;
@@ -585,8 +584,7 @@ int mbedtls_lms_generate_private_key(mbedtls_lms_private_t *ctx,
     ctx->params.otstype = otstype;
     ctx->have_private_key = 1;
 
-    ret = f_rng(p_rng,
-                ctx->params.I_key_identifier,
+    ret = psa_generate_random(ctx->params.I_key_identifier,
                 MBEDTLS_LMOTS_I_KEY_ID_LEN);
     if (ret != 0) {
         goto exit;
@@ -693,8 +691,7 @@ exit:
 
 
 int mbedtls_lms_sign(mbedtls_lms_private_t *ctx,
-                     int (*f_rng)(void *, unsigned char *, size_t),
-                     void *p_rng, const unsigned char *msg,
+                     const unsigned char *msg,
                      unsigned int msg_size, unsigned char *sig, size_t sig_size,
                      size_t *sig_len)
 {
@@ -735,8 +732,6 @@ int mbedtls_lms_sign(mbedtls_lms_private_t *ctx,
     }
 
     ret = mbedtls_lmots_sign(&ctx->ots_private_keys[q_leaf_identifier],
-                             f_rng,
-                             p_rng,
                              msg,
                              msg_size,
                              sig + SIG_OTS_SIG_OFFSET,

--- a/tests/suites/test_suite_lmots.function
+++ b/tests/suites/test_suite_lmots.function
@@ -42,7 +42,7 @@ void lmots_sign_verify_test(data_t *msg, data_t *key_id, int leaf_id,
     TEST_EQUAL(mbedtls_lmots_generate_private_key(&priv_ctx, MBEDTLS_LMOTS_SHA256_N32_W8,
                                                   key_id->x, leaf_id, seed->x, seed->len), 0);
     TEST_EQUAL(mbedtls_lmots_calculate_public_key(&pub_ctx, &priv_ctx), 0);
-    TEST_EQUAL(mbedtls_lmots_sign(&priv_ctx, &mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lmots_sign(&priv_ctx,
                                   msg->x, msg->len, sig, sizeof(sig), NULL), 0);
     TEST_EQUAL(mbedtls_lmots_verify(&pub_ctx, msg->x, msg->len, sig, sizeof(sig)), 0);
 
@@ -67,7 +67,7 @@ void lmots_sign_verify_null_msg_test(data_t *key_id, int leaf_id, data_t *seed)
     TEST_EQUAL(mbedtls_lmots_generate_private_key(&priv_ctx, MBEDTLS_LMOTS_SHA256_N32_W8,
                                                   key_id->x, leaf_id, seed->x, seed->len), 0);
     TEST_EQUAL(mbedtls_lmots_calculate_public_key(&pub_ctx, &priv_ctx), 0);
-    TEST_EQUAL(mbedtls_lmots_sign(&priv_ctx, &mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lmots_sign(&priv_ctx,
                                   NULL, 0, sig, sizeof(sig), NULL), 0);
     TEST_EQUAL(mbedtls_lmots_verify(&pub_ctx, NULL, 0, sig, sizeof(sig)), 0);
 
@@ -215,13 +215,13 @@ void lmots_reuse_test(data_t *msg, data_t *key_id, int leaf_id, data_t *seed)
     TEST_EQUAL(mbedtls_lmots_generate_private_key(&ctx, MBEDTLS_LMOTS_SHA256_N32_W8,
                                                   key_id->x, leaf_id, seed->x,
                                                   seed->len), 0);
-    TEST_EQUAL(mbedtls_lmots_sign(&ctx, mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lmots_sign(&ctx,
                                   msg->x, msg->len, sig, sizeof(sig), NULL), 0);
 
     /* Running another sign operation should fail, since the key should now have
      * been erased.
      */
-    TEST_EQUAL(mbedtls_lmots_sign(&ctx, mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lmots_sign(&ctx,
                                   msg->x, msg->len, sig, sizeof(sig), NULL),
                MBEDTLS_ERR_LMS_BAD_INPUT_DATA);
 
@@ -248,7 +248,7 @@ void lmots_signature_leak_test(data_t *msg, data_t *key_id, int leaf_id,
     TEST_EQUAL(mbedtls_lmots_generate_private_key(&ctx, MBEDTLS_LMOTS_SHA256_N32_W8,
                                                   key_id->x, leaf_id, seed->x,
                                                   seed->len), 0);
-    TEST_EQUAL(mbedtls_lmots_sign(&ctx, mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lmots_sign(&ctx,
                                   msg->x, msg->len, sig, sizeof(sig), NULL), 0);
 
 exit:

--- a/tests/suites/test_suite_lms.function
+++ b/tests/suites/test_suite_lms.function
@@ -24,12 +24,11 @@ void lms_sign_verify_test(data_t *msg, data_t *seed)
      */
     TEST_EQUAL(mbedtls_lms_generate_private_key(&priv_ctx, MBEDTLS_LMS_SHA256_M32_H10,
                                                 MBEDTLS_LMOTS_SHA256_N32_W8,
-                                                mbedtls_test_rnd_std_rand, NULL,
                                                 seed->x, seed->len), 0);
 
     TEST_EQUAL(mbedtls_lms_calculate_public_key(&pub_ctx, &priv_ctx), 0);
 
-    TEST_EQUAL(mbedtls_lms_sign(&priv_ctx, mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lms_sign(&priv_ctx,
                                 msg->x, msg->len, sig, sizeof(sig),
                                 NULL), 0);
 
@@ -59,12 +58,11 @@ void lms_sign_verify_null_msg_test(data_t *seed)
      */
     TEST_EQUAL(mbedtls_lms_generate_private_key(&priv_ctx, MBEDTLS_LMS_SHA256_M32_H10,
                                                 MBEDTLS_LMOTS_SHA256_N32_W8,
-                                                mbedtls_test_rnd_std_rand, NULL,
                                                 seed->x, seed->len), 0);
 
     TEST_EQUAL(mbedtls_lms_calculate_public_key(&pub_ctx, &priv_ctx), 0);
 
-    TEST_EQUAL(mbedtls_lms_sign(&priv_ctx, mbedtls_test_rnd_std_rand, NULL,
+    TEST_EQUAL(mbedtls_lms_sign(&priv_ctx,
                                 NULL, 0, sig, sizeof(sig),
                                 NULL), 0);
 


### PR DESCRIPTION
## Description

Remove RNG parameters from LMS resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/168

## PR checklist 

- [x] **changelog** not required as we have agreed to add it it as another task once all rng removal has been completed.
- [x] **framework PR** not required
- [x] **mbedtls PR** not required because: API not used in mbedtls
- [x] **mbedtls 3.6 PR** not required because: API change
- [x] **mbedtls 2.28 PR** not required because: API change
- **tests**  not required because: no changes to test
