### PR TITLE
Remove temporary SHA3 definition

### DIFF
--- a/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_legacy_crypto.h
@@ -378,13 +378,4 @@
 #define MBEDTLS_SSL_HAVE_AEAD
 #endif
 
-// Temporary definition to menage the removal of MBEDTLS_SHA3_C.
-// After all PR of the removal is merged this needs to be deleted.
-#if defined(PSA_WANT_ALG_SHA3_224) || \
-    defined(PSA_WANT_ALG_SHA3_256) || \
-    defined(PSA_WANT_ALG_SHA3_384) || \
-    defined(PSA_WANT_ALG_SHA3_512)
-#define MBEDTLS_SHA3_C
-#endif
-
 #endif /* MBEDTLS_CONFIG_ADJUST_LEGACY_CRYPTO_H */


### PR DESCRIPTION
Remove the temporary definition for MBEDTLS_SHA3_C created for merging the removal of this macro.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: already done in #266 
- [x] **framework PR**  not required
- [x] **mbedtls development PR** not required because: all usage removed in Mbed-TLS/mbedtls#10145
- [x] **mbedtls 3.6 PR** not required because: 1.0/4.0 specific
- **tests**  not required because: has tests
