### PR TITLE
Hide DES error with parentheses so that generate_errors.pl skips it

### DIFF
--- a/drivers/builtin/include/mbedtls/des.h
+++ b/drivers/builtin/include/mbedtls/des.h
@@ -28,7 +28,7 @@
 #endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 
 /** The data input has an invalid length. */
-#define MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH              -0x0032
+#define MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH              (-0x0032)
 
 #if defined(MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
 #define MBEDTLS_DES_KEY_SIZE    8


### PR DESCRIPTION
## Description

Hide DES error with parentheses so that generate_errors.pl skips it, in order to proceed to removing DES instances from the TF PSA Crypto submodule without breaking error generation.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because change is internal only with no functional or API impact.
- [ ] **framework PR** not required because it does not concern the framework.
- [ ] **mbedtls development PR** not required change only affects tf-psa-crypto and error generator interaction.
- [ ] **mbedtls 3.6 PR** not required because DES is still supported in 3.6 and unaffected by this change.
- **tests**  not required because no logic or test-relevant behavior is changed.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
