### PR TITLE
The LTS branch 2.28 is now EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,6 @@ If the provided content is part of the present PR remove the # symbol.
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
 - [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
 - [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **mbedtls 2.28 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 
 
 


### PR DESCRIPTION
## Description

Update the PR template.

## PR checklist

- [ ] **changelog** not required because: doc only / announced via other channels
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10093
- [ ] **mbedtls 3.6 PR** not required because: PR template irrelevant, and BRANCHES.md already updated as part of the release
- [ ] **mbedtls 2.28 PR** not required because: well, 2.28 is EOL
- **tests**  not required because: doc only
