### PR TITLE
Constify cipher_wrap:mbedtls_cipher_base_lookup_table

### DIFF
--- a/drivers/builtin/src/cipher_wrap.c
+++ b/drivers/builtin/src/cipher_wrap.c
@@ -2425,7 +2425,7 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
                      sizeof(mbedtls_cipher_definitions[0]))
 int mbedtls_cipher_supported[NUM_CIPHERS];
 
-const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[] = {
+const mbedtls_cipher_base_t * const mbedtls_cipher_base_lookup_table[] = {
 #if defined(MBEDTLS_AES_C)
     [MBEDTLS_CIPHER_BASE_INDEX_AES] = &aes_info,
 #endif

--- a/drivers/builtin/src/cipher_wrap.h
+++ b/drivers/builtin/src/cipher_wrap.h
@@ -169,7 +169,7 @@ extern const mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
 
 extern int mbedtls_cipher_supported[];
 
-extern const mbedtls_cipher_base_t *mbedtls_cipher_base_lookup_table[];
+extern const mbedtls_cipher_base_t * const mbedtls_cipher_base_lookup_table[];
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

Constify cipher_wrap:mbedtls_cipher_base_lookup_table

This structure is initialized during the compilation and there is no reason it changes.
Making it const allows the compiler to put it in .rodata section instead of .data one.


## PR checklist

- [x] **changelog** not required because: This doesn't fix anything relevant
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because:  This is independent, but should be included at some point.
- [x] **mbedtls 3.6 PR** : https://github.com/Mbed-TLS/mbedtls/pull/10138
- [x] **tests**  not required because: Already included in cipher tests build.
