### PR TITLE
Remove trailing line to fix code style

### DIFF
--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -86,4 +86,3 @@ exit:
     mbedtls_free(signature);
 }
 /* END_CASE */
-


### PR DESCRIPTION
Fixes CI error in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/213 so that https://github.com/Mbed-TLS/mbedtls/pull/10073 can be updated and merged.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not provided: 
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: 
- [ ] **mbedtls 3.6 PR** not required because: 
- **tests**  not required because: 
