### PR TITLE
scripts: driver_templates: call driver init/free

### DIFF
--- a/ChangeLog.d/driver-init-free.txt
+++ b/ChangeLog.d/driver-init-free.txt
@@ -1,0 +1,3 @@
+Changes
+    * Add dispatch code to call the drivers' "init" and "free" entry
+      points for drivers that declare them.

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -56,7 +56,7 @@
     {{ capability.names[entry_point]}}
     {% else -%}
     {{driver.prefix}}_{{driver.type}}_{{entry_point}}
-    {% endif -%}
+    {%- endif -%}
 {% endmacro %}
 /* END-Common Macro definitions */
 
@@ -74,6 +74,18 @@ static inline psa_status_t psa_driver_wrapper_init( void )
         return( status );
 #endif
 
+{% with entry_point = "init" -%}
+{% for driver in drivers -%}
+{% for capability in driver.capabilities if entry_point in capability.entry_points -%}
+#if ({% if capability['mbedtls/c_condition'] is defined -%}{{ capability['mbedtls/c_condition'] }} {% else -%} {{ 1 }} {% endif %})
+    status = {{ entry_point_name(capability, entry_point, driver) }}( );
+    if( status != PSA_SUCCESS )
+        return( status );
+#endif
+{% endfor -%}
+{% endfor -%}
+{% endwith %}
+
     (void) status;
     return( PSA_SUCCESS );
 }
@@ -84,6 +96,16 @@ static inline void psa_driver_wrapper_free( void )
     mbedtls_test_transparent_free( );
     mbedtls_test_opaque_free( );
 #endif
+
+{% with entry_point = "free" -%}
+{% for driver in drivers -%}
+{% for capability in driver.capabilities if entry_point in capability.entry_points -%}
+#if ({% if capability['mbedtls/c_condition'] is defined -%}{{ capability['mbedtls/c_condition'] }} {% else -%} {{ 1 }} {% endif %})
+    {{ entry_point_name(capability, entry_point, driver) }}( );
+#endif
+{% endfor -%}
+{% endfor -%}
+{% endwith %}
 }
 
 /* Start delegation functions */


### PR DESCRIPTION
If a driver declares "init" or "free" entry points, these should be called during the PSA initialization/uninitialization.

While here, fix a minor whitespace issue to make the generated code look slightly more readable (the entry_point_name macro was adding a newline between the function name and open paranthesis).

## Description

I'm in the process of writing an opaque driver that is using a secure element for some crypto operations. I found that the driver dispatch code is sometimes not generated properly to direct requests to my driver. As an example, the [PSA driver interface](https://github.com/ilie-halip-nxp/TF-PSA-Crypto/blob/development/docs/proposed/psa-driver-interface.md#driver-initialization) mentions that if a driver declares an "init" entry point, it would get called during initialization - but this is not the case, as the `psa_driver_wrapper_init()` is hardcoded to only initialize the test drivers.

There are other such cases where the driver wrapper function doesn't have the dispatch code (`psa_driver_wrapper_mac_compute()`, `psa_driver_wrapper_aead_encrypt()` are only 2 other such examples), but I wanted to start with this simple init/free PR for some feedback, I can submit other PRs for those functions as well.

Notably, for init/free I'm not using the `OS-template-opaque.jinja` common template because in init/free there's no switch for the key location.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: change is internal to TF-PSA-Crypto
- [ ] **mbedtls 3.6 PR** not required because: this is a slight behavior change
- [ ] **tests**  not required because: test drivers are already initialized/freed
