### PR TITLE
Privatize content in Everest headers

### DIFF
--- a/drivers/everest/include/tf-psa-crypto/private/everest/Hacl_Curve25519.h
+++ b/drivers/everest/include/tf-psa-crypto/private/everest/Hacl_Curve25519.h
@@ -15,7 +15,11 @@
 
 #include "kremlib.h"
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 void Hacl_Curve25519_crypto_scalarmult(uint8_t *mypublic, uint8_t *secret, uint8_t *basepoint);
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #define __Hacl_Curve25519_H_DEFINED
 #endif

--- a/drivers/everest/include/tf-psa-crypto/private/everest/everest.h
+++ b/drivers/everest/include/tf-psa-crypto/private/everest/everest.h
@@ -41,6 +41,8 @@ typedef struct {
 
 #define MBEDTLS_ECDH_CONTEXT_EVEREST_INIT {MBEDTLS_X25519_CONTEXT_INIT}
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function sets up the ECDH context with the information
  *                  given.
@@ -225,6 +227,8 @@ int mbedtls_everest_calc_secret( mbedtls_ecdh_context_everest *ctx, size_t *olen
                                  unsigned char *buf, size_t blen,
                                  int( *f_rng )( void *, unsigned char *, size_t ),
                                  void *p_rng );
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/everest/include/tf-psa-crypto/private/everest/x25519.h
+++ b/drivers/everest/include/tf-psa-crypto/private/everest/x25519.h
@@ -49,6 +49,8 @@ typedef struct
 
 #define MBEDTLS_X25519_CONTEXT_INIT {{0}, {0}}
 
+#if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
+
 /**
  * \brief           This function initializes an x25519 context.
  *
@@ -184,6 +186,8 @@ int mbedtls_x25519_make_public( mbedtls_x25519_context *ctx, size_t *olen,
  */
 int mbedtls_x25519_read_public( mbedtls_x25519_context *ctx,
                         const unsigned char *buf, size_t blen );
+
+#endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 #ifdef __cplusplus
 }

--- a/drivers/everest/library/Hacl_Curve25519_joined.c
+++ b/drivers/everest/library/Hacl_Curve25519_joined.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "common.h"
+#include "mbedtls/private_access.h"
 
 #if defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED)
 
@@ -47,4 +48,3 @@
 #include "kremlib/FStar_UInt64_FStar_UInt32_FStar_UInt16_FStar_UInt8.c"
 
 #endif /* defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED) */
-


### PR DESCRIPTION
## Description

Resolves #230.

## PR checklist

- [x] **changelog** not required because: these functions were already meant to be private and we're only enforcing it here, so nothing changes from the end user point of view.
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **mbedtls 3.6 PR** not required because: no change there
- **tests** not required because: no code change
