### PR TITLE
Privatize part of psa_util.h

### DIFF
--- a/ChangeLog.d/privatize-part-of-psa_util.txt
+++ b/ChangeLog.d/privatize-part-of-psa_util.txt
@@ -1,0 +1,2 @@
+API changes
+   * Privatize the functions mbedtls_ecc_group_to_psa and mbedtls_ecc_group_from_psa.

--- a/ChangeLog.d/privatize-part-of-psa_util.txt
+++ b/ChangeLog.d/privatize-part-of-psa_util.txt
@@ -1,2 +1,3 @@
 API changes
-   * Privatize the functions mbedtls_ecc_group_to_psa and mbedtls_ecc_group_from_psa.
+   * Privatize the functions mbedtls_ecc_group_to_psa and 
+     mbedtls_ecc_group_from_psa.

--- a/ChangeLog.d/privatize-part-of-psa_util.txt
+++ b/ChangeLog.d/privatize-part-of-psa_util.txt
@@ -1,3 +1,3 @@
 API changes
-   * Privatize the functions mbedtls_ecc_group_to_psa and 
+   * Privatize the functions mbedtls_ecc_group_to_psa and
      mbedtls_ecc_group_from_psa.

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -64,7 +64,7 @@
 #include "mbedtls/sha1.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/sha512.h"
-#include "mbedtls/psa_util.h"
+#include "pk_internal.h"
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -64,7 +64,7 @@
 #include "mbedtls/sha1.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/sha512.h"
-#include "pk_internal.h"
+#include "psa_util_internal.h"
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \

--- a/drivers/builtin/include/mbedtls/psa_util.h
+++ b/drivers/builtin/include/mbedtls/psa_util.h
@@ -69,40 +69,6 @@ int mbedtls_psa_get_random(void *p_rng,
 /** \defgroup psa_tls_helpers TLS helper functions
  * @{
  */
-#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
-#include <mbedtls/ecp.h>
-
-/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
- *
- * \param grpid         An Mbed TLS elliptic curve identifier
- *                      (`MBEDTLS_ECP_DP_xxx`).
- * \param[out] bits     On success the bit size of the curve; 0 on failure.
- *
- * \return              If the curve is supported in the PSA API, this function
- *                      returns the proper PSA curve identifier
- *                      (`PSA_ECC_FAMILY_xxx`). This holds even if the curve is
- *                      not supported by the ECP module.
- * \return              \c 0 if the curve is not supported in the PSA API.
- */
-psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid,
-                                          size_t *bits);
-
-/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
- *
- * \param family        A PSA elliptic curve family identifier
- *                      (`PSA_ECC_FAMILY_xxx`).
- * \param bits          The bit-length of a private key on \p curve.
- *
- * \return              If the curve is supported in the PSA API, this function
- *                      returns the corresponding Mbed TLS elliptic curve
- *                      identifier (`MBEDTLS_ECP_DP_xxx`).
- * \return              #MBEDTLS_ECP_DP_NONE if the combination of \c curve
- *                      and \p bits is not supported.
- */
-mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
-                                                size_t bits);
-#endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
-
 /**
  * \brief           This function returns the PSA algorithm identifier
  *                  associated with the given digest type.

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -83,6 +83,37 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY && !MBEDTLS_PK_USE_PSA_EC_DATA */
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#include <mbedtls/ecp.h>
+
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success the bit size of the curve; 0 on failure.
+ *
+ * \return              If the curve is supported in the PSA API, this function
+ *                      returns the proper PSA curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`). This holds even if the curve is
+ *                      not supported by the ECP module.
+ * \return              \c 0 if the curve is not supported in the PSA API.
+ */
+psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid,
+                                          size_t *bits);
+
+/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
+ *
+ * \param family        A PSA elliptic curve family identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \param bits          The bit-length of a private key on \p curve.
+ *
+ * \return              If the curve is supported in the PSA API, this function
+ *                      returns the corresponding Mbed TLS elliptic curve
+ *                      identifier (`MBEDTLS_ECP_DP_xxx`).
+ * \return              #MBEDTLS_ECP_DP_NONE if the combination of \c curve
+ *                      and \p bits is not supported.
+ */
+mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
+                                                size_t bits);
 static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_context *pk)
 {
     mbedtls_ecp_group_id id;

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -83,7 +83,6 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY && !MBEDTLS_PK_USE_PSA_EC_DATA */
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
-#include <mbedtls/ecp.h>
 
 static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_context *pk)
 {

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -85,35 +85,6 @@ static inline mbedtls_ecp_keypair *mbedtls_pk_ec_rw(const mbedtls_pk_context pk)
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include <mbedtls/ecp.h>
 
-/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
- *
- * \param grpid         An Mbed TLS elliptic curve identifier
- *                      (`MBEDTLS_ECP_DP_xxx`).
- * \param[out] bits     On success the bit size of the curve; 0 on failure.
- *
- * \return              If the curve is supported in the PSA API, this function
- *                      returns the proper PSA curve identifier
- *                      (`PSA_ECC_FAMILY_xxx`). This holds even if the curve is
- *                      not supported by the ECP module.
- * \return              \c 0 if the curve is not supported in the PSA API.
- */
-psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid,
-                                          size_t *bits);
-
-/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
- *
- * \param family        A PSA elliptic curve family identifier
- *                      (`PSA_ECC_FAMILY_xxx`).
- * \param bits          The bit-length of a private key on \p curve.
- *
- * \return              If the curve is supported in the PSA API, this function
- *                      returns the corresponding Mbed TLS elliptic curve
- *                      identifier (`MBEDTLS_ECP_DP_xxx`).
- * \return              #MBEDTLS_ECP_DP_NONE if the combination of \c curve
- *                      and \p bits is not supported.
- */
-mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
-                                                size_t bits);
 static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_context *pk)
 {
     mbedtls_ecp_group_id id;

--- a/drivers/builtin/src/psa_crypto_ecp.c
+++ b/drivers/builtin/src/psa_crypto_ecp.c
@@ -14,7 +14,7 @@
 #include "psa_crypto_core.h"
 #include "psa_crypto_ecp.h"
 #include "psa_crypto_random_impl.h"
-#include "mbedtls/psa_util.h"
+#include "pk_internal.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/drivers/builtin/src/psa_crypto_ecp.c
+++ b/drivers/builtin/src/psa_crypto_ecp.c
@@ -14,7 +14,7 @@
 #include "psa_crypto_core.h"
 #include "psa_crypto_ecp.h"
 #include "psa_crypto_random_impl.h"
-#include "pk_internal.h"
+#include "psa_util_internal.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/drivers/builtin/src/psa_util.c
+++ b/drivers/builtin/src/psa_util.c
@@ -17,7 +17,6 @@
 #endif
 
 #include "psa_util_internal.h"
-#include "pk_internal.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 

--- a/drivers/builtin/src/psa_util.c
+++ b/drivers/builtin/src/psa_util.c
@@ -17,6 +17,7 @@
 #endif
 
 #include "psa_util_internal.h"
+#include "pk_internal.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 

--- a/drivers/builtin/src/psa_util_internal.h
+++ b/drivers/builtin/src/psa_util_internal.h
@@ -16,6 +16,12 @@
 
 #include "psa/crypto.h"
 
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+
+#include "mbedtls/ecp.h"
+
+#endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
+
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 /*************************************************************************

--- a/drivers/builtin/src/psa_util_internal.h
+++ b/drivers/builtin/src/psa_util_internal.h
@@ -93,4 +93,35 @@ int psa_pk_status_to_mbedtls(psa_status_t status);
                           fallback_f)
 
 #endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success the bit size of the curve; 0 on failure.
+ *
+ * \return              If the curve is supported in the PSA API, this function
+ *                      returns the proper PSA curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`). This holds even if the curve is
+ *                      not supported by the ECP module.
+ * \return              \c 0 if the curve is not supported in the PSA API.
+ */
+psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid,
+                                          size_t *bits);
+
+/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
+ *
+ * \param family        A PSA elliptic curve family identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \param bits          The bit-length of a private key on \p curve.
+ *
+ * \return              If the curve is supported in the PSA API, this function
+ *                      returns the corresponding Mbed TLS elliptic curve
+ *                      identifier (`MBEDTLS_ECP_DP_xxx`).
+ * \return              #MBEDTLS_ECP_DP_NONE if the combination of \c curve
+ *                      and \p bits is not supported.
+ */
+mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family,
+                                                size_t bits);
+#endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 #endif /* MBEDTLS_PSA_UTIL_INTERNAL_H */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -6,7 +6,7 @@
 #include "mbedtls/oid.h"
 #include "common.h"
 
-#include "pk_internal.h"
+#include "psa_util_internal.h"
 
 /* For MBEDTLS_CTR_DRBG_MAX_REQUEST, knowing that psa_generate_random()
  * uses mbedtls_ctr_drbg internally. */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -6,7 +6,7 @@
 #include "mbedtls/oid.h"
 #include "common.h"
 
-#include "mbedtls/psa_util.h"
+#include "pk_internal.h"
 
 /* For MBEDTLS_CTR_DRBG_MAX_REQUEST, knowing that psa_generate_random()
  * uses mbedtls_ctr_drbg internally. */


### PR DESCRIPTION
## Description

Privatize part of psa_util.h resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/231

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: No changes
- [ ] **mbedtls 3.6 PR** not required because: No backports
- [ ] **mbedtls 2.28 PR** not required because: No backports
- **tests**  not required because: No changes
