### PR TITLE
add handling for default CMAKE_BUILD_TYPE values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ set(TF_PSA_CRYPTO_ALLOWED_BUILDTYPES None Debug Release Coverage ASan ASanDbg Me
 
 if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)
     # Inform about the currently possible build types
-    message(STATUS "TF_PSA_CRYPTO : Possible CMAKE_BUILD_TYPE Values : ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+    message(STATUS "${PROJECT_NAME} : Possible CMAKE_BUILD_TYPE Values : ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
 
     # Set the CMake default build type to Release if it is not defined and we are the root project
     if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
@@ -187,7 +187,7 @@ if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)
     endif ()
     # If the value of CMAKE_BUILD_TYPE is defined then validate it and exit fatally if it is invalid
     if(NOT CMAKE_BUILD_TYPE IN_LIST TF_PSA_CRYPTO_ALLOWED_BUILDTYPES)
-        message(FATAL_ERROR "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+        message(FATAL_ERROR "${PROJECT_NAME} : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
     else ()
         # set the valid build type value in the cache only if we are not a subproject
         set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
@@ -197,20 +197,20 @@ if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)
 else ()
     # If we are a subproject then we warn if build type is not compatible with our project
     if(NOT CMAKE_BUILD_TYPE IN_LIST TF_PSA_CRYPTO_ALLOWED_BUILDTYPES)
-        message(WARNING "**** WARNING : TF_PSA_CRYPTO is being configured as a CMake Subdirectory without setting a proper build type. This may lead to unpredictable CMAKE optimizations")
-        message(WARNING "**** WARNING : TF_PSA_CRYPTO : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+        message(WARNING "**** WARNING : ${PROJECT_NAME} is being configured as a CMake Subdirectory without setting a proper build type. This may lead to unpredictable CMAKE optimizations")
+        message(WARNING "**** WARNING : ${PROJECT_NAME} : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
     endif ()
 endif ()
 
 # validate that MemSan Build Configuration is run only with clang
 
 if((CMAKE_BUILD_TYPE STREQUAL "MemSan") AND (NOT CMAKE_COMPILER_IS_CLANG))
-    message(FATAL_ERROR "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE MemSan can only be configured with the clang compiler instead we are using ${COMPILER_ID}")
+    message(FATAL_ERROR "${PROJECT_NAME} : CMAKE_BUILD_TYPE MemSan can only be configured with the clang compiler instead we are using ${COMPILER_ID}")
 endif ()
 
 
 # Inform about the currently selected build type
-message(STATUS "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}")
+message(STATUS "${PROJECT_NAME} : CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}")
 
 # Make TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,12 +172,45 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
 
-# If this is the root project add longer list of available CMAKE_BUILD_TYPE values
+# Handle default CMAKE_BUILD_TYPE values
+# If MBEDTLS is not the root project we let the parent project handle the CMAKE_BUILD_TYPE
+# Define the build types that are available
+set(TF_PSA_CRYPTO_ALLOWED_BUILDTYPES None Debug Release Coverage ASan ASanDbg MemSan MemSanDbg Check CheckFull TSan TSanDbg)
+
 if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)
-    set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
-        CACHE STRING "Choose the type of build: None Debug Release Coverage ASan ASanDbg MemSan MemSanDbg Check CheckFull TSan TSanDbg"
-        FORCE)
-endif()
+    # Inform about the currently possible build types
+    message(STATUS "TF_PSA_CRYPTO : Possible CMAKE_BUILD_TYPE Values : ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+
+    # Set the CMake default build type to Release if it is not defined and we are the root project
+    if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+        set(CMAKE_BUILD_TYPE "Release")
+    endif ()
+    # If the value of CMAKE_BUILD_TYPE is defined then validate it and exit fatally if it is invalid
+    if(NOT CMAKE_BUILD_TYPE IN_LIST TF_PSA_CRYPTO_ALLOWED_BUILDTYPES)
+        message(FATAL_ERROR "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+    else ()
+        # set the valid build type value in the cache only if we are not a subproject
+        set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
+                CACHE STRING "Choose the type of build: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}"
+                FORCE)
+    endif()
+else ()
+    # If we are a subproject then we warn if build type is not compatible with our project
+    if(NOT CMAKE_BUILD_TYPE IN_LIST TF_PSA_CRYPTO_ALLOWED_BUILDTYPES)
+        message(WARNING "**** WARNING : TF_PSA_CRYPTO is being configured as a CMake Subdirectory without setting a proper build type. This may lead to unpredictable CMAKE optimizations")
+        message(WARNING "**** WARNING : TF_PSA_CRYPTO : CMAKE_BUILD_TYPE must be one of: ${TF_PSA_CRYPTO_ALLOWED_BUILDTYPES}")
+    endif ()
+endif ()
+
+# validate that MemSan Build Configuration is run only with clang
+
+if((CMAKE_BUILD_TYPE STREQUAL "MemSan") AND (NOT CMAKE_COMPILER_IS_CLANG))
+    message(FATAL_ERROR "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE MemSan can only be configured with the clang compiler instead we are using ${COMPILER_ID}")
+endif ()
+
+
+# Inform about the currently selected build type
+message(STATUS "TF_PSA_CRYPTO : CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}")
 
 # Make TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")

--- a/ChangeLog.d/222.txt
+++ b/ChangeLog.d/222.txt
@@ -1,0 +1,5 @@
+features
+   * add handling for default CMAKE_BUILD_TYPE
+   * validate that CMAKE_BUILD_TYPE is an accepted value if we are a root project
+   * warn that CMAKE_BUILD_TYPE is invalid if parent project uses an unrecognized build type
+   * Fail if we are a root project and the  build type is unrecognized

--- a/ChangeLog.d/222.txt
+++ b/ChangeLog.d/222.txt
@@ -1,5 +1,5 @@
-features
+Features
    * add handling for default CMAKE_BUILD_TYPE
-   * validate that CMAKE_BUILD_TYPE is an accepted value if we are a root project
-   * warn that CMAKE_BUILD_TYPE is invalid if parent project uses an unrecognized build type
+   * validate CMAKE_BUILD_TYPE upon configuring as a root project
+   * warn about CMAKE_BUILD_TYPE validity if configured as sub-project
    * Fail if we are a root project and the  build type is unrecognized


### PR DESCRIPTION
## Description

- validate that CMAKE_BUILD_TYPE is an accepted value if we are a root project
- warn that CMAKE_BUILD_TYPE is invalid if parent project uses an unrecognized build type
- Fail if we are a root project and the  build type is unrecognized

related to : https://github.com/Mbed-TLS/mbedtls/pull/10079

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework | not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls | https://github.com/Mbed-TLS/mbedtls/pull/10079 
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | https://github.com/Mbed-TLS/mbedtls/pull/10084
- [x] **mbedtls 2.28 PR** provided Mbed-TLS/mbedtls# | not required because: too outdated for changes
- [x] **tests**  provided | ~~not required because:~~


https://github.com/jurassicLizard/mbed-tls-cmake-build-test/tree/TF-PSA-Crypto/development 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
