### PR TITLE
Privatize functions and some types in hash headers

### DIFF
--- a/drivers/builtin/include/mbedtls/md5.h
+++ b/drivers/builtin/include/mbedtls/md5.h
@@ -39,6 +39,7 @@ typedef struct mbedtls_md5_context {
 }
 mbedtls_md5_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          Initialize MD5 context
  *
@@ -158,6 +159,8 @@ int mbedtls_md5(const unsigned char *input,
 int mbedtls_md5_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ripemd160.h
+++ b/drivers/builtin/include/mbedtls/ripemd160.h
@@ -30,6 +30,7 @@ typedef struct mbedtls_ripemd160_context {
 }
 mbedtls_ripemd160_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          Initialize RIPEMD-160 context
  *
@@ -109,6 +110,8 @@ int mbedtls_ripemd160(const unsigned char *input,
 int mbedtls_ripemd160_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha1.h
+++ b/drivers/builtin/include/mbedtls/sha1.h
@@ -45,6 +45,7 @@ typedef struct mbedtls_sha1_context {
 }
 mbedtls_sha1_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          This function initializes a SHA-1 context.
  *
@@ -185,6 +186,8 @@ int mbedtls_sha1(const unsigned char *input,
 int mbedtls_sha1_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha256.h
+++ b/drivers/builtin/include/mbedtls/sha256.h
@@ -44,6 +44,7 @@ typedef struct mbedtls_sha256_context {
 }
 mbedtls_sha256_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          This function initializes a SHA-256 context.
  *
@@ -169,6 +170,8 @@ int mbedtls_sha256_self_test(int verbose);
 #endif /* MBEDTLS_SHA256_C */
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha3.h
+++ b/drivers/builtin/include/mbedtls/sha3.h
@@ -28,6 +28,7 @@ extern "C" {
 /** SHA-3 input data was malformed. */
 #define MBEDTLS_ERR_SHA3_BAD_INPUT_DATA                 -0x0076
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * SHA-3 family id.
  *
@@ -41,6 +42,7 @@ typedef enum {
     MBEDTLS_SHA3_384, /*!< SHA3-384 */
     MBEDTLS_SHA3_512, /*!< SHA3-512 */
 } mbedtls_sha3_id;
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /**
  * \brief          The SHA-3 context structure.
@@ -55,6 +57,7 @@ typedef struct {
 }
 mbedtls_sha3_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          This function initializes a SHA-3 context.
  *
@@ -164,6 +167,8 @@ int mbedtls_sha3(mbedtls_sha3_id id, const uint8_t *input,
  */
 int mbedtls_sha3_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/sha512.h
+++ b/drivers/builtin/include/mbedtls/sha512.h
@@ -43,6 +43,7 @@ typedef struct mbedtls_sha512_context {
 }
 mbedtls_sha512_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief          This function initializes a SHA-512 context.
  *
@@ -177,6 +178,8 @@ int mbedtls_sha512_self_test(int verbose);
 #endif /* MBEDTLS_SHA512_C */
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Privatizes all functions in the following files by guarding them with `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS`

`md5.h`
`ripemd160.h`
`sha1.h`
`sha256.h`
`sha3.h`
`sha512.h`

Also privatizes the type `mbedtls_sha3_id` in `sha3.h` - All of the context types in these files are found in `mbedtls_psa_hash_operation_t` in the file `tf-psa-crypto/include/psa/crypto_builtin_primitives.h` and so are kept unprivatized/internal.
Otherwise there are no other types/macros in these files.

Resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/224


## PR checklist

- [ ] **changelog** not required because: will come later encompassing all privatization using `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS`
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: crypto change only
- [ ] **mbedtls 3.6 PR** not required because: 4.0/1.0 only change
- **tests**  not required because: no functional change