### PR TITLE
[tf-psa-crypto] md: allow dispatch to PSA whenever CRYPTO_CLIENT is enabled

### DIFF
--- a/ChangeLog.d/9652.txt
+++ b/ChangeLog.d/9652.txt
@@ -1,0 +1,9 @@
+Features
+   * MD module can now perform PSA dispatching also when
+     `MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C`, even though this
+     configuration is not officially supported. This requires that a
+     PSA Crypto provider library which:
+     * supports the required `PSA_WANT_ALG_xxx` and
+     * implements `psa_can_do_hash()` on the client interface
+     is linked against Mbed TLS and that `psa_crypto_init()` is called before
+     performing any PSA call.

--- a/core/psa_crypto_core.h
+++ b/core/psa_crypto_core.h
@@ -18,18 +18,6 @@
 #endif
 
 /**
- * Tell if PSA is ready for this hash.
- *
- * \note            For now, only checks the state of the driver subsystem,
- *                  not the algorithm. Might do more in the future.
- *
- * \param hash_alg  The hash algorithm (ignored for now).
- *
- * \return 1 if the driver subsytem is ready, 0 otherwise.
- */
-int psa_can_do_hash(psa_algorithm_t hash_alg);
-
-/**
  * Tell if PSA is ready for this cipher.
  *
  * \note            For now, only checks the state of the driver subsystem,

--- a/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
@@ -117,7 +117,54 @@
  */
 
 /* PSA accelerated implementations */
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+
+#if defined(MBEDTLS_PSA_ACCEL_ALG_MD5)
+#define MBEDTLS_MD_MD5_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_1)
+#define MBEDTLS_MD_SHA1_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_224)
+#define MBEDTLS_MD_SHA224_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_256)
+#define MBEDTLS_MD_SHA256_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_384)
+#define MBEDTLS_MD_SHA384_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_512)
+#define MBEDTLS_MD_SHA512_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_RIPEMD160)
+#define MBEDTLS_MD_RIPEMD160_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+#define MBEDTLS_MD_SHA3_224_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+#define MBEDTLS_MD_SHA3_256_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+#define MBEDTLS_MD_SHA3_384_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+#define MBEDTLS_MD_SHA3_512_VIA_PSA
+#define MBEDTLS_MD_SOME_PSA
+#endif
+
+#elif defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 #if defined(PSA_WANT_ALG_MD5)
 #define MBEDTLS_MD_MD5_VIA_PSA
@@ -163,7 +210,8 @@
 #define MBEDTLS_MD_SHA3_512_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
+
+#endif /* !MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C */
 
 /* Built-in implementations */
 #if defined(MBEDTLS_MD5_C) || \

--- a/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
@@ -48,6 +48,12 @@
 #endif
 #endif /* _MINGW32__ || (_MSC_VER && (_MSC_VER <= 1900)) */
 
+/* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
+ * is defined as well to include all PSA code.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#define MBEDTLS_PSA_CRYPTO_CLIENT
+#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 /**
  * \def MBEDTLS_USE_PSA_CRYPTO
@@ -299,13 +305,6 @@
     (!defined(MBEDTLS_USE_PSA_CRYPTO) && defined(MBEDTLS_ECDH_C))
 #define MBEDTLS_CAN_ECDH
 #endif
-
-/* If MBEDTLS_PSA_CRYPTO_C is defined, make sure MBEDTLS_PSA_CRYPTO_CLIENT
- * is defined as well to include all PSA code.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_C)
-#define MBEDTLS_PSA_CRYPTO_CLIENT
-#endif /* MBEDTLS_PSA_CRYPTO_C */
 
 /* Historically pkparse did not check the CBC padding when decrypting
  * a key. This was a bug, which is now fixed. As a consequence, pkparse

--- a/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
@@ -117,53 +117,53 @@
  */
 
 /* PSA accelerated implementations */
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
-#if defined(MBEDTLS_PSA_ACCEL_ALG_MD5)
+#if defined(PSA_WANT_ALG_MD5)
 #define MBEDTLS_MD_MD5_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_1)
+#if defined(PSA_WANT_ALG_SHA_1)
 #define MBEDTLS_MD_SHA1_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_224)
+#if defined(PSA_WANT_ALG_SHA_224)
 #define MBEDTLS_MD_SHA224_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_256)
+#if defined(PSA_WANT_ALG_SHA_256)
 #define MBEDTLS_MD_SHA256_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_384)
+#if defined(PSA_WANT_ALG_SHA_384)
 #define MBEDTLS_MD_SHA384_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA_512)
+#if defined(PSA_WANT_ALG_SHA_512)
 #define MBEDTLS_MD_SHA512_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_RIPEMD160)
+#if defined(PSA_WANT_ALG_RIPEMD160)
 #define MBEDTLS_MD_RIPEMD160_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_224)
+#if defined(PSA_WANT_ALG_SHA3_224)
 #define MBEDTLS_MD_SHA3_224_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_256)
+#if defined(PSA_WANT_ALG_SHA3_256)
 #define MBEDTLS_MD_SHA3_256_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_384)
+#if defined(PSA_WANT_ALG_SHA3_384)
 #define MBEDTLS_MD_SHA3_384_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#if defined(MBEDTLS_PSA_ACCEL_ALG_SHA3_512)
+#if defined(PSA_WANT_ALG_SHA3_512)
 #define MBEDTLS_MD_SHA3_512_VIA_PSA
 #define MBEDTLS_MD_SOME_PSA
 #endif
-#endif /* MBEDTLS_PSA_CRYPTO_C */
+#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 /* Built-in implementations */
 #if defined(MBEDTLS_MD5_C) || \

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -583,6 +583,32 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
 
 /** @} */
 
+/** \defgroup psa_crypto_client Functions defined by a client provider
+ *
+ * The functions in this group are meant to be implemented by providers of
+ * the PSA Crypto client interface. They are provided by the library when
+ * #MBEDTLS_PSA_CRYPTO_C is enabled.
+ *
+ * \note All functions in this group are experimental, as using
+ *       alternative client interface providers is experimental.
+ *
+ * @{
+ */
+
+/**
+ * Tell if PSA is ready for this hash.
+ *
+ * \note            For now, only checks the state of the driver subsystem,
+ *                  not the algorithm. Might do more in the future.
+ *
+ * \param hash_alg  The hash algorithm (ignored for now).
+ *
+ * \return 1 if the driver subsytem is ready, 0 otherwise.
+ */
+int psa_can_do_hash(psa_algorithm_t hash_alg);
+
+/**@}*/
+
 /** \addtogroup crypto_types
  * @{
  */

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -595,15 +595,18 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * @{
  */
 
-/**
- * Tell if PSA is ready for this hash.
+/** Check if PSA is capable of handling the specified hash algorithm.
  *
- * \note            For now, only checks the state of the driver subsystem,
- *                  not the algorithm. Might do more in the future.
+ * This means that PSA core was built with the corresponding PSA_WANT_ALG_xxx
+ * set and that psa_crypto_init has already been called.
  *
- * \param hash_alg  The hash algorithm (ignored for now).
+ * \note When using Mbed TLS version of PSA core (i.e. MBEDTLS_PSA_CRYPTO_C is
+ *       set) for now this function only checks the state of the driver
+ *       subsystem, not the algorithm. This might be improved in the future.
  *
- * \return 1 if the driver subsytem is ready, 0 otherwise.
+ * \param hash_alg  The hash algorithm.
+ *
+ * \return 1 if the PSA can handle \p hash_alg, 0 otherwise.
  */
 int psa_can_do_hash(psa_algorithm_t hash_alg);
 

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -420,7 +420,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_PSA_CRYPTO_C */
 void md_psa_dynamic_dispatch(int md_type, int pre_psa_ret, int post_psa_engine)
 {
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(md_type);


### PR DESCRIPTION
## Description

This is the forward porting of https://github.com/Mbed-TLS/mbedtls/pull/9562.
I'm opening the PR here instead of the main repo because MD was moved in this one.

I (manually [^1]) copied all the commits from https://github.com/Mbed-TLS/mbedtls/pull/9562 a part:
- https://github.com/Mbed-TLS/mbedtls/pull/9562/commits/1a2d07d83ac0cd2abf0d1fad12a7dfab5998dfac because there's no such document in tf-psa-crypto
- https://github.com/Mbed-TLS/mbedtls/pull/9562/commits/cc1b26bd9a31642a1afcae135c758fe636b47fb9 because I thought that since tf-psa-crypto never had a release, I doesn't make much sense to add a ChangeLog

[^1]: because I didn't find a way to make git to help me with this (I tried `cherry-pick`, `format-patch` + `am`, `diff` + `apply`).

## PR checklist

- [x] **changelog** provided
- [x] **development PR** not required because crypto only
- [x] **crypto PR** here
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/140
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9562
- [x] **2.28 PR** not required because new feature
- [x] **tests** in the psasim build
