### PR TITLE
Move the inclusion of crypto_sizes.h and crypto_struct.h in crypto.h

### DIFF
--- a/ChangeLog.d/move-crypto-struct-inclusion.txt
+++ b/ChangeLog.d/move-crypto-struct-inclusion.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Resolved build issue with C++ projects using TF-PSA-Crypto when compiling
+     with the MSVC toolset v142 and earlier. Fixes mbedtls issue #7087.

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -59,6 +59,18 @@ extern "C" {
  * of integral types defined in "crypto_types.h". */
 #include "crypto_values.h"
 
+/* The file "crypto_sizes.h" contains definitions for size calculation
+ * macros whose definitions are implementation-specific. */
+#include "crypto_sizes.h"
+
+/* The file "crypto_struct.h" contains definitions for
+ * implementation-specific structs that are declared above. */
+#if defined(MBEDTLS_PSA_CRYPTO_STRUCT_FILE)
+#include MBEDTLS_PSA_CRYPTO_STRUCT_FILE
+#else
+#include "crypto_struct.h"
+#endif
+
 /** \defgroup initialization Library initialization
  * @{
  */
@@ -5801,18 +5813,6 @@ psa_status_t psa_export_public_key_iop_abort(psa_export_public_key_iop_t *operat
 
 #ifdef __cplusplus
 }
-#endif
-
-/* The file "crypto_sizes.h" contains definitions for size calculation
- * macros whose definitions are implementation-specific. */
-#include "crypto_sizes.h"
-
-/* The file "crypto_struct.h" contains definitions for
- * implementation-specific structs that are declared above. */
-#if defined(MBEDTLS_PSA_CRYPTO_STRUCT_FILE)
-#include MBEDTLS_PSA_CRYPTO_STRUCT_FILE
-#else
-#include "crypto_struct.h"
 #endif
 
 /* The file "crypto_extra.h" contains vendor-specific definitions. This


### PR DESCRIPTION
## Description
Move the inclusion of crypto_sizes.h and crypto_struct.h in crypto.h
That way when API are declared, the types they used are defined.
This should resolve the issues related to psa_xyz_init functions returning a structure described in Mbed-TLS/mbedtls#7087.

## PR checklist
- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto-only change not affecting mbedtls
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10196
- **tests**  not required because: the change is validated by the current tests. We can't afford the effort required for non-regression testing right now. Covered by  https://github.com/Mbed-TLS/mbedtls/issues/1767.