### PR TITLE
Privatize functions in drivers/builtin/include/mbedtls header files

### DIFF
--- a/drivers/builtin/include/mbedtls/aes.h
+++ b/drivers/builtin/include/mbedtls/aes.h
@@ -84,6 +84,8 @@ typedef struct mbedtls_aes_xts_context {
 } mbedtls_aes_xts_context;
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes the specified AES context.
  *
@@ -577,6 +579,8 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_aes_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/aria.h
+++ b/drivers/builtin/include/mbedtls/aria.h
@@ -52,6 +52,8 @@ typedef struct mbedtls_aria_context {
 }
 mbedtls_aria_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes the specified ARIA context.
  *
@@ -327,6 +329,8 @@ int mbedtls_aria_crypt_ctr(mbedtls_aria_context *ctx,
  */
 int mbedtls_aria_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/bignum.h
+++ b/drivers/builtin/include/mbedtls/bignum.h
@@ -240,6 +240,8 @@ mbedtls_mpi;
 
 #define MBEDTLS_MPI_INIT { 0, 1, 0 }
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           Initialize an MPI context.
  *
@@ -1078,6 +1080,8 @@ int mbedtls_mpi_gen_prime(mbedtls_mpi *X, size_t nbits, int flags,
 int mbedtls_mpi_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/block_cipher.h
+++ b/drivers/builtin/include/mbedtls/block_cipher.h
@@ -39,7 +39,6 @@ typedef enum {
     MBEDTLS_BLOCK_CIPHER_ID_ARIA,      /**< The Aria cipher. */
 } mbedtls_block_cipher_id_t;
 
-#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * Used internally to indicate whether a context uses legacy or PSA.
  *
@@ -49,7 +48,6 @@ typedef enum {
     MBEDTLS_BLOCK_CIPHER_ENGINE_LEGACY = 0,
     MBEDTLS_BLOCK_CIPHER_ENGINE_PSA,
 } mbedtls_block_cipher_engine_t;
-#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 typedef struct {
     mbedtls_block_cipher_id_t MBEDTLS_PRIVATE(id);

--- a/drivers/builtin/include/mbedtls/block_cipher.h
+++ b/drivers/builtin/include/mbedtls/block_cipher.h
@@ -39,6 +39,7 @@ typedef enum {
     MBEDTLS_BLOCK_CIPHER_ID_ARIA,      /**< The Aria cipher. */
 } mbedtls_block_cipher_id_t;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * Used internally to indicate whether a context uses legacy or PSA.
  *
@@ -48,6 +49,7 @@ typedef enum {
     MBEDTLS_BLOCK_CIPHER_ENGINE_LEGACY = 0,
     MBEDTLS_BLOCK_CIPHER_ENGINE_PSA,
 } mbedtls_block_cipher_engine_t;
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 typedef struct {
     mbedtls_block_cipher_id_t MBEDTLS_PRIVATE(id);

--- a/drivers/builtin/include/mbedtls/camellia.h
+++ b/drivers/builtin/include/mbedtls/camellia.h
@@ -40,6 +40,8 @@ typedef struct mbedtls_camellia_context {
 }
 mbedtls_camellia_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          Initialize a CAMELLIA context.
  *
@@ -289,6 +291,8 @@ int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context *ctx,
 int mbedtls_camellia_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ccm.h
+++ b/drivers/builtin/include/mbedtls/ccm.h
@@ -90,6 +90,8 @@ typedef struct mbedtls_ccm_context {
 }
 mbedtls_ccm_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes the specified CCM context,
  *                  to make references valid, and prepare the context
@@ -510,6 +512,8 @@ int mbedtls_ccm_finish(mbedtls_ccm_context *ctx,
  */
 int mbedtls_ccm_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/chacha20.h
+++ b/drivers/builtin/include/mbedtls/chacha20.h
@@ -40,6 +40,8 @@ typedef struct mbedtls_chacha20_context {
 }
 mbedtls_chacha20_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes the specified ChaCha20 context.
  *
@@ -188,6 +190,8 @@ int mbedtls_chacha20_crypt(const unsigned char key[32],
  */
 int mbedtls_chacha20_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/chachapoly.h
+++ b/drivers/builtin/include/mbedtls/chachapoly.h
@@ -53,6 +53,8 @@ typedef struct mbedtls_chachapoly_context {
 }
 mbedtls_chachapoly_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes the specified ChaCha20-Poly1305 context.
  *
@@ -328,6 +330,8 @@ int mbedtls_chachapoly_auth_decrypt(mbedtls_chachapoly_context *ctx,
  */
 int mbedtls_chachapoly_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/cipher.h
+++ b/drivers/builtin/include/mbedtls/cipher.h
@@ -363,6 +363,8 @@ typedef struct mbedtls_cipher_context_t {
 
 } mbedtls_cipher_context_t;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief This function retrieves the list of ciphers supported
  *        by the generic cipher module.
@@ -1160,6 +1162,9 @@ int mbedtls_cipher_auth_decrypt_ext(mbedtls_cipher_context_t *ctx,
                                     unsigned char *output, size_t output_len,
                                     size_t *olen, size_t tag_len);
 #endif /* MBEDTLS_CIPHER_MODE_AEAD || MBEDTLS_NIST_KW_C */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/builtin/include/mbedtls/cmac.h
+++ b/drivers/builtin/include/mbedtls/cmac.h
@@ -66,6 +66,8 @@ struct mbedtls_cmac_context_t {
     size_t              MBEDTLS_PRIVATE(unprocessed_len);
 };
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief               This function starts a new CMAC computation
  *                      by setting the CMAC key, and preparing to authenticate
@@ -214,6 +216,8 @@ int mbedtls_aes_cmac_prf_128(const unsigned char *key, size_t key_len,
  */
 int mbedtls_cmac_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST && ( MBEDTLS_AES_C || MBEDTLS_DES_C ) */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/des.h
+++ b/drivers/builtin/include/mbedtls/des.h
@@ -58,6 +58,7 @@ typedef struct mbedtls_des3_context {
 }
 mbedtls_des3_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 
 /**
  * \brief          Initialize DES context
@@ -355,6 +356,8 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_des_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ecdh.h
+++ b/drivers/builtin/include/mbedtls/ecdh.h
@@ -181,6 +181,8 @@ mbedtls_ecdh_context;
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 #endif /* MBEDTLS_ECDH_LEGACY_CONTEXT */
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          Return the ECP group for provided context.
  *
@@ -486,6 +488,8 @@ int mbedtls_ecdh_calc_secret(mbedtls_ecdh_context *ctx, size_t *olen,
  */
 void mbedtls_ecdh_enable_restart(mbedtls_ecdh_context *ctx);
 #endif /* MBEDTLS_ECP_RESTARTABLE */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ecdsa.h
+++ b/drivers/builtin/include/mbedtls/ecdsa.h
@@ -69,6 +69,8 @@ typedef mbedtls_ecp_keypair mbedtls_ecdsa_context;
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           Internal restart context for ecdsa_verify()
  *
@@ -92,6 +94,8 @@ typedef struct mbedtls_ecdsa_restart_sig mbedtls_ecdsa_restart_sig_ctx;
 typedef struct mbedtls_ecdsa_restart_det mbedtls_ecdsa_restart_det_ctx;
 #endif
 
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
+
 /**
  * \brief           General context for resuming ECDSA operations
  */
@@ -111,6 +115,8 @@ typedef struct {
 typedef void mbedtls_ecdsa_restart_ctx;
 
 #endif /* MBEDTLS_ECP_RESTARTABLE */
+
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 
 /**
  * \brief          This function checks whether a given group can be used
@@ -657,6 +663,8 @@ void mbedtls_ecdsa_restart_init(mbedtls_ecdsa_restart_ctx *ctx);
  */
 void mbedtls_ecdsa_restart_free(mbedtls_ecdsa_restart_ctx *ctx);
 #endif /* MBEDTLS_ECP_RESTARTABLE */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ecdsa.h
+++ b/drivers/builtin/include/mbedtls/ecdsa.h
@@ -69,8 +69,6 @@ typedef mbedtls_ecp_keypair mbedtls_ecdsa_context;
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 
-#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
-
 /**
  * \brief           Internal restart context for ecdsa_verify()
  *
@@ -93,8 +91,6 @@ typedef struct mbedtls_ecdsa_restart_sig mbedtls_ecdsa_restart_sig_ctx;
  */
 typedef struct mbedtls_ecdsa_restart_det mbedtls_ecdsa_restart_det_ctx;
 #endif
-
-#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /**
  * \brief           General context for resuming ECDSA operations

--- a/drivers/builtin/include/mbedtls/ecjpake.h
+++ b/drivers/builtin/include/mbedtls/ecjpake.h
@@ -74,6 +74,8 @@ typedef struct mbedtls_ecjpake_context {
     mbedtls_mpi MBEDTLS_PRIVATE(s);                      /**< Pre-shared secret (passphrase) */
 } mbedtls_ecjpake_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           Initialize an ECJPAKE context.
  *
@@ -284,6 +286,8 @@ void mbedtls_ecjpake_free(mbedtls_ecjpake_context *ctx);
 int mbedtls_ecjpake_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ecp.h
+++ b/drivers/builtin/include/mbedtls/ecp.h
@@ -349,6 +349,8 @@ mbedtls_ecp_group;
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           Internal restart context for multiplication
  *
@@ -362,6 +364,8 @@ typedef struct mbedtls_ecp_restart_mul mbedtls_ecp_restart_mul_ctx;
  * \note            Opaque struct
  */
 typedef struct mbedtls_ecp_restart_muladd mbedtls_ecp_restart_muladd_ctx;
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /**
  * \brief           General context for resuming ECC operations
@@ -383,6 +387,7 @@ typedef struct {
 #define MBEDTLS_ECP_OPS_ADD  11 /*!< basic ops count for see ecp_add_mixed() */
 #define MBEDTLS_ECP_OPS_INV 120 /*!< empirical equivalent for mpi_mod_inv()  */
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief           Internal; for restartable functions in other modules.
  *                  Check and update basic ops budget.
@@ -397,6 +402,7 @@ typedef struct {
 int mbedtls_ecp_check_budget(const mbedtls_ecp_group *grp,
                              mbedtls_ecp_restart_ctx *rs_ctx,
                              unsigned ops);
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /* Utility macro for checking and updating ops budget */
 #define MBEDTLS_ECP_BUDGET(ops)   \
@@ -451,6 +457,8 @@ mbedtls_ecp_keypair;
  * Some other constants from RFC 4492
  */
 #define MBEDTLS_ECP_TLS_NAMED_CURVE    3   /**< The named_curve of ECCurveType. */
+
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 /**
@@ -1517,6 +1525,8 @@ int mbedtls_ecp_export(const mbedtls_ecp_keypair *key, mbedtls_ecp_group *grp,
 int mbedtls_ecp_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ecp.h
+++ b/drivers/builtin/include/mbedtls/ecp.h
@@ -349,8 +349,6 @@ mbedtls_ecp_group;
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 
-#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
-
 /**
  * \brief           Internal restart context for multiplication
  *
@@ -364,8 +362,6 @@ typedef struct mbedtls_ecp_restart_mul mbedtls_ecp_restart_mul_ctx;
  * \note            Opaque struct
  */
 typedef struct mbedtls_ecp_restart_muladd mbedtls_ecp_restart_muladd_ctx;
-
-#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /**
  * \brief           General context for resuming ECC operations
@@ -387,7 +383,6 @@ typedef struct {
 #define MBEDTLS_ECP_OPS_ADD  11 /*!< basic ops count for see ecp_add_mixed() */
 #define MBEDTLS_ECP_OPS_INV 120 /*!< empirical equivalent for mpi_mod_inv()  */
 
-#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief           Internal; for restartable functions in other modules.
  *                  Check and update basic ops budget.
@@ -402,7 +397,6 @@ typedef struct {
 int mbedtls_ecp_check_budget(const mbedtls_ecp_group *grp,
                              mbedtls_ecp_restart_ctx *rs_ctx,
                              unsigned ops);
-#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /* Utility macro for checking and updating ops budget */
 #define MBEDTLS_ECP_BUDGET(ops)   \

--- a/drivers/builtin/include/mbedtls/gcm.h
+++ b/drivers/builtin/include/mbedtls/gcm.h
@@ -72,6 +72,8 @@ typedef struct mbedtls_gcm_context {
 }
 mbedtls_gcm_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes the specified GCM context,
  *                  to make references valid, and prepares the context
@@ -368,6 +370,8 @@ void mbedtls_gcm_free(mbedtls_gcm_context *ctx);
 int mbedtls_gcm_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/md5.h
+++ b/drivers/builtin/include/mbedtls/md5.h
@@ -39,6 +39,8 @@ typedef struct mbedtls_md5_context {
 }
 mbedtls_md5_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          Initialize MD5 context
  *
@@ -158,6 +160,8 @@ int mbedtls_md5(const unsigned char *input,
 int mbedtls_md5_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/poly1305.h
+++ b/drivers/builtin/include/mbedtls/poly1305.h
@@ -42,6 +42,8 @@ typedef struct mbedtls_poly1305_context {
 }
 mbedtls_poly1305_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes the specified Poly1305 context.
  *
@@ -154,6 +156,8 @@ int mbedtls_poly1305_mac(const unsigned char key[32],
  */
 int mbedtls_poly1305_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ripemd160.h
+++ b/drivers/builtin/include/mbedtls/ripemd160.h
@@ -30,6 +30,8 @@ typedef struct mbedtls_ripemd160_context {
 }
 mbedtls_ripemd160_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          Initialize RIPEMD-160 context
  *
@@ -109,6 +111,8 @@ int mbedtls_ripemd160(const unsigned char *input,
 int mbedtls_ripemd160_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha1.h
+++ b/drivers/builtin/include/mbedtls/sha1.h
@@ -45,6 +45,8 @@ typedef struct mbedtls_sha1_context {
 }
 mbedtls_sha1_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes a SHA-1 context.
  *
@@ -185,6 +187,8 @@ int mbedtls_sha1(const unsigned char *input,
 int mbedtls_sha1_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha256.h
+++ b/drivers/builtin/include/mbedtls/sha256.h
@@ -44,6 +44,8 @@ typedef struct mbedtls_sha256_context {
 }
 mbedtls_sha256_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes a SHA-256 context.
  *
@@ -169,6 +171,8 @@ int mbedtls_sha256_self_test(int verbose);
 #endif /* MBEDTLS_SHA256_C */
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha3.h
+++ b/drivers/builtin/include/mbedtls/sha3.h
@@ -55,6 +55,8 @@ typedef struct {
 }
 mbedtls_sha3_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes a SHA-3 context.
  *
@@ -164,6 +166,8 @@ int mbedtls_sha3(mbedtls_sha3_id id, const uint8_t *input,
  */
 int mbedtls_sha3_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha512.h
+++ b/drivers/builtin/include/mbedtls/sha512.h
@@ -43,6 +43,8 @@ typedef struct mbedtls_sha512_context {
 }
 mbedtls_sha512_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief          This function initializes a SHA-512 context.
  *
@@ -177,6 +179,8 @@ int mbedtls_sha512_self_test(int verbose);
 #endif /* MBEDTLS_SHA512_C */
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds the guard `#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)` around all functions in the files below so that they cannot be accessed by user programs (as they are now private).
~~Also adds this guard to a couple of structs/types that are explicitly marked as internal (in ecp.h, ecdsa.h & block_cipher.h).~~

List of files (for ease of reference, matches the files specified in the linked issues):
- aes.h
- aria.h
- bignum.h
- camellia.h
- cipher.h
- ccm.h
- chacha20.h
- chachapoly.h
- cipher.h
- cmac.h
- des.h
- ecdh.h
- ecdsa.h
- ecjpake.h
- ecp.h
- gcm.h
- md5.h
- poly1305.h
- ripemd160.h
- sha1.h
- sha256.h
- sha3.h
- sha512.h

resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/220, resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/224, resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/225, resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/226, resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/227


## PR checklist

- [ ] **changelog** not required because: Changelog and other documentation to be added with this issue: https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/232
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: tf-psa-crypto-only change
- [ ] **mbedtls 3.6 PR** not required because: new API for 4.0
- **tests**  not required because: no internal change to PSA crypto/mbedtls (I guess could have a test that uses the private functions and is expected to fail to compile, but I'm not sure how possible that is with the framework & it would require a 'wrong' example program so may be confusing?)