### PR TITLE
Add issue templates (same as Mbed TLS)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: To report a bug, please fill this form.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**WARNING:** if the bug you are reporting has or may have security implications,
+we ask that you report it privately to
+<mbed-tls-security@lists.trustedfirmware.org>
+so that we can prepare and release a fix before publishing the details.
+See [SECURITY.md](https://github.com/Mbed-TLS/mbedtls/blob/development/SECURITY.md).
+
+### Summary
+
+
+
+### System information
+
+Mbed TLS version (number or commit id): 
+Operating system and version: 
+Configuration (if not default, please attach `mbedtls_config.h`): 
+Compiler and options (if you used a pre-built binary, please indicate how you obtained it): 
+Additional environment information: 
+
+### Expected behavior
+
+
+
+### Actual behavior
+
+**WARNING:* if the actual behaviour suggests memory corruption (like a crash or an error
+from a memory checker), then the bug should be assumed to have security
+implications (until proven otherwise), and we ask what you report it privately,
+see the note at the top of this template.
+
+
+### Steps to reproduce
+
+
+
+### Additional information
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,9 +19,9 @@ See [SECURITY.md](https://github.com/Mbed-TLS/mbedtls/blob/development/SECURITY.
 
 ### System information
 
-Mbed TLS version (number or commit id): 
+TF-PSA-Crypto version (number or commit id): 
 Operating system and version: 
-Configuration (if not default, please attach `mbedtls_config.h`): 
+Configuration (if not default, please attach `crypto_config.h`): 
 Compiler and options (if you used a pre-built binary, please indicate how you obtained it): 
 Additional environment information: 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 we ask that you report it privately to
 <mbed-tls-security@lists.trustedfirmware.org>
 so that we can prepare and release a fix before publishing the details.
-See [SECURITY.md](https://github.com/Mbed-TLS/mbedtls/blob/development/SECURITY.md).
+See [SECURITY.md](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/SECURITY.md).
 
 ### Summary
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Mbed TLS security team
+      url: mailto:mbed-tls-security@lists.trustedfirmware.org
+      about: Report a security vulnerability.
+    - name: Mbed TLS mailing list
+      url: https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org
+      about: Mbed TLS community support and general discussion.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-    - name: Mbed TLS security team
+    - name: Mbed TLS & TF-PSA-Crypto security team
       url: mailto:mbed-tls-security@lists.trustedfirmware.org
       about: Report a security vulnerability.
-    - name: Mbed TLS mailing list
-      url: https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org
-      about: Mbed TLS community support and general discussion.
+    - name: PSA Crypto mailing list
+      url: https://lists.trustedfirmware.org/mailman3/lists/psa-crypto.lists.trustedfirmware.org/
+      about: PSA Crypto community support and general discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement request
+about: To request an enhancement, please fill this form.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Suggested enhancement
+
+
+
+### Justification
+
+Mbed TLS needs this because 
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,5 +13,5 @@ assignees: ''
 
 ### Justification
 
-Mbed TLS needs this because 
+TF-PSA-Crypto needs this because 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,6 @@ If the provided content is part of the present PR remove the # symbol.
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
 - [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
 - [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **mbedtls 2.28 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 
 
 


### PR DESCRIPTION
## Description

This was meant to be a side port of https://github.com/Mbed-TLS/mbedtls/pull/10118 but I noticed we didn't have any issue templates yet, so this PR creates them.

Also, while creating this PR I noticed the PR template still had Mbed TLS 2.28 so I removed it while at it.

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10118 
- [x] **mbedtls 3.6 PR** not required because: templates taken from default branch
- [x] **mbedtls 2.28 PR** not required because: EOL
- **tests** not required because: doc only