### PR TITLE
Remove RNG from x509 and PK

### DIFF
--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -283,8 +283,6 @@ typedef int (*mbedtls_pk_rsa_alt_decrypt_func)(void *ctx, size_t *olen,
                                                const unsigned char *input, unsigned char *output,
                                                size_t output_max_len);
 typedef int (*mbedtls_pk_rsa_alt_sign_func)(void *ctx,
-                                            int (*f_rng)(void *, unsigned char *, size_t),
-                                            void *p_rng,
                                             mbedtls_md_type_t md_alg, unsigned int hashlen,
                                             const unsigned char *hash, unsigned char *sig);
 typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)(void *ctx);
@@ -828,8 +826,6 @@ int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
  * \param sig_size  The size of the \p sig buffer in bytes.
  * \param sig_len   On successful return,
  *                  the number of bytes written to \p sig.
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  *
  * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
  *                  either PKCS#1 v1.5 or PSS (using the largest possible salt
@@ -846,8 +842,7 @@ int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
  */
 int mbedtls_pk_sign(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                     const unsigned char *hash, size_t hash_len,
-                    unsigned char *sig, size_t sig_size, size_t *sig_len,
-                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                    unsigned char *sig, size_t sig_size, size_t *sig_len);
 
 /**
  * \brief           Make signature given a signature type.
@@ -866,8 +861,6 @@ int mbedtls_pk_sign(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
  * \param sig_size  The size of the \p sig buffer in bytes.
  * \param sig_len   On successful return,
  *                  the number of bytes written to \p sig.
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  *
  * \return          0 on success, or a specific error code.
  *
@@ -882,9 +875,7 @@ int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
                         mbedtls_pk_context *ctx,
                         mbedtls_md_type_t md_alg,
                         const unsigned char *hash, size_t hash_len,
-                        unsigned char *sig, size_t sig_size, size_t *sig_len,
-                        int (*f_rng)(void *, unsigned char *, size_t),
-                        void *p_rng);
+                        unsigned char *sig, size_t sig_size, size_t *sig_len);
 
 /**
  * \brief           Restartable version of \c mbedtls_pk_sign()
@@ -907,8 +898,6 @@ int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
  * \param sig_size  The size of the \p sig buffer in bytes.
  * \param sig_len   On successful return,
  *                  the number of bytes written to \p sig.
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  * \param rs_ctx    Restart context (NULL to disable restart)
  *
  * \return          See \c mbedtls_pk_sign().
@@ -919,7 +908,6 @@ int mbedtls_pk_sign_restartable(mbedtls_pk_context *ctx,
                                 mbedtls_md_type_t md_alg,
                                 const unsigned char *hash, size_t hash_len,
                                 unsigned char *sig, size_t sig_size, size_t *sig_len,
-                                int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                                 mbedtls_pk_restart_ctx *rs_ctx);
 
 /**
@@ -932,8 +920,6 @@ int mbedtls_pk_sign_restartable(mbedtls_pk_context *ctx,
  * \param output    Decrypted output
  * \param olen      Decrypted message length
  * \param osize     Size of the output buffer
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  *
  * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
  *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
@@ -944,8 +930,7 @@ int mbedtls_pk_sign_restartable(mbedtls_pk_context *ctx,
  */
 int mbedtls_pk_decrypt(mbedtls_pk_context *ctx,
                        const unsigned char *input, size_t ilen,
-                       unsigned char *output, size_t *olen, size_t osize,
-                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                       unsigned char *output, size_t *olen, size_t osize);
 
 /**
  * \brief           Encrypt message (including padding if relevant).
@@ -956,30 +941,23 @@ int mbedtls_pk_decrypt(mbedtls_pk_context *ctx,
  * \param output    Encrypted output
  * \param olen      Encrypted output length
  * \param osize     Size of the output buffer
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  *
  * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
  *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
  *                  the underlying RSA context. For a pk object constructed by
  *                  parsing, this is PKCS#1 v1.5 by default.
  *
- * \note            \p f_rng is used for padding generation.
- *
  * \return          0 on success, or a specific error code.
  */
 int mbedtls_pk_encrypt(mbedtls_pk_context *ctx,
                        const unsigned char *input, size_t ilen,
-                       unsigned char *output, size_t *olen, size_t osize,
-                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                       unsigned char *output, size_t *olen, size_t osize);
 
 /**
  * \brief           Check if a public-private pair of keys matches.
  *
  * \param pub       Context holding a public key.
  * \param prv       Context holding a private (and public) key.
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
  *
  * \return          \c 0 on success (keys were checked and match each other).
  * \return          #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the keys could not
@@ -988,9 +966,7 @@ int mbedtls_pk_encrypt(mbedtls_pk_context *ctx,
  * \return          Another non-zero value if the keys do not match.
  */
 int mbedtls_pk_check_pair(const mbedtls_pk_context *pub,
-                          const mbedtls_pk_context *prv,
-                          int (*f_rng)(void *, unsigned char *, size_t),
-                          void *p_rng);
+                          const mbedtls_pk_context *prv);
 
 /**
  * \brief           Export debug information
@@ -1092,8 +1068,6 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
  *                  The empty password is not supported.
  * \param pwdlen    Size of the password in bytes.
  *                  Ignored if \p pwd is \c NULL.
- * \param f_rng     RNG function, must not be \c NULL. Used for blinding.
- * \param p_rng     RNG parameter
  *
  * \note            On entry, ctx must be empty, either freshly initialised
  *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If you need a
@@ -1105,8 +1079,7 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
  */
 int mbedtls_pk_parse_key(mbedtls_pk_context *ctx,
                          const unsigned char *key, size_t keylen,
-                         const unsigned char *pwd, size_t pwdlen,
-                         int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                         const unsigned char *pwd, size_t pwdlen);
 
 /** \ingroup pk_module */
 /**
@@ -1155,8 +1128,6 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context *ctx,
  *                  Pass a null-terminated string if expecting an encrypted
  *                  key; a non-encrypted key will also be accepted.
  *                  The empty password is not supported.
- * \param f_rng     RNG function, must not be \c NULL. Used for blinding.
- * \param p_rng     RNG parameter
  *
  * \note            On entry, ctx must be empty, either freshly initialised
  *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If you need a
@@ -1167,8 +1138,7 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context *ctx,
  * \return          0 if successful, or a specific PK or PEM error code
  */
 int mbedtls_pk_parse_keyfile(mbedtls_pk_context *ctx,
-                             const char *path, const char *password,
-                             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                             const char *path, const char *password);
 
 /** \ingroup pk_module */
 /**

--- a/drivers/builtin/src/pk_ecc.c
+++ b/drivers/builtin/src/pk_ecc.c
@@ -82,13 +82,10 @@ int mbedtls_pk_ecc_set_key(mbedtls_pk_context *pk, unsigned char *key, size_t ke
 }
 
 int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
-                                       const unsigned char *prv, size_t prv_len,
-                                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                                       const unsigned char *prv, size_t prv_len)
 {
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 
-    (void) f_rng;
-    (void) p_rng;
     (void) prv;
     (void) prv_len;
     psa_status_t status;
@@ -99,8 +96,6 @@ int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
 
 #elif defined(MBEDTLS_USE_PSA_CRYPTO) /* && !MBEDTLS_PK_USE_PSA_EC_DATA */
 
-    (void) f_rng;
-    (void) p_rng;
     psa_status_t status;
 
     mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
@@ -137,7 +132,7 @@ int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
     (void) prv_len;
 
     mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
-    return mbedtls_ecp_mul(&eck->grp, &eck->Q, &eck->d, &eck->grp.G, f_rng, p_rng);
+    return mbedtls_ecp_mul(&eck->grp, &eck->Q, &eck->d, &eck->grp.G);
 
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -168,7 +168,6 @@ int mbedtls_pk_ecc_set_pubkey(mbedtls_pk_context *pk, const unsigned char *pub, 
  * [in/out] pk: in: must have the private key set, see mbedtls_pk_ecc_set_key().
  *              out: will have the public key set.
  * [in] prv, prv_len: the raw private key (see note below).
- * [in] f_rng, p_rng: RNG function and context.
  *
  * Note: the private key information is always available from pk,
  * however for convenience the serialized version is also passed,
@@ -181,8 +180,7 @@ int mbedtls_pk_ecc_set_pubkey(mbedtls_pk_context *pk, const unsigned char *pub, 
  * 3. not MBEDTLS_USE_PSA_CRYPTO.
  */
 int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
-                                       const unsigned char *prv, size_t prv_len,
-                                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+                                       const unsigned char *prv, size_t prv_len);
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 
 /* Helper for (deterministic) ECDSA */
@@ -196,8 +194,7 @@ int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
 MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_encrypted_der(
     mbedtls_pk_context *pk,
     unsigned char *key, size_t keylen,
-    const unsigned char *pwd, size_t pwdlen,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+    const unsigned char *pwd, size_t pwdlen);
 #endif
 
 #if defined(MBEDTLS_FS_IO)

--- a/drivers/builtin/src/pk_wrap.c
+++ b/drivers/builtin/src/pk_wrap.c
@@ -229,12 +229,8 @@ cleanup:
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 static int rsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                          const unsigned char *hash, size_t hash_len,
-                         unsigned char *sig, size_t sig_size, size_t *sig_len,
-                         int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                         unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
-    ((void) f_rng);
-    ((void) p_rng);
-
     psa_algorithm_t psa_md_alg;
     psa_md_alg = mbedtls_md_psa_alg_from_type(md_alg);
     if (psa_md_alg == 0) {
@@ -253,8 +249,7 @@ static int rsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 static int rsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                          const unsigned char *hash, size_t hash_len,
-                         unsigned char *sig, size_t sig_size, size_t *sig_len,
-                         int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                         unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
 
@@ -269,7 +264,7 @@ static int rsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
         return MBEDTLS_ERR_PK_BUFFER_TOO_SMALL;
     }
 
-    return mbedtls_rsa_pkcs1_sign(rsa, f_rng, p_rng,
+    return mbedtls_rsa_pkcs1_sign(rsa,
                                   md_alg, (unsigned int) hash_len,
                                   hash, sig);
 }
@@ -278,8 +273,7 @@ static int rsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
                             const unsigned char *input, size_t ilen,
-                            unsigned char *output, size_t *olen, size_t osize,
-                            int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                            unsigned char *output, size_t *olen, size_t osize)
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -290,9 +284,6 @@ static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES];
     unsigned char *p = buf + sizeof(buf);
-
-    ((void) f_rng);
-    ((void) p_rng);
 
     if (ilen != mbedtls_rsa_get_len(rsa)) {
         return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
@@ -344,8 +335,7 @@ cleanup:
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
                             const unsigned char *input, size_t ilen,
-                            unsigned char *output, size_t *olen, size_t osize,
-                            int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                            unsigned char *output, size_t *olen, size_t osize)
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
 
@@ -353,7 +343,7 @@ static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
         return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
     }
 
-    return mbedtls_rsa_pkcs1_decrypt(rsa, f_rng, p_rng,
+    return mbedtls_rsa_pkcs1_decrypt(rsa,
                                      olen, input, output, osize);
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -361,8 +351,7 @@ static int rsa_decrypt_wrap(mbedtls_pk_context *pk,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 static int rsa_encrypt_wrap(mbedtls_pk_context *pk,
                             const unsigned char *input, size_t ilen,
-                            unsigned char *output, size_t *olen, size_t osize,
-                            int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                            unsigned char *output, size_t *olen, size_t osize)
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -373,9 +362,6 @@ static int rsa_encrypt_wrap(mbedtls_pk_context *pk,
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES];
     unsigned char *p = buf + sizeof(buf);
-
-    ((void) f_rng);
-    ((void) p_rng);
 
     if (mbedtls_rsa_get_len(rsa) > osize) {
         return MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE;
@@ -426,8 +412,7 @@ cleanup:
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 static int rsa_encrypt_wrap(mbedtls_pk_context *pk,
                             const unsigned char *input, size_t ilen,
-                            unsigned char *output, size_t *olen, size_t osize,
-                            int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                            unsigned char *output, size_t *olen, size_t osize)
 {
     mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
     *olen = mbedtls_rsa_get_len(rsa);
@@ -436,17 +421,13 @@ static int rsa_encrypt_wrap(mbedtls_pk_context *pk,
         return MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE;
     }
 
-    return mbedtls_rsa_pkcs1_encrypt(rsa, f_rng, p_rng,
+    return mbedtls_rsa_pkcs1_encrypt(rsa,
                                      ilen, input, output);
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-static int rsa_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
-                               int (*f_rng)(void *, unsigned char *, size_t),
-                               void *p_rng)
+static int rsa_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv)
 {
-    (void) f_rng;
-    (void) p_rng;
     return mbedtls_rsa_check_pub_priv((const mbedtls_rsa_context *) pub->pk_ctx,
                                       (const mbedtls_rsa_context *) prv->pk_ctx);
 }
@@ -729,13 +710,8 @@ static int ecdsa_opaque_sign_wrap(mbedtls_pk_context *pk,
                                   mbedtls_md_type_t md_alg,
                                   const unsigned char *hash, size_t hash_len,
                                   unsigned char *sig, size_t sig_size,
-                                  size_t *sig_len,
-                                  int (*f_rng)(void *, unsigned char *, size_t),
-                                  void *p_rng)
+                                  size_t *sig_len)
 {
-    ((void) f_rng);
-    ((void) p_rng);
-
     return ecdsa_sign_psa(pk->priv_id, md_alg, hash, hash_len, sig, sig_size,
                           sig_len);
 }
@@ -747,8 +723,7 @@ static int ecdsa_opaque_sign_wrap(mbedtls_pk_context *pk,
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
 static int ecdsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                            const unsigned char *hash, size_t hash_len,
-                           unsigned char *sig, size_t sig_size, size_t *sig_len,
-                           int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                           unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
@@ -762,8 +737,6 @@ static int ecdsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
     size_t key_len = PSA_BITS_TO_BYTES(curve_bits);
     psa_algorithm_t psa_hash = mbedtls_md_psa_alg_from_type(md_alg);
     psa_algorithm_t psa_sig_md = MBEDTLS_PK_PSA_ALG_ECDSA_MAYBE_DET(psa_hash);
-    ((void) f_rng);
-    ((void) p_rng);
 
     if (curve == 0) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
@@ -802,13 +775,11 @@ cleanup:
 #else /* MBEDTLS_USE_PSA_CRYPTO */
 static int ecdsa_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                            const unsigned char *hash, size_t hash_len,
-                           unsigned char *sig, size_t sig_size, size_t *sig_len,
-                           int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                           unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
     return mbedtls_ecdsa_write_signature((mbedtls_ecdsa_context *) pk->pk_ctx,
                                          md_alg, hash, hash_len,
-                                         sig, sig_size, sig_len,
-                                         f_rng, p_rng);
+                                         sig, sig_size, sig_len);
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* PSA_HAVE_ALG_ECDSA_SIGN */
@@ -823,7 +794,6 @@ static int ecdsa_verify_rs_wrap(mbedtls_pk_context *ctx, mbedtls_md_type_t md_al
 static int ecdsa_sign_rs_wrap(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                               const unsigned char *hash, size_t hash_len,
                               unsigned char *sig, size_t sig_size, size_t *sig_len,
-                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                               void *rs_ctx);
 
 /*
@@ -896,7 +866,6 @@ cleanup:
 static int eckey_sign_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                               const unsigned char *hash, size_t hash_len,
                               unsigned char *sig, size_t sig_size, size_t *sig_len,
-                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                               void *rs_ctx)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -914,7 +883,7 @@ static int eckey_sign_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
 
     MBEDTLS_MPI_CHK(ecdsa_sign_rs_wrap(pk, md_alg,
                                        hash, hash_len, sig, sig_size, sig_len,
-                                       f_rng, p_rng, &rs->ecdsa_rs));
+                                       &rs->ecdsa_rs));
 
 cleanup:
     return ret;
@@ -1010,22 +979,15 @@ static int eckey_check_pair_psa(mbedtls_pk_context *pub, mbedtls_pk_context *prv
 }
 #endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
-static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
-                                 int (*f_rng)(void *, unsigned char *, size_t),
-                                 void *p_rng)
+static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv)
 {
-    (void) f_rng;
-    (void) p_rng;
     return eckey_check_pair_psa(pub, prv);
 }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
-static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
-                                 int (*f_rng)(void *, unsigned char *, size_t),
-                                 void *p_rng)
+static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv)
 {
     return mbedtls_ecp_check_pub_priv((const mbedtls_ecp_keypair *) pub->pk_ctx,
-                                      (const mbedtls_ecp_keypair *) prv->pk_ctx,
-                                      f_rng, p_rng);
+                                      (const mbedtls_ecp_keypair *) prv->pk_ctx);
 }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -1036,9 +998,7 @@ static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *pr
 #define ecdsa_opaque_check_pair_wrap    eckey_check_pair_wrap
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
 static int ecdsa_opaque_check_pair_wrap(mbedtls_pk_context *pub,
-                                        mbedtls_pk_context *prv,
-                                        int (*f_rng)(void *, unsigned char *, size_t),
-                                        void *p_rng)
+                                        mbedtls_pk_context *prv)
 {
     psa_status_t status;
     uint8_t exp_pub_key[MBEDTLS_PK_MAX_EC_PUBKEY_RAW_LEN];
@@ -1046,8 +1006,6 @@ static int ecdsa_opaque_check_pair_wrap(mbedtls_pk_context *pub,
     uint8_t pub_key[MBEDTLS_PK_MAX_EC_PUBKEY_RAW_LEN];
     size_t pub_key_len = 0;
     int ret;
-    (void) f_rng;
-    (void) p_rng;
 
     status = psa_export_public_key(prv->priv_id, exp_pub_key, sizeof(exp_pub_key),
                                    &exp_pub_key_len);
@@ -1201,12 +1159,12 @@ static int ecdsa_verify_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg
 static int ecdsa_sign_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                               const unsigned char *hash, size_t hash_len,
                               unsigned char *sig, size_t sig_size, size_t *sig_len,
-                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                               void *rs_ctx)
 {
     return mbedtls_ecdsa_write_signature_restartable(
         (mbedtls_ecdsa_context *) pk->pk_ctx,
-        md_alg, hash, hash_len, sig, sig_size, sig_len, f_rng, p_rng,
+        md_alg, hash, hash_len, sig, sig_size, sig_len,
+        mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE,
         (mbedtls_ecdsa_restart_ctx *) rs_ctx);
 
 }
@@ -1284,8 +1242,7 @@ static size_t rsa_alt_get_bitlen(mbedtls_pk_context *pk)
 
 static int rsa_alt_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                              const unsigned char *hash, size_t hash_len,
-                             unsigned char *sig, size_t sig_size, size_t *sig_len,
-                             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                             unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
     mbedtls_rsa_alt_context *rsa_alt = pk->pk_ctx;
 
@@ -1303,19 +1260,15 @@ static int rsa_alt_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
         return MBEDTLS_ERR_PK_BUFFER_TOO_SMALL;
     }
 
-    return rsa_alt->sign_func(rsa_alt->key, f_rng, p_rng,
+    return rsa_alt->sign_func(rsa_alt->key,
                               md_alg, (unsigned int) hash_len, hash, sig);
 }
 
 static int rsa_alt_decrypt_wrap(mbedtls_pk_context *pk,
                                 const unsigned char *input, size_t ilen,
-                                unsigned char *output, size_t *olen, size_t osize,
-                                int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                                unsigned char *output, size_t *olen, size_t osize)
 {
     mbedtls_rsa_alt_context *rsa_alt = pk->pk_ctx;
-
-    ((void) f_rng);
-    ((void) p_rng);
 
     if (ilen != rsa_alt->key_len_func(rsa_alt->key)) {
         return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
@@ -1326,9 +1279,7 @@ static int rsa_alt_decrypt_wrap(mbedtls_pk_context *pk,
 }
 
 #if defined(MBEDTLS_RSA_C)
-static int rsa_alt_check_pair(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
-                              int (*f_rng)(void *, unsigned char *, size_t),
-                              void *p_rng)
+static int rsa_alt_check_pair(mbedtls_pk_context *pub, mbedtls_pk_context *prv)
 {
     unsigned char sig[MBEDTLS_MPI_MAX_SIZE];
     unsigned char hash[32];
@@ -1343,8 +1294,7 @@ static int rsa_alt_check_pair(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
 
     if ((ret = rsa_alt_sign_wrap(prv, MBEDTLS_MD_NONE,
                                  hash, sizeof(hash),
-                                 sig, sizeof(sig), &sig_len,
-                                 f_rng, p_rng)) != 0) {
+                                 sig, sizeof(sig), &sig_len)) != 0) {
         return ret;
     }
 
@@ -1460,8 +1410,7 @@ static int rsa_opaque_can_do(mbedtls_pk_type_t type)
 #if defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC)
 static int rsa_opaque_decrypt(mbedtls_pk_context *pk,
                               const unsigned char *input, size_t ilen,
-                              unsigned char *output, size_t *olen, size_t osize,
-                              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                              unsigned char *output, size_t *olen, size_t osize)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg;
@@ -1469,8 +1418,6 @@ static int rsa_opaque_decrypt(mbedtls_pk_context *pk,
     psa_status_t status;
 
     /* PSA has its own RNG */
-    (void) f_rng;
-    (void) p_rng;
 
     status = psa_get_key_attributes(pk->priv_id, &attributes);
     if (status != PSA_SUCCESS) {
@@ -1496,8 +1443,7 @@ static int rsa_opaque_decrypt(mbedtls_pk_context *pk,
 
 static int rsa_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                                 const unsigned char *hash, size_t hash_len,
-                                unsigned char *sig, size_t sig_size, size_t *sig_len,
-                                int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                                unsigned char *sig, size_t sig_size, size_t *sig_len)
 {
 #if defined(MBEDTLS_RSA_C)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -1506,8 +1452,6 @@ static int rsa_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg
     psa_status_t status;
 
     /* PSA has its own RNG */
-    (void) f_rng;
-    (void) p_rng;
 
     status = psa_get_key_attributes(pk->priv_id, &attributes);
     if (status != PSA_SUCCESS) {
@@ -1542,8 +1486,6 @@ static int rsa_opaque_sign_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg
     ((void) sig);
     ((void) sig_size);
     ((void) sig_len);
-    ((void) f_rng);
-    ((void) p_rng);
     return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
 #endif /* !MBEDTLS_RSA_C */
 }

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -40,9 +40,7 @@ struct mbedtls_pk_info_t {
     /** Make signature */
     int (*sign_func)(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                      const unsigned char *hash, size_t hash_len,
-                     unsigned char *sig, size_t sig_size, size_t *sig_len,
-                     int (*f_rng)(void *, unsigned char *, size_t),
-                     void *p_rng);
+                     unsigned char *sig, size_t sig_size, size_t *sig_len);
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     /** Verify signature (restartable) */
@@ -55,26 +53,19 @@ struct mbedtls_pk_info_t {
     int (*sign_rs_func)(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
                         const unsigned char *hash, size_t hash_len,
                         unsigned char *sig, size_t sig_size, size_t *sig_len,
-                        int (*f_rng)(void *, unsigned char *, size_t),
-                        void *p_rng, void *rs_ctx);
+                        void *rs_ctx);
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
     /** Decrypt message */
     int (*decrypt_func)(mbedtls_pk_context *pk, const unsigned char *input, size_t ilen,
-                        unsigned char *output, size_t *olen, size_t osize,
-                        int (*f_rng)(void *, unsigned char *, size_t),
-                        void *p_rng);
+                        unsigned char *output, size_t *olen, size_t osize);
 
     /** Encrypt message */
     int (*encrypt_func)(mbedtls_pk_context *pk, const unsigned char *input, size_t ilen,
-                        unsigned char *output, size_t *olen, size_t osize,
-                        int (*f_rng)(void *, unsigned char *, size_t),
-                        void *p_rng);
+                        unsigned char *output, size_t *olen, size_t osize);
 
     /** Check public-private key pair */
-    int (*check_pair_func)(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
-                           int (*f_rng)(void *, unsigned char *, size_t),
-                           void *p_rng);
+    int (*check_pair_func)(mbedtls_pk_context *pub, mbedtls_pk_context *prv);
 
     /** Allocate a new context */
     void * (*ctx_alloc_func)(void);

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -427,8 +427,7 @@ static int pk_use_ecparams_rfc8410(const mbedtls_asn1_buf *params,
  * CurvePrivateKey ::= OCTET STRING
  */
 static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
-                                    unsigned char *key, size_t keylen, const unsigned char *end,
-                                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                                    unsigned char *key, size_t keylen, const unsigned char *end)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len;
@@ -452,7 +451,7 @@ static int pk_parse_key_rfc8410_der(mbedtls_pk_context *pk,
     /* pk_parse_key_pkcs8_unencrypted_der() only supports version 1 PKCS8 keys,
      * which never contain a public key. As such, derive the public key
      * unconditionally. */
-    if ((ret = mbedtls_pk_ecc_set_pubkey_from_prv(pk, key, len, f_rng, p_rng)) != 0) {
+    if ((ret = mbedtls_pk_ecc_set_pubkey_from_prv(pk, key, len)) != 0) {
         return ret;
     }
 
@@ -602,8 +601,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
  * Parse a SEC1 encoded private EC key
  */
 static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
-                                 const unsigned char *key, size_t keylen,
-                                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                                 const unsigned char *key, size_t keylen)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     int version, pubkey_done;
@@ -711,7 +709,7 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
     }
 
     if (!pubkey_done) {
-        if ((ret = mbedtls_pk_ecc_set_pubkey_from_prv(pk, d, d_len, f_rng, p_rng)) != 0) {
+        if ((ret = mbedtls_pk_ecc_set_pubkey_from_prv(pk, d, d_len)) != 0) {
             return ret;
         }
     }
@@ -741,8 +739,7 @@ static int pk_parse_key_sec1_der(mbedtls_pk_context *pk,
  */
 static int pk_parse_key_pkcs8_unencrypted_der(
     mbedtls_pk_context *pk,
-    const unsigned char *key, size_t keylen,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+    const unsigned char *key, size_t keylen)
 {
     int ret, version;
     size_t len;
@@ -752,11 +749,6 @@ static int pk_parse_key_pkcs8_unencrypted_der(
     mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
     mbedtls_ecp_group_id ec_grp_id = MBEDTLS_ECP_DP_NONE;
     const mbedtls_pk_info_t *pk_info;
-
-#if !defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
-    (void) f_rng;
-    (void) p_rng;
-#endif
 
     /*
      * This function parses the PrivateKeyInfo object (PKCS#8 v1.2 = RFC 5208)
@@ -825,8 +817,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
             if ((ret =
                      pk_use_ecparams_rfc8410(&params, ec_grp_id, pk)) != 0 ||
                 (ret =
-                     pk_parse_key_rfc8410_der(pk, p, len, end, f_rng,
-                                              p_rng)) != 0) {
+                     pk_parse_key_rfc8410_der(pk, p, len, end)) != 0) {
                 mbedtls_pk_free(pk);
                 return ret;
             }
@@ -834,7 +825,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
 #endif
         {
             if ((ret = pk_use_ecparams(&params, pk)) != 0 ||
-                (ret = pk_parse_key_sec1_der(pk, p, len, f_rng, p_rng)) != 0) {
+                (ret = pk_parse_key_sec1_der(pk, p, len)) != 0) {
                 mbedtls_pk_free(pk);
                 return ret;
             }
@@ -865,8 +856,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
 MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_encrypted_der(
     mbedtls_pk_context *pk,
     unsigned char *key, size_t keylen,
-    const unsigned char *pwd, size_t pwdlen,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+    const unsigned char *pwd, size_t pwdlen)
 {
     int ret, decrypted = 0;
     size_t len;
@@ -957,7 +947,7 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_encrypted_der(
     if (decrypted == 0) {
         return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
     }
-    return pk_parse_key_pkcs8_unencrypted_der(pk, buf, outlen, f_rng, p_rng);
+    return pk_parse_key_pkcs8_unencrypted_der(pk, buf, outlen);
 }
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 
@@ -972,8 +962,7 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_encrypted_der(
  */
 int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
                          const unsigned char *key, size_t keylen,
-                         const unsigned char *pwd, size_t pwdlen,
-                         int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                         const unsigned char *pwd, size_t pwdlen)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_pk_info_t *pk_info;
@@ -1033,8 +1022,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
 
         if ((ret = mbedtls_pk_setup(pk, pk_info)) != 0 ||
             (ret = pk_parse_key_sec1_der(pk,
-                                         pem.buf, pem.buflen,
-                                         f_rng, p_rng)) != 0) {
+                                         pem.buf, pem.buflen)) != 0) {
             mbedtls_pk_free(pk);
         }
 
@@ -1059,7 +1047,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     }
     if (ret == 0) {
         if ((ret = pk_parse_key_pkcs8_unencrypted_der(pk,
-                                                      pem.buf, pem.buflen, f_rng, p_rng)) != 0) {
+                                                      pem.buf, pem.buflen)) != 0) {
             mbedtls_pk_free(pk);
         }
 
@@ -1081,7 +1069,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     }
     if (ret == 0) {
         if ((ret = mbedtls_pk_parse_key_pkcs8_encrypted_der(pk, pem.buf, pem.buflen,
-                                                            pwd, pwdlen, f_rng, p_rng)) != 0) {
+                                                            pwd, pwdlen)) != 0) {
             mbedtls_pk_free(pk);
         }
 
@@ -1114,7 +1102,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
         memcpy(key_copy, key, keylen);
 
         ret = mbedtls_pk_parse_key_pkcs8_encrypted_der(pk, key_copy, keylen,
-                                                       pwd, pwdlen, f_rng, p_rng);
+                                                       pwd, pwdlen);
 
         mbedtls_zeroize_and_free(key_copy, keylen);
     }
@@ -1131,7 +1119,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     }
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 
-    ret = pk_parse_key_pkcs8_unencrypted_der(pk, key, keylen, f_rng, p_rng);
+    ret = pk_parse_key_pkcs8_unencrypted_der(pk, key, keylen);
     if (ret == 0) {
         return 0;
     }
@@ -1155,7 +1143,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context *pk,
     pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
     if (mbedtls_pk_setup(pk, pk_info) == 0 &&
         pk_parse_key_sec1_der(pk,
-                              key, keylen, f_rng, p_rng) == 0) {
+                              key, keylen) == 0) {
         return 0;
     }
     mbedtls_pk_free(pk);
@@ -1345,8 +1333,7 @@ int mbedtls_pk_load_file(const char *path, unsigned char **buf, size_t *n)
  * Load and parse a private key
  */
 int mbedtls_pk_parse_keyfile(mbedtls_pk_context *ctx,
-                             const char *path, const char *pwd,
-                             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+                             const char *path, const char *pwd)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
@@ -1357,10 +1344,10 @@ int mbedtls_pk_parse_keyfile(mbedtls_pk_context *ctx,
     }
 
     if (pwd == NULL) {
-        ret = mbedtls_pk_parse_key(ctx, buf, n, NULL, 0, f_rng, p_rng);
+        ret = mbedtls_pk_parse_key(ctx, buf, n, NULL, 0);
     } else {
         ret = mbedtls_pk_parse_key(ctx, buf, n,
-                                   (const unsigned char *) pwd, strlen(pwd), f_rng, p_rng);
+                                   (const unsigned char *) pwd, strlen(pwd));
     }
 
     mbedtls_zeroize_and_free(buf, n);

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -469,12 +469,9 @@ static int mbedtls_rsa_decrypt_func(void *ctx, size_t *olen,
                                      olen, input, output, output_max_len);
 }
 static int mbedtls_rsa_sign_func(void *ctx,
-                                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                                  mbedtls_md_type_t md_alg, unsigned int hashlen,
                                  const unsigned char *hash, unsigned char *sig)
 {
-    ((void) f_rng);
-    ((void) p_rng);
     return mbedtls_rsa_pkcs1_sign((mbedtls_rsa_context *) ctx,
                                   mbedtls_test_rnd_std_rand, NULL,
                                   md_alg, hashlen, hash, sig);
@@ -701,13 +698,11 @@ void pk_psa_utils(int key_is_rsa)
                     == MBEDTLS_ERR_PK_TYPE_MISMATCH);
     } else {
         TEST_ASSERT(mbedtls_pk_decrypt(&pk, b1, sizeof(b1),
-                                       b2, &len, sizeof(b2),
-                                       NULL, NULL)
+                                       b2, &len, sizeof(b2))
                     == MBEDTLS_ERR_PK_TYPE_MISMATCH);
     }
     TEST_ASSERT(mbedtls_pk_encrypt(&pk, b1, sizeof(b1),
-                                   b2, &len, sizeof(b2),
-                                   NULL, NULL)
+                                   b2, &len, sizeof(b2))
                 == MBEDTLS_ERR_PK_TYPE_MISMATCH);
 
     /* unsupported functions: check_pair, debug */
@@ -718,8 +713,7 @@ void pk_psa_utils(int key_is_rsa)
         TEST_ASSERT(mbedtls_pk_setup(&pk2,
                                      mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0);
     }
-    TEST_ASSERT(mbedtls_pk_check_pair(&pk, &pk2,
-                                      mbedtls_test_rnd_std_rand, NULL)
+    TEST_ASSERT(mbedtls_pk_check_pair(&pk, &pk2)
                 == MBEDTLS_ERR_PK_TYPE_MISMATCH);
     TEST_ASSERT(mbedtls_pk_debug(&pk, &dbg)
                 == MBEDTLS_ERR_PK_TYPE_MISMATCH);
@@ -814,24 +808,20 @@ void pk_invalid_param()
                mbedtls_pk_sign_restartable(&ctx, MBEDTLS_MD_NONE,
                                            NULL, buf_size,
                                            buf, buf_size, &buf_size,
-                                           NULL, NULL,
                                            NULL));
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
                mbedtls_pk_sign_restartable(&ctx, MBEDTLS_MD_SHA256,
                                            NULL, 0,
                                            buf, buf_size, &buf_size,
-                                           NULL, NULL,
                                            NULL));
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
                mbedtls_pk_sign_ext(pk_type, &ctx, MBEDTLS_MD_NONE,
                                    NULL, buf_size,
-                                   buf, buf_size, &buf_size,
-                                   NULL, NULL));
+                                   buf, buf_size, &buf_size));
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
                mbedtls_pk_sign_ext(pk_type, &ctx, MBEDTLS_MD_SHA256,
                                    NULL, 0,
-                                   buf, buf_size, &buf_size,
-                                   NULL, NULL));
+                                   buf, buf_size, &buf_size));
 exit:
     mbedtls_pk_free(&ctx);
     USE_PSA_DONE();
@@ -864,22 +854,19 @@ void valid_parameters()
                                             MBEDTLS_MD_NONE,
                                             NULL, 0,
                                             buf, sizeof(buf), &len,
-                                            mbedtls_test_rnd_std_rand, NULL,
                                             NULL) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     TEST_ASSERT(mbedtls_pk_sign(&pk,
                                 MBEDTLS_MD_NONE,
                                 NULL, 0,
-                                buf, sizeof(buf), &len,
-                                mbedtls_test_rnd_std_rand, NULL) ==
+                                buf, sizeof(buf), &len) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     TEST_ASSERT(mbedtls_pk_sign_ext(MBEDTLS_PK_NONE, &pk,
                                     MBEDTLS_MD_NONE,
                                     NULL, 0,
-                                    buf, sizeof(buf), &len,
-                                    mbedtls_test_rnd_std_rand, NULL) ==
+                                    buf, sizeof(buf), &len) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     TEST_ASSERT(mbedtls_pk_verify_restartable(&pk,
@@ -904,19 +891,16 @@ void valid_parameters()
 
     TEST_ASSERT(mbedtls_pk_encrypt(&pk,
                                    NULL, 0,
-                                   NULL, &len, 0,
-                                   mbedtls_test_rnd_std_rand, NULL) ==
+                                   NULL, &len, 0) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     TEST_ASSERT(mbedtls_pk_decrypt(&pk,
                                    NULL, 0,
-                                   NULL, &len, 0,
-                                   mbedtls_test_rnd_std_rand, NULL) ==
+                                   NULL, &len, 0) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
 #if defined(MBEDTLS_PK_PARSE_C)
-    TEST_ASSERT(mbedtls_pk_parse_key(&pk, NULL, 0, NULL, 1,
-                                     mbedtls_test_rnd_std_rand, NULL) ==
+    TEST_ASSERT(mbedtls_pk_parse_key(&pk, NULL, 0, NULL, 1) ==
                 MBEDTLS_ERR_PK_KEY_INVALID_FORMAT);
 
     TEST_ASSERT(mbedtls_pk_parse_public_key(&pk, NULL, 0) ==
@@ -936,8 +920,7 @@ void valid_parameters_pkwrite(data_t *key_data)
     USE_PSA_INIT();
 
     TEST_ASSERT(mbedtls_pk_parse_key(&pk,
-                                     key_data->x, key_data->len, NULL, 0,
-                                     mbedtls_test_rnd_std_rand, NULL) == 0);
+                                     key_data->x, key_data->len, NULL, 0) == 0);
 
     TEST_ASSERT(mbedtls_pk_write_key_der(&pk, NULL, 0) ==
                 MBEDTLS_ERR_ASN1_BUF_TOO_SMALL);
@@ -1006,12 +989,10 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     TEST_ASSERT(mbedtls_pk_parse_public_keyfile(&pub, pub_file) == 0);
-    TEST_ASSERT(mbedtls_pk_parse_keyfile(&prv, prv_file, NULL,
-                                         mbedtls_test_rnd_std_rand, NULL)
+    TEST_ASSERT(mbedtls_pk_parse_keyfile(&prv, prv_file, NULL)
                 == 0);
 
-    TEST_ASSERT(mbedtls_pk_check_pair(&pub, &prv,
-                                      mbedtls_test_rnd_std_rand, NULL)
+    TEST_ASSERT(mbedtls_pk_check_pair(&pub, &prv)
                 == ret);
 
 #if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
@@ -1019,8 +1000,7 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
         TEST_ASSERT(mbedtls_pk_setup_rsa_alt(&alt, mbedtls_pk_rsa(prv),
                                              mbedtls_rsa_decrypt_func, mbedtls_rsa_sign_func,
                                              mbedtls_rsa_key_len_func) == 0);
-        TEST_ASSERT(mbedtls_pk_check_pair(&pub, &alt,
-                                          mbedtls_test_rnd_std_rand, NULL)
+        TEST_ASSERT(mbedtls_pk_check_pair(&pub, &alt)
                     == ret);
     }
 #endif
@@ -1036,11 +1016,9 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     /* Test check_pair() between the opaque key we just created and the public PK counterpart.
      * Note: opaque EC keys support check_pair(), whereas RSA ones do not. */
     if (is_ec_key) {
-        TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv, mbedtls_test_rnd_std_rand,
-                                         NULL), ret);
+        TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv),ret);
     } else {
-        TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv, mbedtls_test_rnd_std_rand,
-                                         NULL), MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
+        TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv), MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
     }
 #endif
 
@@ -1255,7 +1233,6 @@ void pk_sign_verify_restart(int pk_type, int grp_id, char *d_str,
     do {
         ret = mbedtls_pk_sign_restartable(&prv, md_alg, hash->x, hash->len,
                                           sig, sizeof(sig), &slen,
-                                          mbedtls_test_rnd_std_rand, NULL,
                                           &rs_ctx);
     } while (ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart);
 
@@ -1295,7 +1272,6 @@ void pk_sign_verify_restart(int pk_type, int grp_id, char *d_str,
         slen = sizeof(sig);
         ret = mbedtls_pk_sign_restartable(&prv, md_alg, hash->x, hash->len,
                                           sig, sizeof(sig), &slen,
-                                          mbedtls_test_rnd_std_rand, NULL,
                                           &rs_ctx);
         TEST_ASSERT(ret == MBEDTLS_ERR_ECP_IN_PROGRESS);
     }
@@ -1349,7 +1325,6 @@ void pk_sign_verify(int type, int curve_or_keybits, int rsa_padding, int rsa_md_
     TEST_ASSERT(mbedtls_pk_sign_restartable(&pk, MBEDTLS_MD_SHA256,
                                             hash, hash_len,
                                             sig, sizeof(sig), &sig_len,
-                                            mbedtls_test_rnd_std_rand, NULL,
                                             rs_ctx) == sign_ret);
     if (sign_ret == 0) {
         TEST_ASSERT(sig_len <= MBEDTLS_PK_SIGNATURE_MAX_SIZE);
@@ -1373,9 +1348,7 @@ void pk_sign_verify(int type, int curve_or_keybits, int rsa_padding, int rsa_md_
     }
 
     TEST_ASSERT(mbedtls_pk_sign(&pk, MBEDTLS_MD_SHA256, hash, hash_len,
-                                sig, sizeof(sig), &sig_len,
-                                mbedtls_test_rnd_std_rand,
-                                NULL) == sign_ret);
+                                sig, sizeof(sig), &sig_len) == sign_ret);
     if (sign_ret == 0) {
         TEST_ASSERT(sig_len <= MBEDTLS_PK_SIGNATURE_MAX_SIZE);
     } else {
@@ -1440,8 +1413,7 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod, int padding,
     TEST_ASSERT(mbedtls_test_read_mpi(&rsa->E, input_E) == 0);
 
     TEST_ASSERT(mbedtls_pk_encrypt(&pk, message->x, message->len,
-                                   output, &olen, sizeof(output),
-                                   mbedtls_test_rnd_pseudo_rand, &rnd_info) == ret);
+                                   output, &olen, sizeof(output)) == ret);
 
     /* decryption test */
     mbedtls_mpi_init(&N); mbedtls_mpi_init(&P);
@@ -1471,8 +1443,7 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod, int padding,
     memset(result, 0, sizeof(result));
     rlen = 0;
     TEST_ASSERT(mbedtls_pk_decrypt(&pk, output, olen,
-                                   result, &rlen, sizeof(result),
-                                   mbedtls_test_rnd_pseudo_rand, &rnd_info) == ret);
+                                   result, &rlen, sizeof(result)) == ret);
     if (ret == 0) {
         TEST_ASSERT(rlen == message->len);
         TEST_ASSERT(memcmp(result, message->x, rlen) == 0);
@@ -1533,8 +1504,7 @@ void pk_rsa_decrypt_test_vec(data_t *cipher, int mod, int padding, int md_alg,
     memset(output, 0, sizeof(output));
     olen = 0;
     TEST_ASSERT(mbedtls_pk_decrypt(&pk, cipher->x, cipher->len,
-                                   output, &olen, sizeof(output),
-                                   mbedtls_test_rnd_pseudo_rand, &rnd_info) == ret);
+                                   output, &olen, sizeof(output)) == ret);
     if (ret == 0) {
         TEST_ASSERT(olen == clear->len);
         TEST_ASSERT(memcmp(output, clear->x, olen) == 0);
@@ -1605,8 +1575,7 @@ void pk_wrap_rsa_decrypt_test_vec(data_t *cipher, int mod,
     memset(output, 0, sizeof(output));
     olen = 0;
     TEST_EQUAL(mbedtls_pk_decrypt(&pk, cipher->x, cipher->len,
-                                  output, &olen, sizeof(output),
-                                  mbedtls_test_rnd_pseudo_rand, &rnd_info), ret);
+                                  output, &olen, sizeof(output)), ret);
     if (ret == 0) {
         TEST_EQUAL(olen, clear->len);
         TEST_EQUAL(memcmp(output, clear->x, olen), 0);
@@ -1642,12 +1611,10 @@ void pk_ec_nocrypt(int type)
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(type)) == 0);
 
     TEST_ASSERT(mbedtls_pk_encrypt(&pk, input, sizeof(input),
-                                   output, &olen, sizeof(output),
-                                   mbedtls_test_rnd_pseudo_rand, &rnd_info) == ret);
+                                   output, &olen, sizeof(output)) == ret);
 
     TEST_ASSERT(mbedtls_pk_decrypt(&pk, input, sizeof(input),
-                                   output, &olen, sizeof(output),
-                                   mbedtls_test_rnd_pseudo_rand, &rnd_info) == ret);
+                                   output, &olen, sizeof(output)) == ret);
 
 exit:
     mbedtls_pk_free(&pk);
@@ -1684,14 +1651,12 @@ void pk_rsa_overflow()
 #if defined(MBEDTLS_PKCS1_V21)
     TEST_EQUAL(mbedtls_pk_sign_ext(MBEDTLS_PK_RSASSA_PSS, &pk,
                                    MBEDTLS_MD_NONE, hash, hash_len,
-                                   sig, sizeof(sig), &sig_len,
-                                   mbedtls_test_rnd_std_rand, NULL),
+                                   sig, sizeof(sig), &sig_len),
                MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 #endif /* MBEDTLS_PKCS1_V21 */
 
     TEST_EQUAL(mbedtls_pk_sign(&pk, MBEDTLS_MD_NONE, hash, hash_len,
-                               sig, sizeof(sig), &sig_len,
-                               mbedtls_test_rnd_std_rand, NULL),
+                               sig, sizeof(sig), &sig_len),
                MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
 exit:
@@ -1759,13 +1724,11 @@ void pk_rsa_alt()
     /* Test signature */
 #if SIZE_MAX > UINT_MAX
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, SIZE_MAX,
-                                sig, sizeof(sig), &sig_len,
-                                mbedtls_test_rnd_std_rand, NULL)
+                                sig, sizeof(sig), &sig_len)
                 == MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 #endif /* SIZE_MAX > UINT_MAX */
     TEST_ASSERT(mbedtls_pk_sign(&alt, MBEDTLS_MD_NONE, hash, sizeof(hash),
-                                sig, sizeof(sig), &sig_len,
-                                mbedtls_test_rnd_std_rand, NULL)
+                                sig, sizeof(sig), &sig_len)
                 == 0);
     TEST_ASSERT(sig_len == RSA_KEY_LEN);
     TEST_ASSERT(mbedtls_pk_verify(&rsa, MBEDTLS_MD_NONE,
@@ -1773,18 +1736,15 @@ void pk_rsa_alt()
 
     /* Test decrypt */
     TEST_ASSERT(mbedtls_pk_encrypt(&rsa, msg, sizeof(msg),
-                                   ciph, &ciph_len, sizeof(ciph),
-                                   mbedtls_test_rnd_std_rand, NULL) == 0);
+                                   ciph, &ciph_len, sizeof(ciph)) == 0);
     TEST_ASSERT(mbedtls_pk_decrypt(&alt, ciph, ciph_len,
-                                   test, &test_len, sizeof(test),
-                                   mbedtls_test_rnd_std_rand, NULL) == 0);
+                                   test, &test_len, sizeof(test)) == 0);
     TEST_ASSERT(test_len == sizeof(msg));
     TEST_ASSERT(memcmp(test, msg, test_len) == 0);
 
     /* Test forbidden operations */
     TEST_ASSERT(mbedtls_pk_encrypt(&alt, msg, sizeof(msg),
-                                   ciph, &ciph_len, sizeof(ciph),
-                                   mbedtls_test_rnd_std_rand, NULL) == ret);
+                                   ciph, &ciph_len, sizeof(ciph)) == ret);
     TEST_ASSERT(mbedtls_pk_verify(&alt, MBEDTLS_MD_NONE,
                                   hash, sizeof(hash), sig, sig_len) == ret);
     TEST_ASSERT(mbedtls_pk_debug(&alt, dbg_items) == ret);
@@ -1891,8 +1851,7 @@ void pk_psa_sign(int psa_type, int bits, int rsa_padding)
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
     TEST_ASSERT(mbedtls_pk_sign(&pk, MBEDTLS_MD_SHA256,
-                                hash, sizeof(hash), sig, sizeof(sig), &sig_len,
-                                NULL, NULL) == 0);
+                                hash, sizeof(hash), sig, sizeof(sig), &sig_len) == 0);
     /* Only opaque EC keys support verification. */
     if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_type)) {
         TEST_ASSERT(mbedtls_pk_verify(&pk, MBEDTLS_MD_SHA256,
@@ -1979,8 +1938,7 @@ void pk_sign_ext(int pk_type, int curve_or_keybits, int key_pk_type, int md_alg)
     TEST_EQUAL(pk_setup(&pk, pk_type, curve_or_keybits), 0);
 
     TEST_EQUAL(mbedtls_pk_sign_ext(key_pk_type, &pk, md_alg, hash, hash_len,
-                                   sig, sizeof(sig), &sig_len,
-                                   mbedtls_test_rnd_std_rand, NULL), 0);
+                                   sig, sizeof(sig), &sig_len), 0);
 
     if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
         rsassa_pss_options.mgf1_hash_id = md_alg;
@@ -2050,16 +2008,14 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
      * to use it for PSS (PKCS1 v2.1) and it should fail. */
     if (key_pk_type == MBEDTLS_PK_RSA) {
         TEST_EQUAL(mbedtls_pk_sign_ext(MBEDTLS_PK_RSASSA_PSS, &pk, md_alg, hash, hash_len,
-                                       sig, sizeof(sig), &sig_len,
-                                       mbedtls_test_rnd_std_rand, NULL),
+                                       sig, sizeof(sig), &sig_len),
                    MBEDTLS_ERR_RSA_BAD_INPUT_DATA);
     }
 #endif /* MBEDTLS_PKCS1_V21 */
 
     /* Perform sign_ext() with the correct pk_type. */
     TEST_EQUAL(mbedtls_pk_sign_ext(key_pk_type, &pk, md_alg, hash, hash_len,
-                                   sig, sizeof(sig), &sig_len,
-                                   mbedtls_test_rnd_std_rand, NULL), 0);
+                                   sig, sizeof(sig), &sig_len), 0);
 
     /* verify_ext() is not supported when using an opaque context. */
     if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
@@ -2615,7 +2571,7 @@ void pk_copy_from_psa_success(data_t *priv_key_data, int key_type_arg,
     }
 
     /* Check that generated private/public PK contexts form a valid private/public key pair. */
-    TEST_EQUAL(mbedtls_pk_check_pair(&pk_pub, &pk_priv, mbedtls_test_rnd_std_rand, NULL), 0);
+    TEST_EQUAL(mbedtls_pk_check_pair(&pk_pub, &pk_priv), 0);
 
     /* Check consistency between copied PSA keys and generated PK contexts. */
     TEST_EQUAL(mbedtls_test_key_consistency_psa_pk(priv_key_id, &pk_priv), 1);

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -125,8 +125,7 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
         pwd = NULL;
     }
 
-    res = mbedtls_pk_parse_keyfile(&ctx, key_file, pwd,
-                                   mbedtls_test_rnd_std_rand, NULL);
+    res = mbedtls_pk_parse_keyfile(&ctx, key_file, pwd);
 
     TEST_EQUAL(res, result);
 
@@ -244,8 +243,7 @@ void pk_parse_keyfile_ec(char *key_file, char *password, int result)
     mbedtls_pk_init(&ctx);
     MD_OR_USE_PSA_INIT();
 
-    res = mbedtls_pk_parse_keyfile(&ctx, key_file, password,
-                                   mbedtls_test_rnd_std_rand, NULL);
+    res = mbedtls_pk_parse_keyfile(&ctx, key_file, password);
 
     TEST_EQUAL(res, result);
 
@@ -284,8 +282,7 @@ void pk_parse_key(data_t *buf, int result)
     mbedtls_pk_init(&pk);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_pk_parse_key(&pk, buf->x, buf->len, NULL, 0,
-                                     mbedtls_test_rnd_std_rand, NULL) == result);
+    TEST_ASSERT(mbedtls_pk_parse_key(&pk, buf->x, buf->len, NULL, 0) == result);
 
 exit:
     mbedtls_pk_free(&pk);
@@ -302,9 +299,7 @@ void pk_parse_key_encrypted(data_t *buf, data_t *pass, int result)
     USE_PSA_INIT();
 
     TEST_EQUAL(mbedtls_pk_parse_key_pkcs8_encrypted_der(&pk, buf->x, buf->len,
-                                                        pass->x, pass->len,
-                                                        mbedtls_test_rnd_std_rand,
-                                                        NULL), result);
+                                                        pass->x, pass->len), result);
 exit:
     mbedtls_pk_free(&pk);
     USE_PSA_DONE();
@@ -326,8 +321,7 @@ void pk_parse_fix_montgomery(data_t *input_key, data_t *exp_output)
     mbedtls_pk_init(&pk);
     USE_PSA_INIT();
 
-    TEST_EQUAL(mbedtls_pk_parse_key(&pk, input_key->x, input_key->len, NULL, 0,
-                                    mbedtls_test_rnd_std_rand, NULL), 0);
+    TEST_EQUAL(mbedtls_pk_parse_key(&pk, input_key->x, input_key->len, NULL, 0), 0);
 
     output_key_len = input_key->len;
     TEST_CALLOC(output_key, output_key_len);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -105,8 +105,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     if (is_public_key) {
         TEST_EQUAL(mbedtls_pk_parse_public_keyfile(&key, key_file), 0);
     } else {
-        TEST_EQUAL(mbedtls_pk_parse_keyfile(&key, key_file, NULL,
-                                            mbedtls_test_rnd_std_rand, NULL), 0);
+        TEST_EQUAL(mbedtls_pk_parse_keyfile(&key, key_file, NULL), 0);
     }
 
     start_buf = buf;
@@ -201,8 +200,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     mbedtls_pk_init(&priv_key);
     USE_PSA_INIT();
 
-    TEST_EQUAL(mbedtls_pk_parse_keyfile(&priv_key, priv_key_file, NULL,
-                                        mbedtls_test_rnd_std_rand, NULL), 0);
+    TEST_EQUAL(mbedtls_pk_parse_keyfile(&priv_key, priv_key_file, NULL), 0);
     TEST_EQUAL(mbedtls_pk_load_file(pub_key_file, &pub_key_raw,
                                     &pub_key_len), 0);
 


### PR DESCRIPTION
## Description

remove the f_rng and p_rng parameter from x509 and PK.

resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/169

Cross-depends on the associated mbedtls PR for a clean CI.

## PR checklist

- [x] **changelog** not required because: it will be provided under a later issue
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10037
- [x] **mbedtls 3.6 PR** not required because: No backports (API break)
- [x] **mbedtls 2.28 PR** not required because: No backports (API break)
- **tests** covered by existing tests
