### PR TITLE
Make PK partially private

### DIFF
--- a/drivers/builtin/include/mbedtls/oid.h
+++ b/drivers/builtin/include/mbedtls/oid.h
@@ -511,7 +511,7 @@ int mbedtls_oid_get_attr_short_name(const mbedtls_asn1_buf *oid, const char **sh
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_pk_alg(const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_alg);
+int mbedtls_oid_get_pk_alg(const mbedtls_asn1_buf *oid, mbedtls_pk_spki_alg_t *pk_alg);
 
 /**
  * \brief          Translate pk_type into PublicKeyAlgorithm OID
@@ -522,7 +522,7 @@ int mbedtls_oid_get_pk_alg(const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_al
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_pk_alg(mbedtls_pk_type_t pk_alg,
+int mbedtls_oid_get_oid_by_pk_alg(mbedtls_pk_spki_alg_t pk_alg,
                                   const char **oid, size_t *olen);
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)

--- a/drivers/builtin/include/mbedtls/oid.h
+++ b/drivers/builtin/include/mbedtls/oid.h
@@ -583,7 +583,7 @@ int mbedtls_oid_get_oid_by_ec_grp_algid(mbedtls_ecp_group_id grp_id,
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
 int mbedtls_oid_get_sig_alg(const mbedtls_asn1_buf *oid,
-                            mbedtls_md_type_t *md_alg, mbedtls_pk_type_t *pk_alg);
+                            mbedtls_md_type_t *md_alg, mbedtls_pk_sigalg_t *pk_alg);
 
 /**
  * \brief          Translate SignatureAlgorithm OID into description
@@ -605,7 +605,7 @@ int mbedtls_oid_get_sig_alg_desc(const mbedtls_asn1_buf *oid, const char **desc)
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_sig_alg(mbedtls_pk_type_t pk_alg, mbedtls_md_type_t md_alg,
+int mbedtls_oid_get_oid_by_sig_alg(mbedtls_pk_sigalg_t pk_alg, mbedtls_md_type_t md_alg,
                                    const char **oid, size_t *olen);
 
 /**

--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -70,6 +70,9 @@ extern "C" {
 /**
  * \brief          Public key types
  */
+/* Note that the values must match the corresponding enum constants in
+ * mbedtls_pk_spki_alg_t and mbedtls_pk_sigalg_t until we stop using
+ * mbedtls_pk_type_t in mbedtls_pk_context and mbedtls_pk_can_do(). */
 typedef enum {
     MBEDTLS_PK_NONE=0,
     MBEDTLS_PK_RSA,
@@ -82,19 +85,25 @@ typedef enum {
 } mbedtls_pk_type_t;
 
 /** Key type encoded in SubjectPublicKeyInfo. */
+/* Note that the values must match the corresponding enum constants in
+ * mbedtls_pk_type_t until we stop using that type in mbedtls_pk_context
+ * and mbedtls_pk_can_do(). */
 typedef enum {
-    MBEDTLS_PK_SPKI_NONE = MBEDTLS_PK_NONE,
-    MBEDTLS_PK_SPKI_RSA = MBEDTLS_PK_RSA,
-    MBEDTLS_PK_SPKI_ECKEY = MBEDTLS_PK_ECKEY,
-    MBEDTLS_PK_SPKI_ECKEY_DH = MBEDTLS_PK_ECKEY_DH,
+    MBEDTLS_PK_SPKI_NONE = 0,
+    MBEDTLS_PK_SPKI_RSA = 1,
+    MBEDTLS_PK_SPKI_ECKEY = 2,
+    MBEDTLS_PK_SPKI_ECKEY_DH = 3,
 } mbedtls_pk_spki_alg_t;
 
 /** Key type encoded in X.509 SignatureAlgorithm. */
+/* Note that the values must match the corresponding enum constants in
+ * mbedtls_pk_type_t until we stop using that type in mbedtls_pk_context
+ * and mbedtls_pk_can_do(). */
 typedef enum {
-    MBEDTLS_PK_SIGALG_NONE = MBEDTLS_PK_NONE,
-    MBEDTLS_PK_SIGALG_RSA = MBEDTLS_PK_RSA,
-    MBEDTLS_PK_SIGALG_ECDSA = MBEDTLS_PK_ECDSA,
-    MBEDTLS_PK_SIGALG_RSASSA_PSS = MBEDTLS_PK_RSASSA_PSS,
+    MBEDTLS_PK_SIGALG_NONE = 0,
+    MBEDTLS_PK_SIGALG_RSA = 1,
+    MBEDTLS_PK_SIGALG_ECDSA = 4,
+    MBEDTLS_PK_SIGALG_RSASSA_PSS = 6,
 } mbedtls_pk_sigalg_t;
 
 /**

--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -81,6 +81,14 @@ typedef enum {
     MBEDTLS_PK_OPAQUE,
 } mbedtls_pk_type_t;
 
+/** Key type encoded in SubjectPublicKeyInfo. */
+typedef enum {
+    MBEDTLS_PK_SPKI_NONE = MBEDTLS_PK_NONE,
+    MBEDTLS_PK_SPKI_RSA = MBEDTLS_PK_RSA,
+    MBEDTLS_PK_SPKI_ECKEY = MBEDTLS_PK_ECKEY,
+    MBEDTLS_PK_SPKI_ECKEY_DH = MBEDTLS_PK_ECKEY_DH,
+} mbedtls_pk_spki_alg_t;
+
 /** Key type encoded in X.509 SignatureAlgorithm. */
 typedef enum {
     MBEDTLS_PK_SIGALG_NONE = MBEDTLS_PK_NONE,

--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -81,6 +81,14 @@ typedef enum {
     MBEDTLS_PK_OPAQUE,
 } mbedtls_pk_type_t;
 
+/** Key type encoded in X.509 SignatureAlgorithm. */
+typedef enum {
+    MBEDTLS_PK_SIGALG_NONE = MBEDTLS_PK_NONE,
+    MBEDTLS_PK_SIGALG_RSA = MBEDTLS_PK_RSA,
+    MBEDTLS_PK_SIGALG_ECDSA = MBEDTLS_PK_ECDSA,
+    MBEDTLS_PK_SIGALG_RSASSA_PSS = MBEDTLS_PK_RSASSA_PSS,
+} mbedtls_pk_sigalg_t;
+
 /**
  * \brief           Options for RSASSA-PSS signature verification.
  *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()

--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -129,26 +129,8 @@ typedef enum {
 #endif
 #endif /* defined(MBEDTLS_USE_PSA_CRYPTO) */
 
-/* Internal helper to define which fields in the pk_context structure below
- * should be used for EC keys: legacy ecp_keypair or the raw (PSA friendly)
- * format. It should be noted that this only affects how data is stored, not
- * which functions are used for various operations. The overall picture looks
- * like this:
- * - if USE_PSA is not defined and ECP_C is defined then use ecp_keypair data
- *   structure and legacy functions. (MBEDTLS_USE_PSA_CRYPTO is always on and
- *   although this codepath remains present, it never will be taken.)
- * - if USE_PSA is defined and
- *     - if ECP_C then use ecp_keypair structure, convert data to a PSA friendly
- *       format and use PSA functions
- *     - if !ECP_C then use new raw data and PSA functions directly.
- *
- * The main reason for the "intermediate" (USE_PSA + ECP_C) above is that as long
- * as ECP_C is defined mbedtls_pk_ec() gives the user a read/write access to the
- * ecp_keypair structure inside the pk_context so they can modify it using
- * ECP functions which are not under PK module's control.
- */
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY) && \
-    !defined(MBEDTLS_ECP_C)
+/* Legacy auxiliary symbol, now always enabled. */
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #define MBEDTLS_PK_USE_PSA_EC_DATA
 #endif
 

--- a/drivers/builtin/include/mbedtls/pk.h
+++ b/drivers/builtin/include/mbedtls/pk.h
@@ -16,18 +16,6 @@
 
 #include "mbedtls/md.h"
 
-#if defined(MBEDTLS_RSA_C)
-#include "mbedtls/rsa.h"
-#endif
-
-#if defined(MBEDTLS_ECP_C)
-#include "mbedtls/ecp.h"
-#endif
-
-#if defined(MBEDTLS_ECDSA_C)
-#include "mbedtls/ecdsa.h"
-#endif
-
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include "psa/crypto.h"
 #endif
@@ -67,23 +55,6 @@
 extern "C" {
 #endif
 
-/**
- * \brief          Public key types
- */
-/* Note that the values must match the corresponding enum constants in
- * mbedtls_pk_spki_alg_t and mbedtls_pk_sigalg_t until we stop using
- * mbedtls_pk_type_t in mbedtls_pk_context and mbedtls_pk_can_do(). */
-typedef enum {
-    MBEDTLS_PK_NONE=0,
-    MBEDTLS_PK_RSA,
-    MBEDTLS_PK_ECKEY,
-    MBEDTLS_PK_ECKEY_DH,
-    MBEDTLS_PK_ECDSA,
-    MBEDTLS_PK_RSA_ALT,
-    MBEDTLS_PK_RSASSA_PSS,
-    MBEDTLS_PK_OPAQUE,
-} mbedtls_pk_type_t;
-
 /** Key type encoded in SubjectPublicKeyInfo. */
 /* Note that the values must match the corresponding enum constants in
  * mbedtls_pk_type_t until we stop using that type in mbedtls_pk_context
@@ -105,29 +76,6 @@ typedef enum {
     MBEDTLS_PK_SIGALG_ECDSA = 4,
     MBEDTLS_PK_SIGALG_RSASSA_PSS = 6,
 } mbedtls_pk_sigalg_t;
-
-/**
- * \brief           Options for RSASSA-PSS signature verification.
- *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()
- */
-typedef struct mbedtls_pk_rsassa_pss_options {
-    /** The digest to use for MGF1 in PSS.
-     *
-     * \note When #MBEDTLS_RSA_C is disabled, this must be equal to the \c md_alg argument passed
-     *       to mbedtls_pk_verify_ext(). In a future version of the library, this constraint may
-     *       apply regardless of the status of #MBEDTLS_RSA_C.
-     */
-    mbedtls_md_type_t mgf1_hash_id;
-
-    /** The expected length of the salt, in bytes. This may be
-     * #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
-     *
-     * \note Only #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be ignored (allowing any
-     *       salt length).
-     */
-    int expected_salt_len;
-
-} mbedtls_pk_rsassa_pss_options;
 
 /**
  * \brief           Maximum size of a signature made by mbedtls_pk_sign().
@@ -205,28 +153,6 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 #endif
 
 /**
- * \brief           Types for interfacing with the debug module
- */
-typedef enum {
-    MBEDTLS_PK_DEBUG_NONE = 0,
-    MBEDTLS_PK_DEBUG_MPI,
-    MBEDTLS_PK_DEBUG_ECP,
-    MBEDTLS_PK_DEBUG_PSA_EC,
-} mbedtls_pk_debug_type;
-
-/**
- * \brief           Item to send to the debug module
- */
-typedef struct mbedtls_pk_debug_item {
-    mbedtls_pk_debug_type MBEDTLS_PRIVATE(type);
-    const char *MBEDTLS_PRIVATE(name);
-    void *MBEDTLS_PRIVATE(value);
-} mbedtls_pk_debug_item;
-
-/** Maximum number of item send for debugging, plus 1 */
-#define MBEDTLS_PK_DEBUG_MAX_ITEMS 3
-
-/**
  * \brief           Public key information and operations
  *
  * \note        The library does not support custom pk info structures,
@@ -300,30 +226,6 @@ typedef struct {
 typedef void mbedtls_pk_restart_ctx;
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
-#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-/**
- * \brief           Types for RSA-alt abstraction
- */
-typedef int (*mbedtls_pk_rsa_alt_decrypt_func)(void *ctx, size_t *olen,
-                                               const unsigned char *input, unsigned char *output,
-                                               size_t output_max_len);
-typedef int (*mbedtls_pk_rsa_alt_sign_func)(void *ctx,
-                                            int (*f_rng)(void *, unsigned char *, size_t),
-                                            void *p_rng,
-                                            mbedtls_md_type_t md_alg, unsigned int hashlen,
-                                            const unsigned char *hash, unsigned char *sig);
-typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)(void *ctx);
-#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
-
-/**
- * \brief           Return information associated with the given PK type
- *
- * \param pk_type   PK type to search for.
- *
- * \return          The PK info associated with the type or NULL if not found.
- */
-const mbedtls_pk_info_t *mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type);
-
 /**
  * \brief           Initialize a #mbedtls_pk_context (as NONE).
  *
@@ -362,23 +264,6 @@ void mbedtls_pk_restart_init(mbedtls_pk_restart_ctx *ctx);
  */
 void mbedtls_pk_restart_free(mbedtls_pk_restart_ctx *ctx);
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
-
-/**
- * \brief           Initialize a PK context with the information given
- *                  and allocates the type-specific PK subcontext.
- *
- * \param ctx       Context to initialize. It must not have been set
- *                  up yet (type #MBEDTLS_PK_NONE).
- * \param info      Information to use
- *
- * \return          0 on success,
- *                  MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input,
- *                  MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
- *
- * \note            For contexts holding an RSA-alt key, use
- *                  \c mbedtls_pk_setup_rsa_alt() instead.
- */
-int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
@@ -421,28 +306,6 @@ int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
                             const mbedtls_svc_key_id_t key);
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-/**
- * \brief           Initialize an RSA-alt context
- *
- * \param ctx       Context to initialize. It must not have been set
- *                  up yet (type #MBEDTLS_PK_NONE).
- * \param key       RSA key pointer
- * \param decrypt_func  Decryption function
- * \param sign_func     Signing function
- * \param key_len_func  Function returning key length in bytes
- *
- * \return          0 on success, or MBEDTLS_ERR_PK_BAD_INPUT_DATA if the
- *                  context wasn't already initialized as RSA_ALT.
- *
- * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
- */
-int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context *ctx, void *key,
-                             mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
-                             mbedtls_pk_rsa_alt_sign_func sign_func,
-                             mbedtls_pk_rsa_alt_key_len_func key_len_func);
-#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
-
 /**
  * \brief           Get the size in bits of the underlying key
  *
@@ -451,32 +314,6 @@ int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context *ctx, void *key,
  * \return          Key size in bits, or 0 on error
  */
 size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context *ctx);
-
-/**
- * \brief           Get the length in bytes of the underlying key
- *
- * \param ctx       The context to query. It must have been initialized.
- *
- * \return          Key length in bytes, or 0 on error
- */
-static inline size_t mbedtls_pk_get_len(const mbedtls_pk_context *ctx)
-{
-    return (mbedtls_pk_get_bitlen(ctx) + 7) / 8;
-}
-
-/**
- * \brief           Tell if a context can do the operation given by type
- *
- * \param ctx       The context to query. It must have been initialized.
- * \param type      The desired type.
- *
- * \return          1 if the context can do operations on the given type.
- * \return          0 if the context cannot do the operations on the given
- *                  type. This is always the case for a context that has
- *                  been initialized but not set up, or that has been
- *                  cleared with mbedtls_pk_free().
- */
-int mbedtls_pk_can_do(const mbedtls_pk_context *ctx, mbedtls_pk_type_t type);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
@@ -802,42 +639,6 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
                                   mbedtls_pk_restart_ctx *rs_ctx);
 
 /**
- * \brief           Verify signature, with options.
- *                  (Includes verification of the padding depending on type.)
- *
- * \param type      Signature type (inc. possible padding type) to verify
- * \param options   Pointer to type-specific options, or NULL
- * \param ctx       The PK context to use. It must have been set up.
- * \param md_alg    Hash algorithm used (see notes)
- * \param hash      Hash of the message to sign
- * \param hash_len  Hash length or 0 (see notes)
- * \param sig       Signature to verify
- * \param sig_len   Signature length
- *
- * \return          0 on success (signature is valid),
- *                  #MBEDTLS_ERR_PK_TYPE_MISMATCH if the PK context can't be
- *                  used for this type of signatures,
- *                  #MBEDTLS_ERR_PK_SIG_LEN_MISMATCH if there is a valid
- *                  signature in \p sig but its length is less than \p sig_len,
- *                  or a specific error code.
- *
- * \note            If hash_len is 0, then the length associated with md_alg
- *                  is used instead, or an error returned if it is invalid.
- *
- * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
- *
- * \note            If type is MBEDTLS_PK_RSASSA_PSS, then options must point
- *                  to a mbedtls_pk_rsassa_pss_options structure,
- *                  otherwise it must be NULL. Note that the salt length is not
- *                  verified as contexes have PSA_ALG_RSA_PSS_ANY_SALT as default
- *                  and that is the only valid value.
- */
-int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
-                          mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
-                          const unsigned char *hash, size_t hash_len,
-                          const unsigned char *sig, size_t sig_len);
-
-/**
  * \brief           Make signature, including padding if relevant.
  *
  * \param ctx       The PK context to use. It must have been set up
@@ -873,43 +674,6 @@ int mbedtls_pk_sign(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                     const unsigned char *hash, size_t hash_len,
                     unsigned char *sig, size_t sig_size, size_t *sig_len,
                     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
-
-/**
- * \brief           Make signature given a signature type.
- *
- * \param pk_type   Signature type.
- * \param ctx       The PK context to use. It must have been set up
- *                  with a private key.
- * \param md_alg    Hash algorithm used (see notes)
- * \param hash      Hash of the message to sign
- * \param hash_len  Hash length
- * \param sig       Place to write the signature.
- *                  It must have enough room for the signature.
- *                  #MBEDTLS_PK_SIGNATURE_MAX_SIZE is always enough.
- *                  You may use a smaller buffer if it is large enough
- *                  given the key type.
- * \param sig_size  The size of the \p sig buffer in bytes.
- * \param sig_len   On successful return,
- *                  the number of bytes written to \p sig.
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
- *
- * \return          0 on success, or a specific error code.
- *
- * \note            When \p pk_type is #MBEDTLS_PK_RSASSA_PSS,
- *                  see #PSA_ALG_RSA_PSS for a description of PSS options used.
- *
- * \note            For RSA, md_alg may be MBEDTLS_MD_NONE if hash_len != 0.
- *                  For ECDSA, md_alg may never be MBEDTLS_MD_NONE.
- *
- */
-int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
-                        mbedtls_pk_context *ctx,
-                        mbedtls_md_type_t md_alg,
-                        const unsigned char *hash, size_t hash_len,
-                        unsigned char *sig, size_t sig_size, size_t *sig_len,
-                        int (*f_rng)(void *, unsigned char *, size_t),
-                        void *p_rng);
 
 /**
  * \brief           Restartable version of \c mbedtls_pk_sign()
@@ -948,57 +712,6 @@ int mbedtls_pk_sign_restartable(mbedtls_pk_context *ctx,
                                 mbedtls_pk_restart_ctx *rs_ctx);
 
 /**
- * \brief           Decrypt message (including padding if relevant).
- *
- * \param ctx       The PK context to use. It must have been set up
- *                  with a private key.
- * \param input     Input to decrypt
- * \param ilen      Input size
- * \param output    Decrypted output
- * \param olen      Decrypted message length
- * \param osize     Size of the output buffer
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
- *
- * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
- *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
- *                  the underlying RSA context. For a pk object constructed by
- *                  parsing, this is PKCS#1 v1.5 by default.
- *
- * \return          0 on success, or a specific error code.
- */
-int mbedtls_pk_decrypt(mbedtls_pk_context *ctx,
-                       const unsigned char *input, size_t ilen,
-                       unsigned char *output, size_t *olen, size_t osize,
-                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
-
-/**
- * \brief           Encrypt message (including padding if relevant).
- *
- * \param ctx       The PK context to use. It must have been set up.
- * \param input     Message to encrypt
- * \param ilen      Message size
- * \param output    Encrypted output
- * \param olen      Encrypted output length
- * \param osize     Size of the output buffer
- * \param f_rng     RNG function, must not be \c NULL.
- * \param p_rng     RNG parameter
- *
- * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
- *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
- *                  the underlying RSA context. For a pk object constructed by
- *                  parsing, this is PKCS#1 v1.5 by default.
- *
- * \note            \p f_rng is used for padding generation.
- *
- * \return          0 on success, or a specific error code.
- */
-int mbedtls_pk_encrypt(mbedtls_pk_context *ctx,
-                       const unsigned char *input, size_t ilen,
-                       unsigned char *output, size_t *olen, size_t osize,
-                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
-
-/**
  * \brief           Check if a public-private pair of keys matches.
  *
  * \param pub       Context holding a public key.
@@ -1016,82 +729,6 @@ int mbedtls_pk_check_pair(const mbedtls_pk_context *pub,
                           const mbedtls_pk_context *prv,
                           int (*f_rng)(void *, unsigned char *, size_t),
                           void *p_rng);
-
-/**
- * \brief           Export debug information
- *
- * \param ctx       The PK context to use. It must have been initialized.
- * \param items     Place to write debug items
- *
- * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
- */
-int mbedtls_pk_debug(const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items);
-
-/**
- * \brief           Access the type name
- *
- * \param ctx       The PK context to use. It must have been initialized.
- *
- * \return          Type name on success, or "invalid PK"
- */
-const char *mbedtls_pk_get_name(const mbedtls_pk_context *ctx);
-
-/**
- * \brief           Get the key type
- *
- * \param ctx       The PK context to use. It must have been initialized.
- *
- * \return          Type on success.
- * \return          #MBEDTLS_PK_NONE for a context that has not been set up.
- */
-mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context *ctx);
-
-#if defined(MBEDTLS_RSA_C)
-/**
- * Quick access to an RSA context inside a PK context.
- *
- * \warning This function can only be used when the type of the context, as
- * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_RSA.
- * Ensuring that is the caller's responsibility.
- * Alternatively, you can check whether this function returns NULL.
- *
- * \return The internal RSA context held by the PK context, or NULL.
- */
-static inline mbedtls_rsa_context *mbedtls_pk_rsa(const mbedtls_pk_context pk)
-{
-    switch (mbedtls_pk_get_type(&pk)) {
-        case MBEDTLS_PK_RSA:
-            return (mbedtls_rsa_context *) (pk).MBEDTLS_PRIVATE(pk_ctx);
-        default:
-            return NULL;
-    }
-}
-#endif /* MBEDTLS_RSA_C */
-
-#if defined(MBEDTLS_ECP_C)
-/**
- * Quick access to an EC context inside a PK context.
- *
- * \warning This function can only be used when the type of the context, as
- * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_ECKEY,
- * #MBEDTLS_PK_ECKEY_DH, or #MBEDTLS_PK_ECDSA.
- * Ensuring that is the caller's responsibility.
- * Alternatively, you can check whether this function returns NULL.
- *
- * \return The internal EC context held by the PK context, or NULL.
- */
-static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
-{
-    switch (mbedtls_pk_get_type(&pk)) {
-        case MBEDTLS_PK_ECKEY:
-        case MBEDTLS_PK_ECKEY_DH:
-        case MBEDTLS_PK_ECDSA:
-            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
-        default:
-            return NULL;
-    }
-}
-#endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */
@@ -1272,41 +909,6 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context *ctx, unsigned char *bu
  */
 int mbedtls_pk_write_key_pem(const mbedtls_pk_context *ctx, unsigned char *buf, size_t size);
 #endif /* MBEDTLS_PEM_WRITE_C */
-#endif /* MBEDTLS_PK_WRITE_C */
-
-/*
- * WARNING: Low-level functions. You probably do not want to use these unless
- *          you are certain you do ;)
- */
-
-#if defined(MBEDTLS_PK_PARSE_C)
-/**
- * \brief           Parse a SubjectPublicKeyInfo DER structure
- *
- * \param p         the position in the ASN.1 data
- * \param end       end of the buffer
- * \param pk        The PK context to fill. It must have been initialized
- *                  but not set up.
- *
- * \return          0 if successful, or a specific PK error code
- */
-int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
-                               mbedtls_pk_context *pk);
-#endif /* MBEDTLS_PK_PARSE_C */
-
-#if defined(MBEDTLS_PK_WRITE_C)
-/**
- * \brief           Write a subjectPublicKey to ASN.1 data
- *                  Note: function works backwards in data buffer
- *
- * \param p         reference to current position pointer
- * \param start     start of the buffer (for bounds-checking)
- * \param key       PK context which must contain a valid public or private key.
- *
- * \return          the length written or a negative error code
- */
-int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
-                            const mbedtls_pk_context *key);
 #endif /* MBEDTLS_PK_WRITE_C */
 
 #ifdef __cplusplus

--- a/drivers/builtin/include/mbedtls/pk_private.h
+++ b/drivers/builtin/include/mbedtls/pk_private.h
@@ -1,0 +1,24 @@
+/**
+ * \file pk_private.h
+ *
+ * \brief Deprecated private interfaces formerly in pk.h
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef MBEDTLS_PK_PRIVATE_H
+#define MBEDTLS_PK_PRIVATE_H
+
+#include <mbedtls/pk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_PK_PRIVATE_H */

--- a/drivers/builtin/include/mbedtls/pk_private.h
+++ b/drivers/builtin/include/mbedtls/pk_private.h
@@ -11,6 +11,10 @@
 #ifndef MBEDTLS_PK_PRIVATE_H
 #define MBEDTLS_PK_PRIVATE_H
 
+/* This file only contains private definitions, but it still contains Doxygen
+ * markup. Exclude it from the rendered documentation. */
+#if !defined(__DOXYGEN__)
+
 #include <mbedtls/pk.h>
 
 #if defined(MBEDTLS_RSA_C)
@@ -418,5 +422,7 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* !defined(__DOXYGEN__) */
 
 #endif /* MBEDTLS_PK_PRIVATE_H */

--- a/drivers/builtin/include/mbedtls/pk_private.h
+++ b/drivers/builtin/include/mbedtls/pk_private.h
@@ -13,9 +13,407 @@
 
 #include <mbedtls/pk.h>
 
+#if defined(MBEDTLS_RSA_C)
+#include "mbedtls/rsa.h"
+#endif
+
+#if defined(MBEDTLS_ECP_C)
+#include "mbedtls/ecp.h"
+#endif
+
+#if defined(MBEDTLS_ECDSA_C)
+#include "mbedtls/ecdsa.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * \brief          Public key types
+ */
+/* Note that the values must match the corresponding enum constants in
+ * mbedtls_pk_spki_alg_t and mbedtls_pk_sigalg_t until we stop using
+ * mbedtls_pk_type_t in mbedtls_pk_context and mbedtls_pk_can_do(). */
+typedef enum {
+    MBEDTLS_PK_NONE=0,
+    MBEDTLS_PK_RSA,
+    MBEDTLS_PK_ECKEY,
+    MBEDTLS_PK_ECKEY_DH,
+    MBEDTLS_PK_ECDSA,
+    MBEDTLS_PK_RSA_ALT,
+    MBEDTLS_PK_RSASSA_PSS,
+    MBEDTLS_PK_OPAQUE,
+} mbedtls_pk_type_t;
+
+/**
+ * \brief           Options for RSASSA-PSS signature verification.
+ *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()
+ */
+typedef struct mbedtls_pk_rsassa_pss_options {
+    /** The digest to use for MGF1 in PSS.
+     *
+     * \note When #MBEDTLS_RSA_C is disabled, this must be equal to the \c md_alg argument passed
+     *       to mbedtls_pk_verify_ext(). In a future version of the library, this constraint may
+     *       apply regardless of the status of #MBEDTLS_RSA_C.
+     */
+    mbedtls_md_type_t mgf1_hash_id;
+
+    /** The expected length of the salt, in bytes. This may be
+     * #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
+     *
+     * \note Only #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be ignored (allowing any
+     *       salt length).
+     */
+    int expected_salt_len;
+
+} mbedtls_pk_rsassa_pss_options;
+
+/**
+ * \brief           Types for interfacing with the debug module
+ */
+typedef enum {
+    MBEDTLS_PK_DEBUG_NONE = 0,
+    MBEDTLS_PK_DEBUG_MPI,
+    MBEDTLS_PK_DEBUG_ECP,
+    MBEDTLS_PK_DEBUG_PSA_EC,
+} mbedtls_pk_debug_type;
+
+/**
+ * \brief           Item to send to the debug module
+ */
+typedef struct mbedtls_pk_debug_item {
+    mbedtls_pk_debug_type MBEDTLS_PRIVATE(type);
+    const char *MBEDTLS_PRIVATE(name);
+    void *MBEDTLS_PRIVATE(value);
+} mbedtls_pk_debug_item;
+
+/** Maximum number of item send for debugging, plus 1 */
+#define MBEDTLS_PK_DEBUG_MAX_ITEMS 3
+
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+/**
+ * \brief           Types for RSA-alt abstraction
+ */
+typedef int (*mbedtls_pk_rsa_alt_decrypt_func)(void *ctx, size_t *olen,
+                                               const unsigned char *input, unsigned char *output,
+                                               size_t output_max_len);
+typedef int (*mbedtls_pk_rsa_alt_sign_func)(void *ctx,
+                                            int (*f_rng)(void *, unsigned char *, size_t),
+                                            void *p_rng,
+                                            mbedtls_md_type_t md_alg, unsigned int hashlen,
+                                            const unsigned char *hash, unsigned char *sig);
+typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)(void *ctx);
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+/**
+ * \brief           Return information associated with the given PK type
+ *
+ * \param pk_type   PK type to search for.
+ *
+ * \return          The PK info associated with the type or NULL if not found.
+ */
+const mbedtls_pk_info_t *mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type);
+
+/**
+ * \brief           Initialize a PK context with the information given
+ *                  and allocates the type-specific PK subcontext.
+ *
+ * \param ctx       Context to initialize. It must not have been set
+ *                  up yet (type #MBEDTLS_PK_NONE).
+ * \param info      Information to use
+ *
+ * \return          0 on success,
+ *                  MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input,
+ *                  MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
+ *
+ * \note            For contexts holding an RSA-alt key, use
+ *                  \c mbedtls_pk_setup_rsa_alt() instead.
+ */
+int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
+
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+/**
+ * \brief           Initialize an RSA-alt context
+ *
+ * \param ctx       Context to initialize. It must not have been set
+ *                  up yet (type #MBEDTLS_PK_NONE).
+ * \param key       RSA key pointer
+ * \param decrypt_func  Decryption function
+ * \param sign_func     Signing function
+ * \param key_len_func  Function returning key length in bytes
+ *
+ * \return          0 on success, or MBEDTLS_ERR_PK_BAD_INPUT_DATA if the
+ *                  context wasn't already initialized as RSA_ALT.
+ *
+ * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
+ */
+int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context *ctx, void *key,
+                             mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
+                             mbedtls_pk_rsa_alt_sign_func sign_func,
+                             mbedtls_pk_rsa_alt_key_len_func key_len_func);
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+/**
+ * \brief           Get the length in bytes of the underlying key
+ *
+ * \param ctx       The context to query. It must have been initialized.
+ *
+ * \return          Key length in bytes, or 0 on error
+ */
+static inline size_t mbedtls_pk_get_len(const mbedtls_pk_context *ctx)
+{
+    return (mbedtls_pk_get_bitlen(ctx) + 7) / 8;
+}
+
+/**
+ * \brief           Tell if a context can do the operation given by type
+ *
+ * \param ctx       The context to query. It must have been initialized.
+ * \param type      The desired type.
+ *
+ * \return          1 if the context can do operations on the given type.
+ * \return          0 if the context cannot do the operations on the given
+ *                  type. This is always the case for a context that has
+ *                  been initialized but not set up, or that has been
+ *                  cleared with mbedtls_pk_free().
+ */
+int mbedtls_pk_can_do(const mbedtls_pk_context *ctx, mbedtls_pk_type_t type);
+
+/**
+ * \brief           Verify signature, with options.
+ *                  (Includes verification of the padding depending on type.)
+ *
+ * \param type      Signature type (inc. possible padding type) to verify
+ * \param options   Pointer to type-specific options, or NULL
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length or 0 (see notes)
+ * \param sig       Signature to verify
+ * \param sig_len   Signature length
+ *
+ * \return          0 on success (signature is valid),
+ *                  #MBEDTLS_ERR_PK_TYPE_MISMATCH if the PK context can't be
+ *                  used for this type of signatures,
+ *                  #MBEDTLS_ERR_PK_SIG_LEN_MISMATCH if there is a valid
+ *                  signature in \p sig but its length is less than \p sig_len,
+ *                  or a specific error code.
+ *
+ * \note            If hash_len is 0, then the length associated with md_alg
+ *                  is used instead, or an error returned if it is invalid.
+ *
+ * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
+ *
+ * \note            If type is MBEDTLS_PK_RSASSA_PSS, then options must point
+ *                  to a mbedtls_pk_rsassa_pss_options structure,
+ *                  otherwise it must be NULL. Note that the salt length is not
+ *                  verified as contexes have PSA_ALG_RSA_PSS_ANY_SALT as default
+ *                  and that is the only valid value.
+ */
+int mbedtls_pk_verify_ext(mbedtls_pk_type_t type, const void *options,
+                          mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+                          const unsigned char *hash, size_t hash_len,
+                          const unsigned char *sig, size_t sig_len);
+
+/**
+ * \brief           Make signature given a signature type.
+ *
+ * \param pk_type   Signature type.
+ * \param ctx       The PK context to use. It must have been set up
+ *                  with a private key.
+ * \param md_alg    Hash algorithm used (see notes)
+ * \param hash      Hash of the message to sign
+ * \param hash_len  Hash length
+ * \param sig       Place to write the signature.
+ *                  It must have enough room for the signature.
+ *                  #MBEDTLS_PK_SIGNATURE_MAX_SIZE is always enough.
+ *                  You may use a smaller buffer if it is large enough
+ *                  given the key type.
+ * \param sig_size  The size of the \p sig buffer in bytes.
+ * \param sig_len   On successful return,
+ *                  the number of bytes written to \p sig.
+ * \param f_rng     RNG function, must not be \c NULL.
+ * \param p_rng     RNG parameter
+ *
+ * \return          0 on success, or a specific error code.
+ *
+ * \note            When \p pk_type is #MBEDTLS_PK_RSASSA_PSS,
+ *                  see #PSA_ALG_RSA_PSS for a description of PSS options used.
+ *
+ * \note            For RSA, md_alg may be MBEDTLS_MD_NONE if hash_len != 0.
+ *                  For ECDSA, md_alg may never be MBEDTLS_MD_NONE.
+ *
+ */
+int mbedtls_pk_sign_ext(mbedtls_pk_type_t pk_type,
+                        mbedtls_pk_context *ctx,
+                        mbedtls_md_type_t md_alg,
+                        const unsigned char *hash, size_t hash_len,
+                        unsigned char *sig, size_t sig_size, size_t *sig_len,
+                        int (*f_rng)(void *, unsigned char *, size_t),
+                        void *p_rng);
+/**
+ * \brief           Decrypt message (including padding if relevant).
+ *
+ * \param ctx       The PK context to use. It must have been set up
+ *                  with a private key.
+ * \param input     Input to decrypt
+ * \param ilen      Input size
+ * \param output    Decrypted output
+ * \param olen      Decrypted message length
+ * \param osize     Size of the output buffer
+ * \param f_rng     RNG function, must not be \c NULL.
+ * \param p_rng     RNG parameter
+ *
+ * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
+ *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
+ *                  the underlying RSA context. For a pk object constructed by
+ *                  parsing, this is PKCS#1 v1.5 by default.
+ *
+ * \return          0 on success, or a specific error code.
+ */
+int mbedtls_pk_decrypt(mbedtls_pk_context *ctx,
+                       const unsigned char *input, size_t ilen,
+                       unsigned char *output, size_t *olen, size_t osize,
+                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+
+/**
+ * \brief           Encrypt message (including padding if relevant).
+ *
+ * \param ctx       The PK context to use. It must have been set up.
+ * \param input     Message to encrypt
+ * \param ilen      Message size
+ * \param output    Encrypted output
+ * \param olen      Encrypted output length
+ * \param osize     Size of the output buffer
+ * \param f_rng     RNG function, must not be \c NULL.
+ * \param p_rng     RNG parameter
+ *
+ * \note            For keys of type #MBEDTLS_PK_RSA, the signature algorithm is
+ *                  either PKCS#1 v1.5 or OAEP, depending on the padding mode in
+ *                  the underlying RSA context. For a pk object constructed by
+ *                  parsing, this is PKCS#1 v1.5 by default.
+ *
+ * \note            \p f_rng is used for padding generation.
+ *
+ * \return          0 on success, or a specific error code.
+ */
+int mbedtls_pk_encrypt(mbedtls_pk_context *ctx,
+                       const unsigned char *input, size_t ilen,
+                       unsigned char *output, size_t *olen, size_t osize,
+                       int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+
+
+/**
+ * \brief           Export debug information
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ * \param items     Place to write debug items
+ *
+ * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
+ */
+int mbedtls_pk_debug(const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items);
+
+/**
+ * \brief           Access the type name
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ *
+ * \return          Type name on success, or "invalid PK"
+ */
+const char *mbedtls_pk_get_name(const mbedtls_pk_context *ctx);
+
+/**
+ * \brief           Get the key type
+ *
+ * \param ctx       The PK context to use. It must have been initialized.
+ *
+ * \return          Type on success.
+ * \return          #MBEDTLS_PK_NONE for a context that has not been set up.
+ */
+mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context *ctx);
+
+#if defined(MBEDTLS_RSA_C)
+/**
+ * Quick access to an RSA context inside a PK context.
+ *
+ * \warning This function can only be used when the type of the context, as
+ * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_RSA.
+ * Ensuring that is the caller's responsibility.
+ * Alternatively, you can check whether this function returns NULL.
+ *
+ * \return The internal RSA context held by the PK context, or NULL.
+ */
+static inline mbedtls_rsa_context *mbedtls_pk_rsa(const mbedtls_pk_context pk)
+{
+    switch (mbedtls_pk_get_type(&pk)) {
+        case MBEDTLS_PK_RSA:
+            return (mbedtls_rsa_context *) (pk).MBEDTLS_PRIVATE(pk_ctx);
+        default:
+            return NULL;
+    }
+}
+#endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_ECP_C)
+/**
+ * Quick access to an EC context inside a PK context.
+ *
+ * \warning This function can only be used when the type of the context, as
+ * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_ECKEY,
+ * #MBEDTLS_PK_ECKEY_DH, or #MBEDTLS_PK_ECDSA.
+ * Ensuring that is the caller's responsibility.
+ * Alternatively, you can check whether this function returns NULL.
+ *
+ * \return The internal EC context held by the PK context, or NULL.
+ */
+static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
+{
+    switch (mbedtls_pk_get_type(&pk)) {
+        case MBEDTLS_PK_ECKEY:
+        case MBEDTLS_PK_ECKEY_DH:
+        case MBEDTLS_PK_ECDSA:
+            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
+        default:
+            return NULL;
+    }
+}
+#endif /* MBEDTLS_ECP_C */
+
+/*
+ * WARNING: Low-level functions. You probably do not want to use these unless
+ *          you are certain you do ;)
+ */
+
+#if defined(MBEDTLS_PK_PARSE_C)
+/**
+ * \brief           Parse a SubjectPublicKeyInfo DER structure
+ *
+ * \param p         the position in the ASN.1 data
+ * \param end       end of the buffer
+ * \param pk        The PK context to fill. It must have been initialized
+ *                  but not set up.
+ *
+ * \return          0 if successful, or a specific PK error code
+ */
+int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
+                               mbedtls_pk_context *pk);
+#endif /* MBEDTLS_PK_PARSE_C */
+
+#if defined(MBEDTLS_PK_WRITE_C)
+/**
+ * \brief           Write a subjectPublicKey to ASN.1 data
+ *                  Note: function works backwards in data buffer
+ *
+ * \param p         reference to current position pointer
+ * \param start     start of the buffer (for bounds-checking)
+ * \param key       PK context which must contain a valid public or private key.
+ *
+ * \return          the length written or a negative error code
+ */
+int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
+                            const mbedtls_pk_context *key);
+#endif /* MBEDTLS_PK_WRITE_C */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -373,7 +373,7 @@ FN_OID_GET_ATTR1(mbedtls_oid_get_certificate_policies,
 typedef struct {
     mbedtls_oid_descriptor_t    descriptor;
     mbedtls_md_type_t           md_alg;
-    mbedtls_pk_type_t           pk_alg;
+    mbedtls_pk_sigalg_t        pk_alg;
 } oid_sig_alg_t;
 
 static const oid_sig_alg_t oid_sig_alg[] =
@@ -382,47 +382,47 @@ static const oid_sig_alg_t oid_sig_alg[] =
 #if defined(PSA_WANT_ALG_MD5)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_MD5,        "md5WithRSAEncryption",     "RSA with MD5"),
-        MBEDTLS_MD_MD5,      MBEDTLS_PK_RSA,
+        MBEDTLS_MD_MD5,      MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_MD5 */
 #if defined(PSA_WANT_ALG_SHA_1)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_SHA1,       "sha-1WithRSAEncryption",   "RSA with SHA1"),
-        MBEDTLS_MD_SHA1,     MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_1 */
 #if defined(PSA_WANT_ALG_SHA_224)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_SHA224,     "sha224WithRSAEncryption",
                        "RSA with SHA-224"),
-        MBEDTLS_MD_SHA224,   MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA224,   MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_224 */
 #if defined(PSA_WANT_ALG_SHA_256)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_SHA256,     "sha256WithRSAEncryption",
                        "RSA with SHA-256"),
-        MBEDTLS_MD_SHA256,   MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA256,   MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_256 */
 #if defined(PSA_WANT_ALG_SHA_384)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_SHA384,     "sha384WithRSAEncryption",
                        "RSA with SHA-384"),
-        MBEDTLS_MD_SHA384,   MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA384,   MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_384 */
 #if defined(PSA_WANT_ALG_SHA_512)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_SHA512,     "sha512WithRSAEncryption",
                        "RSA with SHA-512"),
-        MBEDTLS_MD_SHA512,   MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA512,   MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_512 */
 #if defined(PSA_WANT_ALG_SHA_1)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_RSA_SHA_OBS,      "sha-1WithRSAEncryption",   "RSA with SHA1"),
-        MBEDTLS_MD_SHA1,     MBEDTLS_PK_RSA,
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_SIGALG_RSA,
     },
 #endif /* PSA_WANT_ALG_SHA_1 */
 #endif /* MBEDTLS_RSA_C */
@@ -430,43 +430,43 @@ static const oid_sig_alg_t oid_sig_alg[] =
 #if defined(PSA_WANT_ALG_SHA_1)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_ECDSA_SHA1,       "ecdsa-with-SHA1",      "ECDSA with SHA1"),
-        MBEDTLS_MD_SHA1,     MBEDTLS_PK_ECDSA,
+        MBEDTLS_MD_SHA1,     MBEDTLS_PK_SIGALG_ECDSA,
     },
 #endif /* PSA_WANT_ALG_SHA_1 */
 #if defined(PSA_WANT_ALG_SHA_224)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_ECDSA_SHA224,     "ecdsa-with-SHA224",    "ECDSA with SHA224"),
-        MBEDTLS_MD_SHA224,   MBEDTLS_PK_ECDSA,
+        MBEDTLS_MD_SHA224,   MBEDTLS_PK_SIGALG_ECDSA,
     },
 #endif
 #if defined(PSA_WANT_ALG_SHA_256)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_ECDSA_SHA256,     "ecdsa-with-SHA256",    "ECDSA with SHA256"),
-        MBEDTLS_MD_SHA256,   MBEDTLS_PK_ECDSA,
+        MBEDTLS_MD_SHA256,   MBEDTLS_PK_SIGALG_ECDSA,
     },
 #endif /* PSA_WANT_ALG_SHA_256 */
 #if defined(PSA_WANT_ALG_SHA_384)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_ECDSA_SHA384,     "ecdsa-with-SHA384",    "ECDSA with SHA384"),
-        MBEDTLS_MD_SHA384,   MBEDTLS_PK_ECDSA,
+        MBEDTLS_MD_SHA384,   MBEDTLS_PK_SIGALG_ECDSA,
     },
 #endif /* PSA_WANT_ALG_SHA_384 */
 #if defined(PSA_WANT_ALG_SHA_512)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_ECDSA_SHA512,     "ecdsa-with-SHA512",    "ECDSA with SHA512"),
-        MBEDTLS_MD_SHA512,   MBEDTLS_PK_ECDSA,
+        MBEDTLS_MD_SHA512,   MBEDTLS_PK_SIGALG_ECDSA,
     },
 #endif /* PSA_WANT_ALG_SHA_512 */
 #endif /* PSA_HAVE_ALG_SOME_ECDSA */
 #if defined(MBEDTLS_RSA_C)
     {
         OID_DESCRIPTOR(MBEDTLS_OID_RSASSA_PSS,        "RSASSA-PSS",           "RSASSA-PSS"),
-        MBEDTLS_MD_NONE,     MBEDTLS_PK_RSASSA_PSS,
+        MBEDTLS_MD_NONE,     MBEDTLS_PK_SIGALG_RSASSA_PSS,
     },
 #endif /* MBEDTLS_RSA_C */
     {
         NULL_OID_DESCRIPTOR,
-        MBEDTLS_MD_NONE, MBEDTLS_PK_NONE,
+        MBEDTLS_MD_NONE, MBEDTLS_PK_SIGALG_NONE,
     },
 };
 
@@ -485,12 +485,12 @@ FN_OID_GET_ATTR2(mbedtls_oid_get_sig_alg,
                  sig_alg,
                  mbedtls_md_type_t,
                  md_alg,
-                 mbedtls_pk_type_t,
+                 mbedtls_pk_sigalg_t,
                  pk_alg)
 FN_OID_GET_OID_BY_ATTR2(mbedtls_oid_get_oid_by_sig_alg,
                         oid_sig_alg_t,
                         oid_sig_alg,
-                        mbedtls_pk_type_t,
+                        mbedtls_pk_sigalg_t,
                         pk_alg,
                         mbedtls_md_type_t,
                         md_alg)

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -500,35 +500,35 @@ FN_OID_GET_OID_BY_ATTR2(mbedtls_oid_get_oid_by_sig_alg,
  */
 typedef struct {
     mbedtls_oid_descriptor_t    descriptor;
-    mbedtls_pk_type_t           pk_alg;
+    mbedtls_pk_spki_alg_t           pk_alg;
 } oid_pk_alg_t;
 
 static const oid_pk_alg_t oid_pk_alg[] =
 {
     {
         OID_DESCRIPTOR(MBEDTLS_OID_PKCS1_RSA,           "rsaEncryption",    "RSA"),
-        MBEDTLS_PK_RSA,
+        MBEDTLS_PK_SPKI_RSA,
     },
     {
         OID_DESCRIPTOR(MBEDTLS_OID_EC_ALG_UNRESTRICTED, "id-ecPublicKey",   "Generic EC key"),
-        MBEDTLS_PK_ECKEY,
+        MBEDTLS_PK_SPKI_ECKEY,
     },
     {
         OID_DESCRIPTOR(MBEDTLS_OID_EC_ALG_ECDH,         "id-ecDH",          "EC key for ECDH"),
-        MBEDTLS_PK_ECKEY_DH,
+        MBEDTLS_PK_SPKI_ECKEY_DH,
     },
     {
         NULL_OID_DESCRIPTOR,
-        MBEDTLS_PK_NONE,
+        MBEDTLS_PK_SPKI_NONE,
     },
 };
 
 FN_OID_TYPED_FROM_ASN1(oid_pk_alg_t, pk_alg, oid_pk_alg)
-FN_OID_GET_ATTR1(mbedtls_oid_get_pk_alg, oid_pk_alg_t, pk_alg, mbedtls_pk_type_t, pk_alg)
+FN_OID_GET_ATTR1(mbedtls_oid_get_pk_alg, oid_pk_alg_t, pk_alg, mbedtls_pk_spki_alg_t, pk_alg)
 FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_pk_alg,
                         oid_pk_alg_t,
                         oid_pk_alg,
-                        mbedtls_pk_type_t,
+                        mbedtls_pk_spki_alg_t,
                         pk_alg)
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1001,6 +1001,8 @@ static int copy_from_psa(mbedtls_svc_key_id_t key_id,
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
     }
 
+    pk->psa_algorithm = psa_get_key_algorithm(&key_attr);
+
 exit:
     psa_reset_key_attributes(&key_attr);
     mbedtls_platform_zeroize(exp_key, sizeof(exp_key));

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -154,8 +154,8 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
 /*
  * Initialise a PSA-wrapping context
  */
-int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
-                            const mbedtls_svc_key_id_t key)
+int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
+                        const mbedtls_svc_key_id_t key)
 {
     const mbedtls_pk_info_t *info = NULL;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -12,6 +12,7 @@
 #define MBEDTLS_PK_INTERNAL_H
 
 #include "mbedtls/pk.h"
+#include "mbedtls/pk_private.h"
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include "mbedtls/ecp.h"

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -20,8 +20,11 @@
 #endif
 
 struct mbedtls_pk_info_t {
-    /** Public key type */
+    /** Legacy key type */
     mbedtls_pk_type_t type;
+
+    /** Default signature policy */
+    psa_algorithm_t psa_algorithm;
 
     /** Type name */
     const char *name;

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -13,7 +13,7 @@
 
 #include "tf-psa-crypto/build_info.h"
 
-#include "mbedtls/pk.h"
+#include "mbedtls/pk_private.h"
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"

--- a/tests/suites/test_suite_pk.data
+++ b/tests/suites/test_suite_pk.data
@@ -1,3 +1,35 @@
+# Check that mbedtls_pk_spki_alg_t enum values are equal to the
+# legacy mbedtls_pk_type_t values. This is necessary until we update all
+# the places that assume this internally: `(mbedtls_pk_type_t)` casts,
+# maybe more.
+enum value MBEDTLS_PK_SPKI_NONE
+enum_value_equal:MBEDTLS_PK_SPKI_NONE:MBEDTLS_PK_NONE
+
+enum value MBEDTLS_PK_SPKI_RSA
+enum_value_equal:MBEDTLS_PK_SPKI_RSA:MBEDTLS_PK_RSA
+
+enum value MBEDTLS_PK_SPKI_ECKEY
+enum_value_equal:MBEDTLS_PK_SPKI_ECKEY:MBEDTLS_PK_ECKEY
+
+enum value MBEDTLS_PK_SPKI_ECKEY_DH
+enum_value_equal:MBEDTLS_PK_SPKI_ECKEY_DH:MBEDTLS_PK_ECKEY_DH
+
+# Check that mbedtls_pk_sigalg_t enum values are equal to the
+# legacy mbedtls_pk_type_t values. This is necessary until we update all
+# the places that assume this internally: `(mbedtls_pk_type_t)` casts,
+# bit positions in `mbedtls_x509_crt_profile.allowed_pks`, maybe more.
+enum value MBEDTLS_PK_SIGALG_NONE
+enum_value_equal:MBEDTLS_PK_SIGALG_NONE:MBEDTLS_PK_NONE
+
+enum value MBEDTLS_PK_SIGALG_RSA
+enum_value_equal:MBEDTLS_PK_SIGALG_RSA:MBEDTLS_PK_RSA
+
+enum value MBEDTLS_PK_SIGALG_ECDSA
+enum_value_equal:MBEDTLS_PK_SIGALG_ECDSA:MBEDTLS_PK_ECDSA
+
+enum value MBEDTLS_PK_SIGALG_RSASSA_PSS
+enum_value_equal:MBEDTLS_PK_SIGALG_RSASSA_PSS:MBEDTLS_PK_RSASSA_PSS
+
 PK invalid parameters
 pk_invalid_param:
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -636,6 +636,13 @@ exit:
  * END_DEPENDENCIES
  */
 
+/* BEGIN_CASE */
+void enum_value_equal(int x, int y)
+{
+    TEST_EQUAL(x, y);
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_USE_PSA_CRYPTO */
 void pk_psa_utils(int key_is_rsa)
 {

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1086,8 +1086,18 @@ void pk_rsa_verify_test_vec(data_t *message_str, int padding, int digest,
     rsa = mbedtls_pk_rsa(pk);
 
     rsa->len = (mod + 7) / 8;
-    if (padding >= 0) {
-        TEST_EQUAL(mbedtls_rsa_set_padding(rsa, padding, MBEDTLS_MD_NONE), 0);
+
+    switch (padding) {
+        case -1:
+            break;
+        case MBEDTLS_RSA_PKCS_V15:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_ANY_HASH));
+            break;
+        case MBEDTLS_RSA_PKCS_V21:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH));
+            break;
+        default:
+            TEST_FAIL("Unsupported padding specifier");
     }
 
     TEST_ASSERT(mbedtls_test_read_mpi(&rsa->N, input_N) == 0);
@@ -1346,7 +1356,19 @@ void pk_sign_verify(int type, int curve_or_keybits, int rsa_padding, int rsa_md_
 
 #if defined(MBEDTLS_RSA_C)
     if (type == MBEDTLS_PK_RSA) {
-        TEST_ASSERT(mbedtls_rsa_set_padding(mbedtls_pk_rsa(pk), rsa_padding, rsa_md_alg) == 0);
+        psa_algorithm_t hash_alg = mbedtls_md_psa_alg_from_type(rsa_md_alg);
+        switch (rsa_padding) {
+            case -1:
+                break;
+            case MBEDTLS_RSA_PKCS_V15:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg));
+                break;
+            case MBEDTLS_RSA_PKCS_V21:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS(hash_alg));
+                break;
+            default:
+                TEST_FAIL("Unsupported padding specifier");
+        }
     }
 #else
     (void) rsa_padding;
@@ -1439,7 +1461,18 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod, int padding,
     /* init pk-rsa context */
     TEST_ASSERT(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
     rsa = mbedtls_pk_rsa(pk);
-    mbedtls_rsa_set_padding(rsa, padding, MBEDTLS_MD_SHA1);
+    switch (padding) {
+        case -1:
+            break;
+        case MBEDTLS_RSA_PKCS_V15:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_CRYPT);
+            break;
+        case MBEDTLS_RSA_PKCS_V21:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_1));
+            break;
+        default:
+            TEST_FAIL("Unsupported padding specifier");
+    }
 
     /* load public key */
     rsa->len = (mod + 7) / 8;
@@ -1459,7 +1492,18 @@ void pk_rsa_encrypt_decrypt_test(data_t *message, int mod, int padding,
     TEST_ASSERT(mbedtls_pk_setup(&pk,
                                  mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0);
     rsa = mbedtls_pk_rsa(pk);
-    mbedtls_rsa_set_padding(rsa, padding, MBEDTLS_MD_SHA1);
+    switch (padding) {
+        case -1:
+            break;
+        case MBEDTLS_RSA_PKCS_V15:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_CRYPT);
+            break;
+        case MBEDTLS_RSA_PKCS_V21:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_1));
+            break;
+        default:
+            TEST_FAIL("Unsupported padding specifier");
+    }
 
     /* load public key */
     TEST_ASSERT(mbedtls_test_read_mpi(&N, input_N) == 0);
@@ -1532,8 +1576,17 @@ void pk_rsa_decrypt_test_vec(data_t *cipher, int mod, int padding, int md_alg,
     TEST_EQUAL(mbedtls_pk_get_len(&pk), (mod + 7) / 8);
 
     /* set padding mode */
-    if (padding >= 0) {
-        TEST_EQUAL(mbedtls_rsa_set_padding(rsa, padding, md_alg), 0);
+    switch (padding) {
+        case -1:
+            break;
+        case MBEDTLS_RSA_PKCS_V15:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_CRYPT);
+            break;
+        case MBEDTLS_RSA_PKCS_V21:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_OAEP(mbedtls_md_psa_alg_from_type(md_alg)));
+            break;
+        default:
+            TEST_FAIL("Unsupported padding specifier");
     }
 
     /* decryption test */
@@ -1596,7 +1649,7 @@ void pk_wrap_rsa_decrypt_test_vec(data_t *cipher, int mod,
 
     /* Set padding mode */
     if (padding_mode == MBEDTLS_RSA_PKCS_V21) {
-        TEST_EQUAL(mbedtls_rsa_set_padding(rsa, padding_mode, MBEDTLS_MD_SHA1), 0);
+        mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_1));
     }
 
     /* Turn PK context into an opaque one. */
@@ -1837,7 +1890,18 @@ void pk_psa_sign(int psa_type, int bits, int rsa_padding)
 #if defined(MBEDTLS_RSA_C)
     if (PSA_KEY_TYPE_IS_RSA(psa_type)) {
         TEST_EQUAL(pk_setup(&pk, MBEDTLS_PK_RSA, bits), 0);
-        TEST_EQUAL(mbedtls_rsa_set_padding(mbedtls_pk_rsa(pk), rsa_padding, MBEDTLS_MD_NONE), 0);
+        switch (rsa_padding) {
+            case -1:
+                break;
+            case MBEDTLS_RSA_PKCS_V15:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_ANY_HASH));
+                break;
+            case MBEDTLS_RSA_PKCS_V21:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH));
+                break;
+            default:
+                TEST_FAIL("Unsupported padding specifier");
+        }
     }
 #else /* MBEDTLS_RSA_C */
     (void) rsa_padding;
@@ -1953,7 +2017,18 @@ void pk_psa_sign(int psa_type, int bits, int rsa_padding)
 
 #if defined(MBEDTLS_RSA_C)
     if (PSA_KEY_TYPE_IS_RSA(psa_type)) {
-        TEST_EQUAL(mbedtls_rsa_set_padding(mbedtls_pk_rsa(pk), rsa_padding, MBEDTLS_MD_NONE), 0);
+        switch (rsa_padding) {
+            case -1:
+                break;
+            case MBEDTLS_RSA_PKCS_V15:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_ANY_HASH));
+                break;
+            case MBEDTLS_RSA_PKCS_V21:
+                mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH));
+                break;
+            default:
+                TEST_FAIL("Unsupported padding specifier");
+        }
     }
 #endif /* MBEDTLS_RSA_C */
     TEST_ASSERT(mbedtls_pk_verify(&pk, MBEDTLS_MD_SHA256,
@@ -2028,7 +2103,7 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
     TEST_EQUAL(pk_setup(&pk, pk_type, key_bits), 0);
 
     if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
-        mbedtls_rsa_set_padding(mbedtls_pk_rsa(pk), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_NONE);
+        mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH));
     }
 
     /* Export underlying public key for re-importing in a legacy context.
@@ -2189,8 +2264,18 @@ void pk_rsa_v21_get_psa_attributes(int md_type, int from_pair,
     psa_key_type_t expected_psa_type = 0;
     TEST_EQUAL(pk_setup_for_type(MBEDTLS_PK_RSA, from_pair,
                                  &pk, &expected_psa_type), 0);
-    mbedtls_rsa_context *rsa = mbedtls_pk_rsa(pk);
-    TEST_EQUAL(mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21, md_type), 0);
+    psa_algorithm_t hash_policy = (md_type == MBEDTLS_MD_NONE ?
+                                   PSA_ALG_ANY_HASH :
+                                   mbedtls_md_psa_alg_from_type(md_type));
+    switch (usage_arg) {
+        case PSA_KEY_USAGE_DECRYPT:
+        case PSA_KEY_USAGE_ENCRYPT:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_OAEP(hash_policy));
+            break;
+        default:
+            mbedtls_pk_set_algorithm(&pk, PSA_ALG_RSA_PSS_ANY_SALT(hash_policy));
+            break;
+    }
     if (!to_pair) {
         expected_psa_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(expected_psa_type);
     }

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -662,7 +662,7 @@ void pk_psa_utils(int key_is_rsa)
     mbedtls_pk_init(&pk2);
     USE_PSA_INIT();
 
-    TEST_ASSERT(mbedtls_pk_setup_opaque(&pk, MBEDTLS_SVC_KEY_ID_INIT) ==
+    TEST_ASSERT(mbedtls_pk_wrap_psa(&pk, MBEDTLS_SVC_KEY_ID_INIT) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     mbedtls_pk_free(&pk);
@@ -683,7 +683,7 @@ void pk_psa_utils(int key_is_rsa)
         goto exit;
     }
 
-    TEST_ASSERT(mbedtls_pk_setup_opaque(&pk, key) == 0);
+    TEST_ASSERT(mbedtls_pk_wrap_psa(&pk, key) == 0);
 
     TEST_ASSERT(mbedtls_pk_get_type(&pk) == MBEDTLS_PK_OPAQUE);
     TEST_ASSERT(strcmp(mbedtls_pk_get_name(&pk), name) == 0);
@@ -768,7 +768,7 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
             goto exit;
         }
 
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key), 0);
 
         TEST_EQUAL(mbedtls_pk_get_type(&pk), MBEDTLS_PK_OPAQUE);
     } else {
@@ -1039,7 +1039,7 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     TEST_EQUAL(mbedtls_pk_import_into_psa(&prv, &opaque_key_attr, &opaque_key_id), 0);
     mbedtls_pk_free(&prv);
     mbedtls_pk_init(&prv);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&prv, opaque_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&prv, opaque_key_id), 0);
     /* Test check_pair() between the opaque key we just created and the public PK counterpart.
      * Note: opaque EC keys support check_pair(), whereas RSA ones do not. */
     if (is_ec_key) {
@@ -1657,7 +1657,7 @@ void pk_wrap_rsa_decrypt_test_vec(data_t *cipher, int mod,
     TEST_EQUAL(mbedtls_pk_import_into_psa(&pk, &key_attr, &key_id), 0);
     mbedtls_pk_free(&pk);
     mbedtls_pk_init(&pk);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key_id), 0);
 
     TEST_EQUAL(mbedtls_pk_get_bitlen(&pk), mod);
 
@@ -1951,7 +1951,7 @@ void pk_psa_sign(int psa_type, int bits, int rsa_padding)
     TEST_EQUAL(mbedtls_pk_import_into_psa(&pk, &attributes, &key_id), 0);
     mbedtls_pk_free(&pk);
     mbedtls_pk_init(&pk);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key_id), 0);
 
     PSA_ASSERT(psa_get_key_attributes(key_id, &attributes));
     TEST_EQUAL(psa_get_key_type(&attributes), (psa_key_type_t) psa_type);
@@ -2121,7 +2121,7 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
     TEST_EQUAL(mbedtls_pk_import_into_psa(&pk, &key_attr, &key_id), 0);
     mbedtls_pk_free(&pk);
     mbedtls_pk_init(&pk);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key_id), 0);
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -2365,7 +2365,7 @@ void pk_import_into_psa_lifetime(int from_opaque,
         PSA_ASSERT(pk_psa_setup(from_psa_type, MBEDTLS_TEST_PSA_ECC_ONE_CURVE_BITS,
                                 psa_key_usage, PSA_ALG_ECDH, PSA_ALG_NONE,
                                 persistent_key_id, &old_key_id));
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, old_key_id), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, old_key_id), 0);
         psa_reset_key_attributes(&attributes);
 #else
         (void) from_persistent;
@@ -2442,7 +2442,7 @@ void pk_get_psa_attributes_opaque(int from_type_arg, int from_bits_arg,
 
     PSA_ASSERT(pk_psa_setup(from_type, bits, from_usage, alg, 42,
                             MBEDTLS_SVC_KEY_ID_INIT, &old_key_id));
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, old_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, old_key_id), 0);
 
     psa_key_type_t expected_psa_type =
         to_pair ? from_type : PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(from_type);
@@ -2535,7 +2535,7 @@ void pk_import_into_psa_opaque(int from_type, int from_bits,
 
     PSA_ASSERT(pk_psa_setup(from_type, from_bits, from_usage, from_alg, PSA_ALG_NONE,
                             MBEDTLS_SVC_KEY_ID_INIT, &from_key_id));
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, from_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, from_key_id), 0);
 
     psa_set_key_type(&to_attributes, to_type);
     psa_set_key_bits(&to_attributes, to_bits);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -128,16 +128,16 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    /* Verify that pk_write works also for opaque private keys */
+    /* Verify that pk_write works also for wrapped private keys */
     if (!is_public_key) {
         memset(buf, 0, check_buf_len);
-        /* Turn the key PK context into an opaque one.
+        /* Turn the key PK context into a wrapping one.
          * Note: set some practical usage for the key to make get_psa_attributes() happy. */
         TEST_EQUAL(mbedtls_pk_get_psa_attributes(&key, PSA_KEY_USAGE_SIGN_MESSAGE, &key_attr), 0);
         TEST_EQUAL(mbedtls_pk_import_into_psa(&key, &key_attr, &opaque_id), 0);
         mbedtls_pk_free(&key);
         mbedtls_pk_init(&key);
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&key, opaque_id), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&key, opaque_id), 0);
         start_buf = buf;
         buf_len = check_buf_len;
         /* Intentionally pass a wrong size for the provided output buffer and check
@@ -218,12 +218,12 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_platform_zeroize(derived_key_raw, derived_key_len);
 
-    /* Turn the priv_key PK context into an opaque one. */
+    /* Turn the priv_key PK context into a wrapping one. */
     TEST_EQUAL(mbedtls_pk_get_psa_attributes(&priv_key, PSA_KEY_USAGE_SIGN_HASH, &key_attr), 0);
     TEST_EQUAL(mbedtls_pk_import_into_psa(&priv_key, &key_attr, &opaque_key_id), 0);
     mbedtls_pk_free(&priv_key);
     mbedtls_pk_init(&priv_key);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&priv_key, opaque_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&priv_key, opaque_key_id), 0);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);


### PR DESCRIPTION
Implement part of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/203. This started as a prototype branch, and I kept stuff that is on the critical path and that's in a good enough shape to be reviewed and merged.

* New type `mbedtls_pk_spki_alg_t` — DONE
* New type `mbedtls_pk_sigalg_t` — DONE
* Make some pk functions private — mostly done but needs another pass on the documentation to finish removing references to the removed API elements.
* Always enable `MBEDTLS_PK_USE_PSA_EC_DATA` (cheaper than not doing it). Resolves https://github.com/Mbed-TLS/mbedtls/issues/9676.
* Store the algorithm for a PK context in the context, and honor it from operations. — partly done, but needs work on the unit tests
* Rename `mbedtls_pk_wrap_opaque()` to `mbedtls_pk_wrap_psa()`. — DONE

## PR checklist

- [x] **changelog** provided | not required because: task filed for later TODO
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: new stuff
- [x] **mbedtls 3.6 PR** 
- [ ] **mbedtls 2.28 PR** not required because: new stuff
- **tests**  provided plus TODO
