### PR TITLE
Document PSA's need for threading

### DIFF
--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -429,11 +429,12 @@
  * \def MBEDTLS_THREADING_C
  *
  * Enable the threading abstraction layer.
- * By default Mbed TLS assumes it is used in a non-threaded environment or that
- * contexts are not shared between threads. If you do intend to use contexts
- * between threads, you will need to enable this layer to prevent race
- * conditions. See also our Knowledge Base article about threading:
- * https://mbed-tls.readthedocs.io/en/latest/kb/development/thread-safety-and-multi-threading
+ *
+ * \note You must enable this option if TF-PSA-Crypto runs in a
+ * multithreaded environment. Otherwise the PSA cryptography subsystem is
+ * not thread-safe. As an exception, this option can be disabled if all
+ * PSA crypto functions are ever called from a single thread. Note that
+ * this includes indirect calls, for example through PK.
  *
  * Module:  library/threading.c
  *


### PR DESCRIPTION
Document https://github.com/Mbed-TLS/mbedtls/issues/9991

In 1.0/4.0, this is pretty straightforward, because everything uses PSA.

(Technically there are a few public API functions that don't use PSA, such as base64, but there's no point in relaxing the requirements on threading just for those.)

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **development PR** not required because: in 4.0, this is covered inside crypto
- [x] **TF-PSA-Crypto PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10004
- [x] **2.28 PR** https://github.com/Mbed-TLS/mbedtls/pull/10053
- **tests**  not required because: doc only
