### PR TITLE
core: Update common.h to use GCC _Static_assert

### DIFF
--- a/core/common.h
+++ b/core/common.h
@@ -359,6 +359,14 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
  */
 #if defined(static_assert) && !defined(__FreeBSD__)
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg)
+/* The GCC compiler supports _Static_assert since version 4.6 even with C99 so checking the
+ * compiler version should suffice.
+ * For non GCC compilers we check that C>=11 is used since C11 introduced _Static_assert.
+ */
+#elif !defined(__cplusplus) && \
+    ((defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4)) || \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L))
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    _Static_assert(expr, msg)
 #else
 /* Make sure `MBEDTLS_STATIC_ASSERT(expr, msg);` is valid both inside and
  * outside a function. We choose a struct declaration, which can be repeated


### PR DESCRIPTION
GCC supports _Static_assert from version 4.6 as a builtin feature even when you compile with std=99.

Use this _Static_assert for the implementation of MBEDTLS_STATIC_ASSERT if there is no defined static_assert.

his is mostly taken from the picolibc methodology just without using the GNUC_PREREQ macro because to improve prortability.

The mentioned picolibc solution:
[github.com/picolibc/picolibc/blob/db4d0fe5952d5ecd714781e3212d4086d970735a/ newlib/libc/include/sys/cdefs.h
](https://github.com/picolibc/picolibc/blob/db4d0fe5952d5ecd714781e3212d4086d970735a/newlib/libc/include/sys/cdefs.h#L387)
## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 2.28 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
