### PR TITLE
Fix release component names

### DIFF
--- a/tests/scripts/components-sanitizers.sh
+++ b/tests/scripts/components-sanitizers.sh
@@ -53,7 +53,7 @@ component_tf_psa_crypto_test_memsan_constant_flow_psa () {
     make test
 }
 
-component_tf_psa_crypto_release_test_valgrind_constant_flow_no_asm () {
+component_release_tf_psa_crypto_test_valgrind_constant_flow_no_asm () {
     # This tests both (1) everything that valgrind's memcheck usually checks
     # (heap buffer overflows, use of uninitialized memory, use-after-free,
     # etc.) and (2) branches or memory access depending on secret values,
@@ -79,7 +79,7 @@ component_tf_psa_crypto_release_test_valgrind_constant_flow_no_asm () {
     make memcheck
 }
 
-component_tf_psa_crypto_release_test_valgrind_constant_flow_psa () {
+component_release_tf_psa_crypto_test_valgrind_constant_flow_psa () {
     # This tests both (1) everything that valgrind's memcheck usually checks
     # (heap buffer overflows, use of uninitialized memory, use-after-free,
     # etc.) and (2) branches or memory access depending on secret values,
@@ -133,7 +133,7 @@ component_tf_psa_crypto_test_memsan () {
     make test
 }
 
-component_tf_psa_crypto_release_test_valgrind () {
+component_release_tf_psa_crypto_test_valgrind () {
     msg "build: Release (clang)"
     # default config, in particular without MBEDTLS_USE_PSA_CRYPTO
     cd $OUT_OF_SOURCE_DIR
@@ -144,7 +144,7 @@ component_tf_psa_crypto_release_test_valgrind () {
     make memcheck
 }
 
-component_tf_psa_crypto_release_test_valgrind_psa () {
+component_release_tf_psa_crypto_test_valgrind_psa () {
     msg "build: Release, full (clang)"
     # full config, in particular with MBEDTLS_USE_PSA_CRYPTO
     scripts/config.py full


### PR DESCRIPTION
## Description

Release components name should start with "component_release". Their prefix is used to detect them and not run them in PR testing jobs.

## PR checklist

- [x] **changelog** not required
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required 
- [x] **mbedtls 3.6 PR** not required  
- **tests**  not required because: fixing the name of some components 