### PR TITLE
Remove mbedtls_pk_rsassa_pss_options

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -79,29 +79,6 @@ typedef enum {
 } mbedtls_pk_type_t;
 
 /**
- * \brief           Options for RSASSA-PSS signature verification.
- *                  See \c mbedtls_rsa_rsassa_pss_verify_ext()
- */
-typedef struct mbedtls_pk_rsassa_pss_options {
-    /** The digest to use for MGF1 in PSS.
-     *
-     * \note When #MBEDTLS_RSA_C is disabled, this must be equal to the \c md_alg argument passed
-     *       to mbedtls_pk_verify_ext(). In a future version of the library, this constraint may
-     *       apply regardless of the status of #MBEDTLS_RSA_C.
-     */
-    mbedtls_md_type_t mgf1_hash_id;
-
-    /** The expected length of the salt, in bytes. This may be
-     * #MBEDTLS_RSA_SALT_LEN_ANY to accept any salt length.
-     *
-     * \note Only #MBEDTLS_RSA_SALT_LEN_ANY is valid. Any other value may be ignored (allowing any
-     *       salt length).
-     */
-    int expected_salt_len;
-
-} mbedtls_pk_rsassa_pss_options;
-
-/**
  * \brief           Maximum size of a signature made by mbedtls_pk_sign().
  */
 /* We need to set MBEDTLS_PK_SIGNATURE_MAX_SIZE to the maximum signature


### PR DESCRIPTION
## Description

Resolves #274 

~Depends on https://github.com/Mbed-TLS/mbedtls/pull/10130~ (merged).

## PR checklist

- [x] **changelog** not required because: will be covered by other entries
- [x] **development PR** not required because: crypto only
- [x] **TF-PSA-Crypto PR** provided HERE
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: API break
- **tests**  not required because: removal
