### PR TITLE
Don't call mbedtls_test_hook_error_add()

### DIFF
--- a/drivers/builtin/include/mbedtls/error_common.h
+++ b/drivers/builtin/include/mbedtls/error_common.h
@@ -62,8 +62,6 @@ extern "C" {
  * \param low       Low-level error code, i.e. error code returned by
  *                  a lower-level function.
  *                  This can be 0 to just return a high-level error.
- * \param file      file where this error code combination occurred.
- * \param line      line where this error code combination occurred.
  */
 static inline int mbedtls_error_add(int high, int low)
 {

--- a/drivers/builtin/include/mbedtls/error_common.h
+++ b/drivers/builtin/include/mbedtls/error_common.h
@@ -35,7 +35,7 @@ extern "C" {
  *        more details.
  */
 #define MBEDTLS_ERROR_ADD(high, low) \
-    mbedtls_error_add(high, low, __FILE__, __LINE__)
+    mbedtls_error_add(high, low)
 
 #if defined(MBEDTLS_TEST_HOOKS)
 /**
@@ -64,9 +64,6 @@ extern void (*mbedtls_test_hook_error_add)(int, int, const char *, int);
  *        is a good reason to report a different error code in the
  *        higher-level module.
  *
- * \note  When invasive testing is enabled via #MBEDTLS_TEST_HOOKS, also try to
- *        call \link mbedtls_test_hook_error_add \endlink.
- *
  * \param high      High-level error code, i.e. error code from the module
  *                  that is reporting the error.
  *                  This can be 0 to just propagate a low-level error.
@@ -76,17 +73,8 @@ extern void (*mbedtls_test_hook_error_add)(int, int, const char *, int);
  * \param file      file where this error code combination occurred.
  * \param line      line where this error code combination occurred.
  */
-static inline int mbedtls_error_add(int high, int low,
-                                    const char *file, int line)
+static inline int mbedtls_error_add(int high, int low)
 {
-#if defined(MBEDTLS_TEST_HOOKS)
-    if (*mbedtls_test_hook_error_add != NULL) {
-        (*mbedtls_test_hook_error_add)(high, low, file, line);
-    }
-#endif
-    (void) file;
-    (void) line;
-
     /* We give priority to the lower-level error code, because this
      * is usually the right choice. For example, if a low-level module
      * runs out of memory, this should not be converted to a high-level

--- a/drivers/builtin/include/mbedtls/error_common.h
+++ b/drivers/builtin/include/mbedtls/error_common.h
@@ -37,14 +37,6 @@ extern "C" {
 #define MBEDTLS_ERROR_ADD(high, low) \
     mbedtls_error_add(high, low)
 
-#if defined(MBEDTLS_TEST_HOOKS)
-/**
- * \brief Testing hook called before adding/combining two error codes together.
- *        Only used when invasive testing is enabled via MBEDTLS_TEST_HOOKS.
- */
-extern void (*mbedtls_test_hook_error_add)(int, int, const char *, int);
-#endif
-
 /**
  * \brief Combines a high-level and low-level error code together.
  *

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -232,7 +232,6 @@ int main(int argc, const char *argv[])
 #if defined(MBEDTLS_TEST_HOOKS)
     extern void (*mbedtls_test_hook_test_fail)(const char *test, int line, const char *file);
     mbedtls_test_hook_test_fail = &mbedtls_test_fail;
-    mbedtls_test_hook_error_add = &mbedtls_test_err_add_check;
 #endif
 
     /* Try changing to the directory containing the executable, if


### PR DESCRIPTION
Fix an omission in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/167 which is likely to cause test failures when we change more functions to return PSA error codes.

## PR checklist

- [x] **changelog** provided | not required because: test stuff
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: will be automatically consumed by mbedtls, needs no further work there
- [x] **mbedtls 3.6 PR** not required because: new stuff
- **tests**  provided
