### PR TITLE
Zeroize PSA temporary heap buffers

### DIFF
--- a/ChangeLog.d/psa-zeroize.txt
+++ b/ChangeLog.d/psa-zeroize.txt
@@ -1,0 +1,2 @@
+Security
+   * Zeroize temporary heap buffers used in PSA operations.

--- a/ChangeLog.d/psa-zeroize.txt
+++ b/ChangeLog.d/psa-zeroize.txt
@@ -1,2 +1,4 @@
 Security
+   * Zeroize a temporary heap buffer used in psa_key_derivation_output_key()
+     when deriving an ECC key pair.
    * Zeroize temporary heap buffers used in PSA operations.

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -9782,7 +9782,7 @@ psa_status_t psa_crypto_local_input_alloc(const uint8_t *input, size_t input_len
     return PSA_SUCCESS;
 
 error:
-    mbedtls_free(local_input->buffer);
+    mbedtls_zeroize_and_free(local_input->buffer, local_input->length);
     local_input->buffer = NULL;
     local_input->length = 0;
     return status;
@@ -9790,7 +9790,7 @@ error:
 
 void psa_crypto_local_input_free(psa_crypto_local_input_t *local_input)
 {
-    mbedtls_free(local_input->buffer);
+    mbedtls_zeroize_and_free(local_input->buffer, local_input->length);
     local_input->buffer = NULL;
     local_input->length = 0;
 }
@@ -9834,7 +9834,7 @@ psa_status_t psa_crypto_local_output_free(psa_crypto_local_output_t *local_outpu
         return status;
     }
 
-    mbedtls_free(local_output->buffer);
+    mbedtls_zeroize_and_free(local_output->buffer, local_output->length);
     local_output->buffer = NULL;
     local_output->length = 0;
 

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -6457,7 +6457,7 @@ static psa_status_t psa_generate_derived_ecc_key_weierstrass_helper(
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     size_t m;
-    size_t m_bytes;
+    size_t m_bytes = 0;
 
     mbedtls_mpi_init(&k);
     mbedtls_mpi_init(&diff_N_2);

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -6530,7 +6530,7 @@ cleanup:
         status = mbedtls_to_psa_error(ret);
     }
     if (status != PSA_SUCCESS) {
-        mbedtls_free(*data);
+        mbedtls_zeroize_and_free(*data, m_bytes);
         *data = NULL;
     }
     mbedtls_mpi_free(&k);
@@ -6705,7 +6705,7 @@ static psa_status_t psa_generate_derived_key_internal(
     }
 
 exit:
-    mbedtls_free(data);
+    mbedtls_zeroize_and_free(data, bytes);
     return status;
 }
 


### PR DESCRIPTION
## Description

This has been fixed in 3.6 and 2.28, this is the development forward-port. Public re-raise of https://github.com/Mbed-TLS/TF-PSA-Crypto-restricted/pull/2

Resolves https://github.com/Mbed-TLS/mbedtls-restricted/issues/1304

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: only needs updating the submodule, will be done by any number of other PRs
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls-restricted/pull/1316
- [x] **2.28 PR** https://github.com/Mbed-TLS/mbedtls-restricted/pull/1317
- **tests**  provided