### PR TITLE
asn1parse: document behavior on unexpected tags

### DIFF
--- a/drivers/builtin/include/mbedtls/asn1.h
+++ b/drivers/builtin/include/mbedtls/asn1.h
@@ -228,7 +228,9 @@ int mbedtls_asn1_get_len(unsigned char **p,
  * \param p     On entry, \c *p points to the start of the ASN.1 element.
  *              On successful completion, \c *p points to the first byte
  *              after the length, i.e. the first byte of the content.
- *              On error, the value of \c *p is undefined.
+ *              If #MBEDTLS_ERR_ASN1_UNEXPECTED_TAG is returned, \c *p
+ *              is unchanged.
+ *              On any other error, the value of \c *p is undefined.
  * \param end   End of data.
  * \param len   On successful completion, \c *len contains the length
  *              read from the ASN.1 input.


### PR DESCRIPTION
## Description

mbedtls_asn1_get_tag() does not change *p if it returns MBEDTLS_ERR_ASN1_UNEXPECTED_TAG, and code both inside and outside of Mbed TLS relies on this.  Document this behavior.


## PR checklist

- [x] **changelog** not required because: documentation-only
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: documentation-only
- [x] **mbedtls 3.6 PR** not required because: documentation-only
- [x] **mbedtls 2.28 PR** not required because: documentation-only
- [x] **tests** not required because: documentation-only