### PR TITLE
Prepare crypto for the OID module split

### DIFF
--- a/ChangeLog.d/oid.txt
+++ b/ChangeLog.d/oid.txt
@@ -1,0 +1,4 @@
+Removals
+   * TF-PSA-Crypto does not provide an OID API. A subset of the OID
+     interfaces of Mbed TLS 3.x are now in the X.509 library in
+     Mbed TLS 4.x.

--- a/drivers/builtin/include/mbedtls/crypto_oid.h
+++ b/drivers/builtin/include/mbedtls/crypto_oid.h
@@ -7,8 +7,8 @@
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
-#ifndef MBEDTLS_OID_H
-#define MBEDTLS_OID_H
+#ifndef MBEDTLS_CRYPTO_OID_H
+#define MBEDTLS_CRYPTO_OID_H
 #include "mbedtls/private_access.h"
 
 #include "tf-psa-crypto/build_info.h"
@@ -692,4 +692,4 @@ int mbedtls_oid_get_pkcs12_pbe_alg(const mbedtls_asn1_buf *oid, mbedtls_md_type_
 }
 #endif
 
-#endif /* oid.h */
+#endif /* crypto_oid.h */

--- a/drivers/builtin/include/mbedtls/crypto_oid.h
+++ b/drivers/builtin/include/mbedtls/crypto_oid.h
@@ -1,5 +1,5 @@
 /**
- * \file oid.h
+ * \file crypto_oid.h
  *
  * \brief Object Identifier (OID) database
  */

--- a/drivers/builtin/include/mbedtls/crypto_oid.h
+++ b/drivers/builtin/include/mbedtls/crypto_oid.h
@@ -24,10 +24,13 @@
 
 #include "mbedtls/md.h"
 
-/** OID is not found. */
-#define MBEDTLS_ERR_OID_NOT_FOUND                         -0x002E
-/** output buffer is too small */
-#define MBEDTLS_ERR_OID_BUF_TOO_SMALL                     -0x000B
+/* OID is not found. This error is in the process of being removed from
+ * the public API, Hide it from scripts/generate_errors.pl, which
+ * is in the mbedtls repository, and would complain because it doesn't
+ * recognize the header name "crypto_oid.h". */
+#define MBEDTLS_ERR_OID_NOT_FOUND                         (-0x002E)
+/* output buffer is too small */
+#define MBEDTLS_ERR_OID_BUF_TOO_SMALL PSA_ERROR_BUFFER_TOO_SMALL
 
 /* This is for the benefit of X.509, but defined here in order to avoid
  * having a "backwards" include of x.509.h here */

--- a/drivers/builtin/include/mbedtls/crypto_oid.h
+++ b/drivers/builtin/include/mbedtls/crypto_oid.h
@@ -30,7 +30,7 @@
  * recognize the header name "crypto_oid.h". */
 #define MBEDTLS_ERR_OID_NOT_FOUND                         (-0x002E)
 /* output buffer is too small */
-#define MBEDTLS_ERR_OID_BUF_TOO_SMALL PSA_ERROR_BUFFER_TOO_SMALL
+#define MBEDTLS_ERR_OID_BUF_TOO_SMALL (PSA_ERROR_BUFFER_TOO_SMALL)
 
 /* This is for the benefit of X.509, but defined here in order to avoid
  * having a "backwards" include of x.509.h here */

--- a/drivers/builtin/include/mbedtls/oid.h
+++ b/drivers/builtin/include/mbedtls/oid.h
@@ -1,0 +1,15 @@
+/**
+ * \file oid.h
+ *
+ * \brief Transitional wrapper for the sake of mbedtls
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+#ifndef MBEDTLS_OID_H
+#define MBEDTLS_OID_H
+
+#include "mbedtls/crypto_oid.h"
+
+#endif /* oid.h */

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -11,7 +11,7 @@
 
 #if defined(MBEDTLS_OID_C)
 
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/rsa.h"
 #include "mbedtls/error_common.h"
 #include "mbedtls/pk.h"

--- a/drivers/builtin/src/pkcs5.c
+++ b/drivers/builtin/src/pkcs5.c
@@ -27,7 +27,7 @@
 #if defined(MBEDTLS_CIPHER_C)
 #include "mbedtls/cipher.h"
 #endif /* MBEDTLS_CIPHER_C */
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #endif /* MBEDTLS_ASN1_PARSE_C */
 
 #include <string.h>

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -11,7 +11,7 @@
 
 #include "mbedtls/pk.h"
 #include "mbedtls/asn1.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/error_common.h"

--- a/drivers/builtin/src/pkwrite.c
+++ b/drivers/builtin/src/pkwrite.c
@@ -11,7 +11,7 @@
 
 #include "mbedtls/pk.h"
 #include "mbedtls/asn1write.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error_common.h"
 #include "pk_internal.h"

--- a/drivers/builtin/src/rsa.c
+++ b/drivers/builtin/src/rsa.c
@@ -32,7 +32,7 @@
 #include "bignum_internal.h"
 #include "rsa_alt_helpers.h"
 #include "rsa_internal.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/asn1write.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error_common.h"

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -2,7 +2,7 @@
 #include "mbedtls/md.h"
 #include "mbedtls/psa_util.h"
 
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/asn1.h"
 
 #define MD_PSA(md, psa) \

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -1,5 +1,5 @@
 /* BEGIN_HEADER */
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/asn1.h"
 #include "mbedtls/asn1write.h"
 #include "string.h"

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -2,7 +2,7 @@
 #include "mbedtls/error_common.h"
 #include "mbedtls/pk.h"
 #include "mbedtls/pem.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/ecp.h"
 #include "mbedtls/psa_util.h"
 #include "pk_internal.h"

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include "pk_internal.h"
 #include "mbedtls/pem.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "mbedtls/base64.h"
 #include "psa/crypto_sizes.h"
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3,7 +3,7 @@
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/asn1write.h"
-#include "mbedtls/oid.h"
+#include "mbedtls/crypto_oid.h"
 #include "common.h"
 
 #include "psa_util_internal.h"


### PR DESCRIPTION
Prepare for `mbedtls/oid.h` to be in Mbed TLS instead of TF-PSA-Crypto. We want this because crypto OIDs don't need to be public, but some X.509 OIDs should be. This is an early step on the way to https://github.com/Mbed-TLS/mbedtls/issues/10124, which needs to be done before the bulk of the work in mbedtls.

In crypto, the OID module will become fully private, so API breaks are fine here.

This is just a small pull request to enable the mbedtls work. Enforcing the private nature of `mbedtls/oid.h` will be done in a follow-up, once mbedtls no longer needs `mbedtls/oid.h` to exist in TF-PSA-Crypto.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: just crypto stuff
- [x] **mbedtls 3.6 PR** not required because: new stuff
- **tests**  provided (this must not break mbedtls)
