### PR TITLE
Privatize functions and some types/macros in cipher mode headers

### DIFF
--- a/drivers/builtin/include/mbedtls/block_cipher.h
+++ b/drivers/builtin/include/mbedtls/block_cipher.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 typedef enum {
     MBEDTLS_BLOCK_CIPHER_ID_NONE = 0,  /**< Unset. */
     MBEDTLS_BLOCK_CIPHER_ID_AES,       /**< The AES cipher. */
@@ -68,6 +69,8 @@ typedef struct {
 #endif
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_block_cipher_context_t;
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/ccm.h
+++ b/drivers/builtin/include/mbedtls/ccm.h
@@ -44,10 +44,12 @@
 #include "mbedtls/block_cipher.h"
 #endif
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 #define MBEDTLS_CCM_DECRYPT       0
 #define MBEDTLS_CCM_ENCRYPT       1
 #define MBEDTLS_CCM_STAR_DECRYPT  2
 #define MBEDTLS_CCM_STAR_ENCRYPT  3
+#endif
 
 /** Bad input parameters to the function. */
 #define MBEDTLS_ERR_CCM_BAD_INPUT       -0x000D
@@ -90,6 +92,7 @@ typedef struct mbedtls_ccm_context {
 }
 mbedtls_ccm_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief           This function initializes the specified CCM context,
  *                  to make references valid, and prepare the context
@@ -312,9 +315,9 @@ int mbedtls_ccm_star_auth_decrypt(mbedtls_ccm_context *ctx, size_t length,
  * \note            This function is not implemented in Mbed TLS yet.
  *
  * \param ctx       The CCM context. This must be initialized.
- * \param mode      The operation to perform: #MBEDTLS_CCM_ENCRYPT or
- *                  #MBEDTLS_CCM_DECRYPT or #MBEDTLS_CCM_STAR_ENCRYPT or
- *                  #MBEDTLS_CCM_STAR_DECRYPT.
+ * \param mode      The operation to perform: MBEDTLS_CCM_ENCRYPT or
+ *                  MBEDTLS_CCM_DECRYPT or MBEDTLS_CCM_STAR_ENCRYPT or
+ *                  MBEDTLS_CCM_STAR_DECRYPT.
  * \param iv        The initialization vector. This must be a readable buffer
  *                  of at least \p iv_len Bytes.
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
@@ -510,6 +513,8 @@ int mbedtls_ccm_finish(mbedtls_ccm_context *ctx,
  */
 int mbedtls_ccm_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/cmac.h
+++ b/drivers/builtin/include/mbedtls/cmac.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 #define MBEDTLS_AES_BLOCK_SIZE          16
 #define MBEDTLS_DES3_BLOCK_SIZE         8
 
@@ -32,14 +33,15 @@ extern "C" {
 #define MBEDTLS_CMAC_MAX_BLOCK_SIZE      16  /**< The longest block used by CMAC is that of AES. */
 #else
 #define MBEDTLS_CMAC_MAX_BLOCK_SIZE      8   /**< The longest block used by CMAC is that of 3DES. */
-#endif
+#endif /* MBEDTLS_AES_C */
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 /** The longest block supported by the cipher module.
  *
  * \deprecated
  * For the maximum block size of a cipher supported by the CMAC module,
- * use #MBEDTLS_CMAC_MAX_BLOCK_SIZE.
+ * use MBEDTLS_CMAC_MAX_BLOCK_SIZE.
  * For the maximum block size of a cipher supported by the cipher module,
  * use #MBEDTLS_MAX_BLOCK_LENGTH.
  */
@@ -51,6 +53,7 @@ extern "C" {
 #define MBEDTLS_CIPHER_BLKSIZE_MAX MBEDTLS_MAX_BLOCK_LENGTH
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * The CMAC context structure.
  */
@@ -214,6 +217,8 @@ int mbedtls_aes_cmac_prf_128(const unsigned char *key, size_t key_len,
  */
 int mbedtls_cmac_self_test(int verbose);
 #endif /* MBEDTLS_SELF_TEST && ( MBEDTLS_AES_C || MBEDTLS_DES_C ) */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/builtin/include/mbedtls/gcm.h
+++ b/drivers/builtin/include/mbedtls/gcm.h
@@ -30,8 +30,10 @@
 
 #include <stdint.h>
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 #define MBEDTLS_GCM_ENCRYPT     1
 #define MBEDTLS_GCM_DECRYPT     0
+#endif
 
 /** Authenticated decryption failed. */
 #define MBEDTLS_ERR_GCM_AUTH_FAILED                       -0x0012
@@ -72,6 +74,7 @@ typedef struct mbedtls_gcm_context {
 }
 mbedtls_gcm_context;
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 /**
  * \brief           This function initializes the specified GCM context,
  *                  to make references valid, and prepares the context
@@ -121,10 +124,10 @@ int mbedtls_gcm_setkey(mbedtls_gcm_context *ctx,
  * \param ctx       The GCM context to use for encryption or decryption. This
  *                  must be initialized.
  * \param mode      The operation to perform:
- *                  - #MBEDTLS_GCM_ENCRYPT to perform authenticated encryption.
+ *                  - MBEDTLS_GCM_ENCRYPT to perform authenticated encryption.
  *                    The ciphertext is written to \p output and the
  *                    authentication tag is written to \p tag.
- *                  - #MBEDTLS_GCM_DECRYPT to perform decryption.
+ *                  - MBEDTLS_GCM_DECRYPT to perform decryption.
  *                    The plaintext is written to \p output and the
  *                    authentication tag is written to \p tag.
  *                    Note that this mode is not recommended, because it does
@@ -150,7 +153,7 @@ int mbedtls_gcm_setkey(mbedtls_gcm_context *ctx,
  *                  buffer of at least \p tag_len Bytes.
  *
  * \return          \c 0 if the encryption or decryption was performed
- *                  successfully. Note that in #MBEDTLS_GCM_DECRYPT mode,
+ *                  successfully. Note that in MBEDTLS_GCM_DECRYPT mode,
  *                  this does not indicate that the data is authentic.
  * \return          #MBEDTLS_ERR_GCM_BAD_INPUT if the lengths or pointers are
  *                  not valid or a cipher-specific error code if the encryption
@@ -217,8 +220,8 @@ int mbedtls_gcm_auth_decrypt(mbedtls_gcm_context *ctx,
  *                  operation.
  *
  * \param ctx       The GCM context. This must be initialized.
- * \param mode      The operation to perform: #MBEDTLS_GCM_ENCRYPT or
- *                  #MBEDTLS_GCM_DECRYPT.
+ * \param mode      The operation to perform: MBEDTLS_GCM_ENCRYPT or
+ *                  MBEDTLS_GCM_DECRYPT.
  * \param iv        The initialization vector. This must be a readable buffer of
  *                  at least \p iv_len Bytes.
  * \param iv_len    The length of the IV.
@@ -368,6 +371,8 @@ void mbedtls_gcm_free(mbedtls_gcm_context *ctx);
 int mbedtls_gcm_self_test(int verbose);
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Privatizes all functions in the following files by guarding them with `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS`

`block_cipher.h`
`ccm.h`
`cmac.h`
`gcm.h`

Also privatizes the following macros, including unlinking them from the Doxygen to avoid CI errors where applicable:
`MBEDTLS_CCM_<EN/DE>CRYPT`
`MBEDTLS_CCM_STAR_<EN/DE>CRYPT`
`MBEDTLS_AES_BLOCK_SIZE`
`MBEDTLS_DES3_BLOCK_SIZE`
`MBEDTLS_CMAC_MAX_BLOCK_SIZE`
`MBEDTLS_GCM_<EN/DE>CRYPT`

Privatizes the types:
`mbedtls_block_cipher_id_t`
`mbedtls_block_cipher_engine_t`
`mbedtls_block_cipher_context_t`
`mbedts_cmac_context_t`

Does _not_ privatize the types/macros:
`mbedtls_ccm_context`
`MBEDTLS_CIPHER_BLKSIZE_MAX` (deprecated anyway)
`MBEDTLS_GCM_HTABLE_SIZE`
`mbedtls_gcm_context`

Resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/226


## PR checklist

- [ ] **changelog** not required because: will come later encompassing all privatization using `MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS`
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: crypto change only
- [ ] **mbedtls 3.6 PR** not required because: 4.0/1.0 change only
- **tests**  not required because: no functional change