### PR TITLE
[tf-psa-crypto] Remove MBEDTLS_USE_PSA_CRYPTO from PK module

### DIFF
--- a/drivers/builtin/src/pk_ecc.c
+++ b/drivers/builtin/src/pk_ecc.c
@@ -94,7 +94,7 @@ int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
                                    &pk->pub_raw_len);
     return psa_pk_status_to_mbedtls(status);
 
-#elif defined(MBEDTLS_USE_PSA_CRYPTO) /* && !MBEDTLS_PK_USE_PSA_EC_DATA */
+#else /* MBEDTLS_PK_USE_PSA_EC_DATA */
 
     psa_status_t status;
 
@@ -126,15 +126,7 @@ int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
     /* Load serialized public key into ecp_keypair structure */
     return mbedtls_ecp_point_read_binary(&eck->grp, &eck->Q, pub, pub_len);
 
-#else /* MBEDTLS_USE_PSA_CRYPTO */
-
-    (void) prv;
-    (void) prv_len;
-
-    mbedtls_ecp_keypair *eck = (mbedtls_ecp_keypair *) pk->pk_ctx;
-    return mbedtls_ecp_mul(&eck->grp, &eck->Q, &eck->d, &eck->grp.G);
-
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PK_USE_PSA_EC_DATA */
 }
 
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -88,7 +88,6 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_c
 {
     mbedtls_ecp_group_id id;
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         psa_key_attributes_t opaque_attrs = PSA_KEY_ATTRIBUTES_INIT;
         psa_key_type_t opaque_key_type;
@@ -101,9 +100,7 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_c
         curve = PSA_KEY_TYPE_ECC_GET_FAMILY(opaque_key_type);
         id = mbedtls_ecc_group_from_psa(curve, psa_get_key_bits(&opaque_attrs));
         psa_reset_key_attributes(&opaque_attrs);
-    } else
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-    {
+    } else {
 #if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
         id = mbedtls_ecc_group_from_psa(pk->ec_family, pk->ec_bits);
 #else /* MBEDTLS_PK_USE_PSA_EC_DATA */
@@ -175,10 +172,8 @@ int mbedtls_pk_ecc_set_pubkey(mbedtls_pk_context *pk, const unsigned char *pub, 
  * as it's available at each calling site, and useful in some configs
  * (as otherwise we would have to re-serialize it from the pk context).
  *
- * There are three implementations of this function:
- * 1. MBEDTLS_PK_USE_PSA_EC_DATA,
- * 2. MBEDTLS_USE_PSA_CRYPTO but not MBEDTLS_PK_USE_PSA_EC_DATA,
- * 3. not MBEDTLS_USE_PSA_CRYPTO.
+ * There are two implementations of this function depending on
+ * MBEDTLS_PK_USE_PSA_EC_DATA being set or not.
  */
 int mbedtls_pk_ecc_set_pubkey_from_prv(mbedtls_pk_context *pk,
                                        const unsigned char *prv, size_t prv_len);

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -15,9 +15,7 @@
 
 #include "mbedtls/pk.h"
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
-#endif
 
 struct mbedtls_pk_info_t {
     /** Public key type */
@@ -98,7 +96,6 @@ extern const mbedtls_pk_info_t mbedtls_eckeydh_info;
 extern const mbedtls_pk_info_t mbedtls_ecdsa_info;
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 extern const mbedtls_pk_info_t mbedtls_ecdsa_opaque_info;
 extern const mbedtls_pk_info_t mbedtls_rsa_opaque_info;
 
@@ -109,7 +106,5 @@ int mbedtls_pk_psa_rsa_sign_ext(psa_algorithm_t psa_alg_md,
                                 unsigned char *sig, size_t sig_size,
                                 size_t *sig_len);
 #endif /* MBEDTLS_RSA_C */
-
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -20,10 +20,8 @@
 
 #include <string.h>
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/psa_util.h"
 #include "psa/crypto.h"
-#endif
 
 /* Key types */
 #if defined(MBEDTLS_RSA_C)

--- a/drivers/builtin/src/pkwrite.c
+++ b/drivers/builtin/src/pkwrite.c
@@ -36,24 +36,14 @@
 #include "rsa_internal.h"
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "psa_util_internal.h"
-#endif
 #include "mbedtls/platform.h"
 
 /* Helpers for properly sizing buffers aimed at holding public keys or
  * key-pairs based on build symbols. */
-#if defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 #define PK_MAX_EC_PUBLIC_KEY_SIZE       PSA_EXPORT_PUBLIC_KEY_MAX_SIZE
 #define PK_MAX_EC_KEY_PAIR_SIZE         MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH
-#elif defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PK_MAX_EC_PUBLIC_KEY_SIZE       PSA_EXPORT_PUBLIC_KEY_MAX_SIZE
-#define PK_MAX_EC_KEY_PAIR_SIZE         MBEDTLS_PSA_MAX_EC_KEY_PAIR_LENGTH
-#else
-#define PK_MAX_EC_PUBLIC_KEY_SIZE       MBEDTLS_ECP_MAX_PT_LEN
-#define PK_MAX_EC_KEY_PAIR_SIZE         MBEDTLS_ECP_MAX_BYTES
-#endif
 
 /******************************************************************************
  * Internal functions for RSA keys.
@@ -62,7 +52,6 @@
 static int pk_write_rsa_der(unsigned char **p, unsigned char *buf,
                             const mbedtls_pk_context *pk)
 {
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         uint8_t tmp[PSA_EXPORT_KEY_PAIR_MAX_SIZE];
         size_t tmp_len = 0;
@@ -81,7 +70,6 @@ static int pk_write_rsa_der(unsigned char **p, unsigned char *buf,
 
         return (int) tmp_len;
     }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     return mbedtls_rsa_write_key(mbedtls_pk_rsa(*pk), buf, p);
 }
 #endif /* MBEDTLS_RSA_C */
@@ -124,7 +112,6 @@ static int pk_write_ec_pubkey(unsigned char **p, unsigned char *start,
     mbedtls_ecp_keypair *ec = mbedtls_pk_ec(*pk);
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         if (psa_export_public_key(pk->priv_id, buf, sizeof(buf), &len) != PSA_SUCCESS) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
@@ -136,9 +123,7 @@ static int pk_write_ec_pubkey(unsigned char **p, unsigned char *start,
         *p -= len;
         memcpy(*p, buf, len);
         return (int) len;
-    } else
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-    {
+    } else {
         if ((ret = mbedtls_ecp_point_write_binary(&ec->grp, &ec->Q,
                                                   MBEDTLS_ECP_PF_UNCOMPRESSED,
                                                   &len, buf, sizeof(buf))) != 0) {
@@ -196,7 +181,6 @@ static int pk_write_ec_private(unsigned char **p, unsigned char *start,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char tmp[PK_MAX_EC_KEY_PAIR_SIZE];
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status;
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         status = psa_export_key(pk->priv_id, tmp, sizeof(tmp), &byte_length);
@@ -204,9 +188,7 @@ static int pk_write_ec_private(unsigned char **p, unsigned char *start,
             ret = PSA_PK_ECDSA_TO_MBEDTLS_ERR(status);
             return ret;
         }
-    } else
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-    {
+    } else {
         mbedtls_ecp_keypair *ec = mbedtls_pk_ec_rw(*pk);
         byte_length = (ec->grp.pbits + 7) / 8;
 
@@ -356,7 +338,6 @@ static int pk_write_ec_der(unsigned char **p, unsigned char *buf,
 /******************************************************************************
  * Internal functions for Opaque keys.
  ******************************************************************************/
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 static int pk_write_opaque_pubkey(unsigned char **p, unsigned char *start,
                                   const mbedtls_pk_context *pk)
 {
@@ -378,7 +359,6 @@ static int pk_write_opaque_pubkey(unsigned char **p, unsigned char *start,
 
     return (int) len;
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /******************************************************************************
  * Generic helpers
@@ -390,7 +370,6 @@ static mbedtls_pk_type_t pk_get_type_ext(const mbedtls_pk_context *pk)
 {
     mbedtls_pk_type_t pk_type = mbedtls_pk_get_type(pk);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (pk_type == MBEDTLS_PK_OPAQUE) {
         psa_key_attributes_t opaque_attrs = PSA_KEY_ATTRIBUTES_INIT;
         psa_key_type_t opaque_key_type;
@@ -408,8 +387,8 @@ static mbedtls_pk_type_t pk_get_type_ext(const mbedtls_pk_context *pk)
         } else {
             return MBEDTLS_PK_NONE;
         }
-    } else
-#endif
+    }
+
     return pk_type;
 }
 
@@ -432,12 +411,11 @@ int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
         MBEDTLS_ASN1_CHK_ADD(len, pk_write_ec_pubkey(p, start, key));
     } else
 #endif
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(key) == MBEDTLS_PK_OPAQUE) {
         MBEDTLS_ASN1_CHK_ADD(len, pk_write_opaque_pubkey(p, start, key));
-    } else
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-    return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    } else {
+        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
+    }
 
     return (int) len;
 }

--- a/drivers/builtin/src/pkwrite.h
+++ b/drivers/builtin/src/pkwrite.h
@@ -15,9 +15,7 @@
 
 #include "mbedtls/pk.h"
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /*
  * Max sizes of key per types. Shown as tag + len (+ content).
@@ -70,14 +68,10 @@
 /* Find the maximum number of bytes necessary to store an EC point. When USE_PSA
  * is defined this means looking for the maximum between PSA and built-in
  * supported curves. */
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #define MBEDTLS_PK_MAX_ECC_BYTES   (PSA_BITS_TO_BYTES(PSA_VENDOR_ECC_MAX_CURVE_BITS) > \
                                     MBEDTLS_ECP_MAX_BYTES ? \
                                     PSA_BITS_TO_BYTES(PSA_VENDOR_ECC_MAX_CURVE_BITS) : \
                                     MBEDTLS_ECP_MAX_BYTES)
-#else /* MBEDTLS_USE_PSA_CRYPTO */
-#define MBEDTLS_PK_MAX_ECC_BYTES   MBEDTLS_ECP_MAX_BYTES
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /*
  * EC public keys:

--- a/drivers/builtin/src/psa_util.c
+++ b/drivers/builtin/src/psa_util.c
@@ -32,8 +32,7 @@
     defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC)
 #include <mbedtls/rsa.h>
 #endif
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && \
-    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include <mbedtls/ecp.h>
 #endif
 #if defined(MBEDTLS_PK_C)
@@ -90,8 +89,7 @@ const mbedtls_error_pair_t psa_to_pk_rsa_errors[] =
 };
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && \
-    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 const mbedtls_error_pair_t psa_to_pk_ecdsa_errors[] =
 {
     { PSA_SUCCESS,                     0 },

--- a/drivers/builtin/src/psa_util_internal.h
+++ b/drivers/builtin/src/psa_util_internal.h
@@ -71,8 +71,7 @@ extern const mbedtls_error_pair_t psa_to_lms_errors[3];
 extern const mbedtls_error_pair_t psa_to_pk_rsa_errors[8];
 #endif
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && \
-    defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 extern const mbedtls_error_pair_t psa_to_pk_ecdsa_errors[7];
 #endif
 

--- a/include/tf-psa-crypto/check_config.h
+++ b/include/tf-psa-crypto/check_config.h
@@ -151,14 +151,14 @@
 #error "MBEDTLS_ECDSA_C defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PK_C) && defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_PK_C)
 #if defined(PSA_HAVE_ALG_ECDSA_SIGN) && !defined(MBEDTLS_ASN1_WRITE_C)
-#error "MBEDTLS_PK_C with MBEDTLS_USE_PSA_CRYPTO needs MBEDTLS_ASN1_WRITE_C for ECDSA signature"
+#error "MBEDTLS_PK_C needs MBEDTLS_ASN1_WRITE_C for ECDSA signature"
 #endif
 #if defined(PSA_HAVE_ALG_ECDSA_VERIFY) && !defined(MBEDTLS_ASN1_PARSE_C)
-#error "MBEDTLS_PK_C with MBEDTLS_USE_PSA_CRYPTO needs MBEDTLS_ASN1_PARSE_C for ECDSA verification"
+#error "MBEDTLS_PK_C needs MBEDTLS_ASN1_PARSE_C for ECDSA verification"
 #endif
-#endif /* MBEDTLS_PK_C && MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_PK_C */
 
 #if defined(MBEDTLS_ECJPAKE_C) && \
     !defined(MBEDTLS_ECP_C)

--- a/tests/suites/test_suite_pk.data
+++ b/tests/suites/test_suite_pk.data
@@ -588,7 +588,7 @@ mbedtls_pk_check_pair:"../framework/data_files/ec_256_pub.pem":"../framework/dat
 
 Check pair #2 (EC, bad)
 depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:PSA_WANT_ECC_SECP_R1_256:MBEDTLS_PEM_PARSE_C
-mbedtls_pk_check_pair:"../framework/data_files/ec_256_pub.pem":"../framework/data_files/server5.key":MBEDTLS_ERR_ECP_BAD_INPUT_DATA
+mbedtls_pk_check_pair:"../framework/data_files/ec_256_pub.pem":"../framework/data_files/server5.key":MBEDTLS_ERR_PK_BAD_INPUT_DATA
 
 Check pair #3 (RSA, OK)
 depends_on:MBEDTLS_RSA_C:MBEDTLS_PKCS1_V15:MBEDTLS_PEM_PARSE_C
@@ -1312,67 +1312,51 @@ PSA import into PSA: transparent -> persistent public
 pk_import_into_psa_lifetime:0:0:1:1:1
 
 PSA import into PSA: opaque volatile [export] -> volatile pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:1:0:0
 
 PSA import into PSA: opaque volatile [export] -> persistent pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:1:0:1
 
 PSA import into PSA: opaque volatile [export] -> volatile public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:1:1:0
 
 PSA import into PSA: opaque volatile [export] -> persistent public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:1:1:1
 
 PSA import into PSA: opaque volatile [copy] -> volatile pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:0:0:0
 
 PSA import into PSA: opaque volatile [copy] -> persistent pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:0:0:1
 
 PSA import into PSA: opaque volatile [copy] -> volatile public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:0:1:0
 
 PSA import into PSA: opaque volatile [copy] -> persistent public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:0:0:1:1
 
 PSA import into PSA: opaque persistent [export] -> volatile pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:1:0:0
 
 PSA import into PSA: opaque persistent [export] -> persistent pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:1:0:1
 
 PSA import into PSA: opaque persistent [export] -> volatile public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:1:1:0
 
 PSA import into PSA: opaque persistent [export] -> persistent public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:1:1:1
 
 PSA import into PSA: opaque persistent [copy] -> volatile pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:0:0:0
 
 PSA import into PSA: opaque persistent [copy] -> persistent pair
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:0:0:1
 
 PSA import into PSA: opaque persistent [copy] -> volatile public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:0:1:0
 
 PSA import into PSA: opaque persistent [copy] -> persistent public
-depends_on:MBEDTLS_USE_PSA_CRYPTO
 pk_import_into_psa_lifetime:1:1:0:1:1
 
 PSA import into PSA: opaque RSA, COPY (ok)

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -15,7 +15,7 @@
 #include <limits.h>
 #include <stdint.h>
 
-/* Needed only for test case data under #if defined(MBEDTLS_USE_PSA_CRYPTO),
+/* Needed only for test case data using PSA API macros/types because
  * but the test code generator requires test case data to be valid C code
  * unconditionally (https://github.com/Mbed-TLS/mbedtls/issues/2023). */
 #include "psa/crypto.h"
@@ -27,12 +27,6 @@
 
 /* Needed for the definition of MBEDTLS_PK_WRITE_PUBKEY_MAX_SIZE. */
 #include "pkwrite.h"
-
-#if defined(MBEDTLS_RSA_C) ||                                           \
-    defined(MBEDTLS_ECDSA_C) ||                                         \
-    defined(MBEDTLS_USE_PSA_CRYPTO)
-#define PK_CAN_SIGN_SOME
-#endif
 
 /* MBEDTLS_TEST_PK_PSA_SIGN is enabled when:
  * - The build has PK_[PARSE/WRITE]_C for RSA or ECDSA signature.
@@ -609,7 +603,7 @@ exit:
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE depends_on:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE */
 void pk_psa_utils(int key_is_rsa)
 {
     mbedtls_pk_context pk, pk2;
@@ -712,7 +706,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE */
 void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
                    int key_alg2, int curve_or_keybits, int alg_check, int usage_check,
                    int result)
@@ -944,25 +938,14 @@ exit:
 void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
 {
     mbedtls_pk_context pub, prv, alt;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t opaque_key_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t opaque_key_attr = PSA_KEY_ATTRIBUTES_INIT;
     int is_ec_key = 0;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_pk_init(&pub);
     mbedtls_pk_init(&prv);
     mbedtls_pk_init(&alt);
     PSA_INIT();
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    /* mbedtls_pk_check_pair() returns either PK or ECP error codes depending
-       on MBEDTLS_USE_PSA_CRYPTO so here we dynamically translate between the
-       two */
-    if (ret == MBEDTLS_ERR_ECP_BAD_INPUT_DATA) {
-        ret = MBEDTLS_ERR_PK_BAD_INPUT_DATA;
-    }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     TEST_ASSERT(mbedtls_pk_parse_public_keyfile(&pub, pub_file) == 0);
     TEST_ASSERT(mbedtls_pk_parse_keyfile(&prv, prv_file, NULL)
@@ -971,7 +954,6 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     TEST_ASSERT(mbedtls_pk_check_pair(&pub, &prv)
                 == ret);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     is_ec_key = (mbedtls_pk_get_type(&prv) == MBEDTLS_PK_ECKEY);
     /* Turn the prv PK context into an opaque one.*/
     TEST_EQUAL(mbedtls_pk_get_psa_attributes(&prv, PSA_KEY_USAGE_SIGN_HASH,
@@ -987,12 +969,9 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     } else {
         TEST_EQUAL(mbedtls_pk_check_pair(&pub, &prv), MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
     }
-#endif
 
 exit:
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key(opaque_key_id);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_pk_free(&pub);
     mbedtls_pk_free(&prv);
     mbedtls_pk_free(&alt);
@@ -1034,31 +1013,13 @@ void pk_rsa_verify_test_vec(data_t *message_str, int padding, int digest,
     int actual_result;
     actual_result = mbedtls_pk_verify(&pk, digest, message_str->x, 0,
                                       result_str->x, mbedtls_pk_get_len(&pk));
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    if (actual_result == MBEDTLS_ERR_RSA_INVALID_PADDING &&
-        expected_result == MBEDTLS_ERR_RSA_VERIFY_FAILED) {
-        /* Tolerate INVALID_PADDING error for an invalid signature with
-         * the legacy API (but not with PSA). */
-    } else
-#endif
-    {
-        TEST_EQUAL(actual_result, expected_result);
-    }
+    TEST_EQUAL(actual_result, expected_result);
 
     actual_result = mbedtls_pk_verify_restartable(&pk, digest, message_str->x, 0,
                                                   result_str->x,
                                                   mbedtls_pk_get_len(&pk),
                                                   rs_ctx);
-#if !defined(MBEDTLS_USE_PSA_CRYPTO)
-    if (actual_result == MBEDTLS_ERR_RSA_INVALID_PADDING &&
-        expected_result == MBEDTLS_ERR_RSA_VERIFY_FAILED) {
-        /* Tolerate INVALID_PADDING error for an invalid signature with
-         * the legacy API (but not with PSA). */
-    } else
-#endif
-    {
-        TEST_EQUAL(actual_result, expected_result);
-    }
+    TEST_EQUAL(actual_result, expected_result);
 
 exit:
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
@@ -1222,7 +1183,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256:PK_CAN_SIGN_SOME */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256 */
 void pk_sign_verify(int type, int curve_or_keybits, int rsa_padding, int rsa_md_alg,
                     int sign_ret, int verify_ret)
 {
@@ -1456,7 +1417,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_RSA_C:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE depends_on:MBEDTLS_RSA_C */
 void pk_wrap_rsa_decrypt_test_vec(data_t *cipher, int mod,
                                   char *input_P, char *input_Q,
                                   char *input_N, char *input_E,
@@ -1603,7 +1564,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_SHA_256:MBEDTLS_USE_PSA_CRYPTO:MBEDTLS_TEST_PK_PSA_SIGN */
+/* BEGIN_CASE depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_SHA_256:MBEDTLS_TEST_PK_PSA_SIGN */
 void pk_psa_sign(int psa_type, int bits, int rsa_padding)
 {
     mbedtls_pk_context pk;
@@ -1793,7 +1754,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_RSA_C:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE depends_on:MBEDTLS_RSA_C */
 void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg)
 {
     mbedtls_pk_context pk;
@@ -2041,7 +2002,6 @@ void pk_import_into_psa_lifetime(int from_opaque,
     PSA_INIT();
 
     if (from_opaque) {
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_key_type_t from_psa_type =
             PSA_KEY_TYPE_ECC_KEY_PAIR(MBEDTLS_TEST_PSA_ECC_ONE_FAMILY);
         psa_key_usage_t psa_key_usage =
@@ -2058,11 +2018,6 @@ void pk_import_into_psa_lifetime(int from_opaque,
                                 persistent_key_id, &old_key_id));
         TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, old_key_id), 0);
         psa_reset_key_attributes(&attributes);
-#else
-        (void) from_persistent;
-        (void) from_exportable;
-        TEST_FAIL("Attempted to test opaque key without opaque key support");
-#endif
     } else {
         psa_key_type_t psa_type_according_to_setup;
         TEST_EQUAL(pk_setup_for_type(MBEDTLS_PK_ECKEY, 1,
@@ -2110,7 +2065,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE */
 void pk_get_psa_attributes_opaque(int from_type_arg, int from_bits_arg,
                                   int from_usage_arg, int from_alg_arg,
                                   int usage_arg,
@@ -2207,7 +2162,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_USE_PSA_CRYPTO */
+/* BEGIN_CASE */
 void pk_import_into_psa_opaque(int from_type, int from_bits,
                                int from_usage, int from_alg,
                                int to_type, int to_bits,

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -15,9 +15,6 @@
 #include <limits.h>
 #include <stdint.h>
 
-/* Needed only for test case data using PSA API macros/types because
- * but the test code generator requires test case data to be valid C code
- * unconditionally (https://github.com/Mbed-TLS/mbedtls/issues/2023). */
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
 

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -75,10 +75,8 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
     unsigned char *start_buf;
     size_t buf_len, check_buf_len;
     int expected_result;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t opaque_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     USE_PSA_INIT();
 
@@ -126,7 +124,6 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
 
     TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     /* Verify that pk_write works also for opaque private keys */
     if (!is_public_key) {
         memset(buf, 0, check_buf_len);
@@ -150,12 +147,9 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
 
         TEST_MEMORY_COMPARE(start_buf, buf_len, check_buf, check_buf_len);
     }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 exit:
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key(opaque_id);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_free(buf);
     mbedtls_free(check_buf);
     mbedtls_pk_free(&key);
@@ -192,10 +186,8 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     size_t derived_key_len = 0;
     uint8_t *pub_key_raw = NULL;
     size_t pub_key_len = 0;
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t opaque_key_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_pk_init(&priv_key);
     USE_PSA_INIT();
@@ -213,7 +205,6 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                         pub_key_raw, pub_key_len);
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_platform_zeroize(derived_key_raw, derived_key_len);
 
     /* Turn the priv_key PK context into an opaque one. */
@@ -228,12 +219,9 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
 
     TEST_MEMORY_COMPARE(derived_key_raw, derived_key_len,
                         pub_key_raw, pub_key_len);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 exit:
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key(opaque_key_id);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_free(derived_key_raw);
     mbedtls_free(pub_key_raw);
     mbedtls_pk_free(&priv_key);


### PR DESCRIPTION
## Description

Resolves #283

## PR checklist

- [x] **changelog** not required because: internal
- [x] **development PR** not required because: crypto only
- [x] **TF-PSA-Crypto PR** provided HERE
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 1.0 only
- **tests**  not required because: removing dead code