### PR TITLE
Fix bug that caused build to break with -DUSE_SHARED_TF_PSA_CRYPTO_LIBRARY=ON

### DIFF
--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(benchmark PRIVATE ${tfpsacrypto_target} ${CMAKE_THREAD_LIB
 
 # which_aes
 tfpsacrypto_build_program_common(which_aes)
+target_sources(which_aes PRIVATE $<TARGET_OBJECTS:tf_psa_crypto_test>)
 target_link_libraries(which_aes PRIVATE ${tfpsacrypto_target})
 
 # dlopen


### PR DESCRIPTION
This bug caused errors like:
```
/usr/bin/ld: ../../drivers/builtin/libbuiltin.so: undefined reference to `psa_asymmetric_encrypt'
/usr/bin/ld: ../../drivers/builtin/libbuiltin.so: undefined reference to `psa_crypto_driver_pake_get_user'
collect2: error: ld returned 1 exit status
make[2]: *** [programs/test/CMakeFiles/which_aes.dir/build.make:101: programs/test/which_aes] Error 1
make[1]: *** [CMakeFiles/Makefile2:1127: programs/test/CMakeFiles/which_aes.dir/all] Error 2
```
When building with `-DUSE_SHARED_TF_PSA_CRYPTO_LIBRARY=ON`, e.g. the test `component_test_tf_psa_crypto_shared` in `component-build-system.sh` should have picked it up, I found it locally on Ubuntu 22.

It wasn't caught by the CI, presumably because the CI was running it on Ubuntu 16 and the older version of `ld` didn't notice it...

Originally introduced in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/199

## PR checklist

- [ ] **changelog** not required because: Bug fix in 4.0/1.0 work, not present in releases
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: tf-psa-crypto change only
- [ ] **mbedtls 3.6 PR** not required because: tf-psa-crypto change only
- **tests**  not required because: Can't easily run same test on newer Ubuntu (?)