### PR TITLE
PR template checklist: add lines for backports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,9 @@ If the provided content is part of the present PR remove the # symbol.
 
 - [ ] **changelog** provided | not required because: 
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **mbedtls PR** provided Mbed-TLS/mbedtls# | not required
+- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **mbedtls 2.28 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 
 
 


### PR DESCRIPTION
A bug fix to TF-PSA-Crypto should be backported to Mbed TLS if applicable.

## PR checklist

- [x] **changelog** not required because: just metadata changes
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: specific to this repository
- [x] **mbedtls 3.6 PR** not required because: specific to this repository
- [x] **mbedtls 2.28 PR** not required because: specific to this repository
- **tests**  not required because: not code
