### PR TITLE
Added OID of Ed448 ECDSA signature algorithm

### DIFF
--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -457,6 +457,12 @@ static const oid_sig_alg_t oid_sig_alg[] =
         MBEDTLS_MD_SHA512,   MBEDTLS_PK_ECDSA,
     },
 #endif /* PSA_WANT_ALG_SHA_512 */
+#if defined(PSA_WANT_ALG_SHA3_256)
+    {
+        OID_DESCRIPTOR(MBEDTLS_OID_ED448,            "Ed448",                "Ed448 with SHA3-256"),
+        MBEDTLS_MD_SHA3_256, MBEDTLS_PK_ECDSA
+    },
+#endif /* PSA_WANT_ALG_SHA3_256 */
 #endif /* PSA_HAVE_ALG_SOME_ECDSA */
 #if defined(MBEDTLS_RSA_C)
     {


### PR DESCRIPTION
Trust roots are more and more frequently signed with Ed448. Adding the related algorithm identifiers (see RFC 9481) is needed to be able to load certificates signed with Ed448.

## Description

One of my customers signs the trust roots for his embedded appliances with Ed448 signature algorithm. This results in an unknown OID error when loading such certificates. Adding the related algorithm identifier to the OID database fixes that issue.



## PR checklist

- [ ] **changelog** provided | not required because: minimal change
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: ?
- [ ] **mbedtls 3.6 PR** provided #[10100 ](https://github.com/Mbed-TLS/mbedtls/pull/10100)
- **tests**  provided | not required because: minimal change

