### PR TITLE
Add PSA API-only dynamic loading in tfpsacrypto_dlopen.c

### DIFF
--- a/programs/test/tfpsacrypto_dlopen.c
+++ b/programs/test/tfpsacrypto_dlopen.c
@@ -47,7 +47,7 @@ int main(void)
     psa_status_t (*psa_hash_compute_ptr)(psa_algorithm_t, const uint8_t *, size_t,
                                          uint8_t *, size_t, size_t *) =
         dlsym(crypto_so, "psa_hash_compute");
-        
+    
 #pragma GCC diagnostic pop
     CHECK_DLERROR("dlsym", "psa_crypto_init");
     CHECK_DLERROR("dlsym", "psa_hash_compute");
@@ -62,7 +62,7 @@ int main(void)
     uint8_t hash[32]; // Buffer to hold the output hash
     size_t hash_len = 0;
 
-    status = psa_hash_compute_ptr(PSA_ALG_SHA_256,  
+    status = psa_hash_compute_ptr(PSA_ALG_SHA_256,
                               input, sizeof(input) - 1,
                               hash, sizeof(hash),
                               &hash_len);

--- a/programs/test/tfpsacrypto_dlopen.c
+++ b/programs/test/tfpsacrypto_dlopen.c
@@ -47,7 +47,7 @@ int main(void)
     psa_status_t (*psa_hash_compute_ptr)(psa_algorithm_t, const uint8_t *, size_t,
                                          uint8_t *, size_t, size_t *) =
         dlsym(crypto_so, "psa_hash_compute");
-    
+
 #pragma GCC diagnostic pop
     CHECK_DLERROR("dlsym", "psa_crypto_init");
     CHECK_DLERROR("dlsym", "psa_hash_compute");
@@ -63,16 +63,16 @@ int main(void)
     size_t hash_len = 0;
 
     status = psa_hash_compute_ptr(PSA_ALG_SHA_256,
-                              input, sizeof(input) - 1,
-                              hash, sizeof(hash),
-                              &hash_len);
+                                  input, sizeof(input) - 1,
+                                  hash, sizeof(hash),
+                                  &hash_len);
     if (status != PSA_SUCCESS) {
         mbedtls_fprintf(stderr, "psa_hash_compute failed: %d\n", (int) status);
         mbedtls_exit(MBEDTLS_EXIT_FAILURE);
     }
 
     mbedtls_printf("dlopen(%s): psa_hash_compute succeeded. SHA-256 output length: %zu\n",
-               CRYPTO_SO_FILENAME, hash_len);
+                   CRYPTO_SO_FILENAME, hash_len);
 
     dlclose(crypto_so);
     CHECK_DLERROR("dlclose", CRYPTO_SO_FILENAME);


### PR DESCRIPTION
## Description

Add PSA API-only dynamic loading in tfpsacrypto_dlopen.c

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required
- [x] **framework PR** not required
- [X] **mbedtls development PR** provided Mbed-TLS/mbedtls#10256
- [x] **mbedtls 3.6 PR** not required because this change concerns MbedTLS 4.0
- **tests**  not required because this is a manual test program



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
