### PR TITLE
asn1parse: Require minimal-length encodings of lengths

### DIFF
--- a/ChangeLog.d/minimal-length-lengths.txt
+++ b/ChangeLog.d/minimal-length-lengths.txt
@@ -1,0 +1,2 @@
+Bugfix
+  * Invalid overlong encodings of ASN.1 DER lengths are now rejected.

--- a/tests/suites/test_suite_asn1parse.data
+++ b/tests/suites/test_suite_asn1parse.data
@@ -56,97 +56,103 @@ Prefixes of SEQUENCE of (SEQUENCE of INTEGER, INTEGER), INTEGER
 parse_prefixes:"300b3006020141020142020161":0:0
 
 length=0 (short form)
-get_len:"00":0
+get_len:"00":0:0
+
+indefinite encoding
+get_len:"80":0:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=0 (1 length byte)
-get_len:"8100":0
+get_len:"8100":0:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=0 (2 length bytes)
-get_len:"820000":0
+get_len:"820000":0:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=1 (short form)
-get_len:"01":1
+get_len:"01":1:0
 
 length=1 (1 length byte)
-get_len:"8101":1
+get_len:"8101":1:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=1 (2 length bytes)
-get_len:"820001":1
+get_len:"820001":1:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=1 (3 length bytes)
-get_len:"83000001":1
+get_len:"83000001":1:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=1 (4 length bytes)
-get_len:"8400000001":1
+get_len:"8400000001":1:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=2 (short form)
-get_len:"02":2
+get_len:"02":2:0
 
 length=2 (1 length byte)
-get_len:"8102":2
+get_len:"8102":2:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=2 (2 length bytes)
-get_len:"820002":2
+get_len:"820002":2:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=2 (3 length bytes)
-get_len:"83000002":2
+get_len:"83000002":2:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=2 (4 length bytes)
-get_len:"8400000002":2
+get_len:"8400000002":2:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=127 (short form)
-get_len:"7f":127
+get_len:"7f":127:0
+
+length=127 (1 length byte)
+get_len:"817f":127:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=128 (1 length byte)
-get_len:"8180":128
+get_len:"8180":128:0
 
 length=128 (2 length bytes)
-get_len:"820080":128
+get_len:"820080":128:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=255 (1 length byte)
-get_len:"81ff":255
+get_len:"81ff":255:0
 
 length=255 (2 length bytes)
-get_len:"8200ff":255
+get_len:"8200ff":255:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=256 (2 length bytes)
-get_len:"820100":256
+get_len:"820100":256:0
 
 length=256 (3 length bytes)
-get_len:"83000100":256
+get_len:"83000100":256:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=258 (2 length bytes)
-get_len:"820102":258
+get_len:"820102":258:0
 
 length=258 (3 length bytes)
-get_len:"83000102":258
+get_len:"83000102":258:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=65535 (2 length bytes)
-get_len:"82ffff":65535
+get_len:"82ffff":65535:0
 
 length=65535 (3 length bytes)
-get_len:"8300ffff":65535
+get_len:"8300ffff":65535:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=65535 (4 length bytes)
-get_len:"840000ffff":65535
+get_len:"840000ffff":65535:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=65536 (3 length bytes)
-get_len:"83010000":65536
+get_len:"83010000":65536:0
 
 length=65536 (4 length bytes)
-get_len:"8400010000":65536
+get_len:"8400010000":0:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=16777215 (3 length bytes)
-get_len:"83ffffff":16777215
+get_len:"83ffffff":16777215:0
 
 length=16777215 (4 length bytes)
-get_len:"8400ffffff":16777215
+get_len:"8400ffffff":16777215:MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 length=16777216 (4 length bytes)
-get_len:"8401000000":16777216
+get_len:"8401000000":16777216:0
 
 length=16909060 (4 length bytes)
-get_len:"8401020304":16909060
+get_len:"8401020304":16909060:0
 
 BOOLEAN FALSE
 get_boolean:"010100":0:0
@@ -176,10 +182,10 @@ INTEGER 0, extra leading 0
 get_integer:"02020000":"0":0
 
 INTEGER 1
-get_integer:"020101":"1":0:
+get_integer:"020101":"1":0
 
 INTEGER 1, extra leading 0
-get_integer:"02020001":"1":0:
+get_integer:"02020001":"1":0
 
 INTEGER 0x7f
 get_integer:"02017f":"7f":0
@@ -230,13 +236,13 @@ INTEGER with 127 value octets
 get_integer:"027f0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":0
 
 INTEGER with 127 value octets (long length encoding)
-get_integer:"02817f0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":0
+get_integer:"02817f0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd":MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 INTEGER with 128 value octets
 get_integer:"0281800123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":0
 
 INTEGER with 128 value octets (leading 0 in length)
-get_integer:"028200800123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":0
+get_integer:"028200800123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef":MBEDTLS_ERR_ASN1_INVALID_LENGTH
 
 INTEGER -1
 get_integer:"0201ff":"-1":0

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -123,7 +123,7 @@ exit:
 }
 
 static int get_len_step(const data_t *input, size_t buffer_size,
-                        size_t actual_length)
+                        size_t actual_length, int err)
 {
     unsigned char *buf = NULL;
     unsigned char *p = NULL;
@@ -152,10 +152,14 @@ static int get_len_step(const data_t *input, size_t buffer_size,
 
     ret = mbedtls_asn1_get_len(&p, end, &parsed_length);
 
-    if (buffer_size >= input->len + actual_length) {
-        TEST_EQUAL(ret, 0);
-        TEST_ASSERT(p == buf + input->len);
-        TEST_EQUAL(parsed_length, actual_length);
+    if (buffer_size >= input->len + actual_length ||
+        (err == MBEDTLS_ERR_ASN1_INVALID_LENGTH && end > p &&
+         (*p < 0x81 || *p > 0x84 || (end - p) > *p - 0x80))) {
+        TEST_EQUAL(ret, err);
+        if (err == 0) {
+            TEST_ASSERT(p == buf + input->len);
+            TEST_EQUAL(parsed_length, actual_length);
+        }
     } else {
         TEST_EQUAL(ret, MBEDTLS_ERR_ASN1_OUT_OF_DATA);
     }
@@ -278,7 +282,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void get_len(const data_t *input, int actual_length_arg)
+void get_len(const data_t *input, int actual_length_arg, int err)
 {
     size_t actual_length = actual_length_arg;
     size_t buffer_size;
@@ -290,14 +294,14 @@ void get_len(const data_t *input, int actual_length_arg)
      * and we only test the empty string on a 1-byte input.
      */
     for (buffer_size = 1; buffer_size <= input->len + 1; buffer_size++) {
-        if (!get_len_step(input, buffer_size, actual_length)) {
+        if (!get_len_step(input, buffer_size, actual_length, err)) {
             goto exit;
         }
     }
-    if (!get_len_step(input, input->len + actual_length - 1, actual_length)) {
+    if (!get_len_step(input, input->len + actual_length - 1, actual_length, err)) {
         goto exit;
     }
-    if (!get_len_step(input, input->len + actual_length, actual_length)) {
+    if (!get_len_step(input, input->len + actual_length, actual_length, err)) {
         goto exit;
     }
 }
@@ -500,20 +504,30 @@ void get_mpi_too_large()
     unsigned char *buf = NULL;
     unsigned char *p;
     mbedtls_mpi actual_mpi;
+    size_t i = 0;
+    size_t lenbytes = 2;
+    size_t size;
+    size_t highbyte;
+
     size_t too_many_octets =
         MBEDTLS_MPI_MAX_LIMBS * sizeof(mbedtls_mpi_uint) + 1;
-    size_t size = too_many_octets + 6;
-
     mbedtls_mpi_init(&actual_mpi);
+    TEST_EQUAL(too_many_octets >> 24, 0);
+    highbyte = too_many_octets >> 16;
+    TEST_ASSERT((too_many_octets >> 8) != 0);
+    lenbytes = highbyte ? 3 : 2;
+    size = too_many_octets + lenbytes + 3;
 
     TEST_CALLOC(buf, size);
-    buf[0] = 0x02; /* tag: INTEGER */
-    buf[1] = 0x84; /* 4-octet length */
-    buf[2] = (too_many_octets >> 24) & 0xff;
-    buf[3] = (too_many_octets >> 16) & 0xff;
-    buf[4] = (too_many_octets >> 8) & 0xff;
-    buf[5] = too_many_octets & 0xff;
-    buf[6] = 0x01; /* most significant octet */
+    buf[i++] = 0x02; /* tag: INTEGER */
+    buf[i++] = 0x80 + lenbytes; /* 2 or 3 octet length */
+    if (highbyte) {
+        buf[i++] = highbyte & 0xff;
+    }
+    buf[i++] = (too_many_octets >> 8) & 0xff;
+    buf[i++] = too_many_octets & 0xff;
+    buf[i++] = 0x01; /* most significant octet */
+    TEST_EQUAL(i, size - too_many_octets);
 
     p = buf;
     TEST_EQUAL(mbedtls_asn1_get_mpi(&p, buf + size, &actual_mpi),

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -308,7 +308,13 @@ void mbedtls_asn1_write_algorithm_identifier(data_t *oid,
                 expected_params_tag = buf_complete[data_len] = 0x04;
                 expected_params_len = par_len - 2;
                 buf_complete[data_len + 1] = (unsigned char) expected_params_len;
-            } else if (par_len >= 4 + 128 && par_len < 3 + 256 * 256) {
+            } else if (par_len >= 3 + 128 && par_len < 3 + 256) {
+                /* Write an OCTET STRING with a one-byte length encoding */
+                expected_params_tag = buf_complete[data_len] = 0x04;
+                expected_params_len = par_len - 3;
+                buf_complete[data_len + 1] = 0x81;
+                buf_complete[data_len + 2] = (unsigned char) (expected_params_len);
+            } else if (par_len >= 4 + 256 && par_len < 4 + 256 * 256) {
                 /* Write an OCTET STRING with a two-byte length encoding */
                 expected_params_tag = buf_complete[data_len] = 0x04;
                 expected_params_len = par_len - 4;


### PR DESCRIPTION

## Description

X.690 explicitly states that DER must use the shortest possible encoding of a length.  For instance, 04 81 00 is not a valid DER encoding of the empty OCTET STRING.  Instead, 04 00 must be used.  With the exception of PKCS#7, Mbed TLS only parses DER, and it is reasonable to require that even PKCS#7 be DER-encoded.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change to mbedtls
- [x] **mbedtls 3.6 PR** not required because: it is unclear whether this should be backported to stable releases
- [x] **mbedtls 2.28 PR** not required because: it is unclear whether this should be backported to stable releases
- [x] **tests**  provided