### PR TITLE
Fix link to PSA Crypto API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ README for TF-PSA-Crypto
 ========================
 
 The TF-PSA-Crypto repository provides an implementation of the
-[PSA Cryptography API] (https://arm-software.github.io/psa-api) (version 1.1).
+[PSA Cryptography API](https://arm-software.github.io/psa-api) (version 1.1).
 This encompasses the on-going extensions to the PSA Cryptography API (e.g. PAKE).
 
 The PSA Cryptography API implementation is organized around the


### PR DESCRIPTION
## Description

Fixes link in README.md that point to PSA Crypto API spec.

## PR checklist

- [x] **changelog** not required because: small doc fix
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: small doc fix
- [x] **mbedtls 3.6 PR** not required because: small doc fix
- [x] **mbedtls 2.28 PR** not required because: small doc fix
- [x] **tests** not required because: small doc fix

