### PR TITLE
include private pk.h internally

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -56,6 +56,9 @@
 #include "mbedtls/gcm.h"
 #include "mbedtls/md5.h"
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "pk_wrap.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error_common.h"

--- a/drivers/builtin/src/crypto_oid.h
+++ b/drivers/builtin/src/crypto_oid.h
@@ -15,6 +15,9 @@
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 
 #include <stddef.h>
 

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -13,6 +13,9 @@
 #include "mbedtls/rsa.h"
 #include "mbedtls/error_common.h"
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 
 #include <stdio.h>
 #include <string.h>

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -15,6 +15,9 @@
 
 #if defined(MBEDTLS_PK_C)
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "pk_wrap.h"
 #include "pkwrite.h"
 #include "pk_internal.h"

--- a/drivers/builtin/src/pk_ecc.c
+++ b/drivers/builtin/src/pk_ecc.c
@@ -8,6 +8,9 @@
 #include "tf_psa_crypto_common.h"
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "mbedtls/error_common.h"
 #include "mbedtls/ecp.h"
 #include "pk_internal.h"

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -12,6 +12,9 @@
 #define MBEDTLS_PK_INTERNAL_H
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include "mbedtls/ecp.h"

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -14,6 +14,9 @@
 #include "tf-psa-crypto/build_info.h"
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 
 #include "psa/crypto.h"
 

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -10,6 +10,9 @@
 #if defined(MBEDTLS_PK_PARSE_C)
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "mbedtls/asn1.h"
 #include "crypto_oid.h"
 #include "mbedtls/platform_util.h"

--- a/drivers/builtin/src/pkwrite.c
+++ b/drivers/builtin/src/pkwrite.c
@@ -10,6 +10,9 @@
 #if defined(MBEDTLS_PK_WRITE_C)
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "mbedtls/asn1write.h"
 #include "crypto_oid.h"
 #include "mbedtls/platform_util.h"

--- a/drivers/builtin/src/pkwrite.h
+++ b/drivers/builtin/src/pkwrite.h
@@ -14,6 +14,9 @@
 #include "tf-psa-crypto/build_info.h"
 
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 
 #include "psa/crypto.h"
 

--- a/drivers/builtin/src/psa_util.c
+++ b/drivers/builtin/src/psa_util.c
@@ -37,6 +37,9 @@
 #endif
 #if defined(MBEDTLS_PK_C)
 #include <mbedtls/pk.h>
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #endif
 #if defined(MBEDTLS_BLOCK_CIPHER_SOME_PSA)
 #include <mbedtls/cipher.h>

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1,5 +1,8 @@
 /* BEGIN_HEADER */
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "mbedtls/psa_util.h"
 #include "pk_internal.h"
 

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -1,6 +1,9 @@
 /* BEGIN_HEADER */
 #include "mbedtls/error_common.h"
 #include "mbedtls/pk.h"
+#if defined(MBEDTLS_PK_HAVE_PRIVATE_HEADER)
+#include <mbedtls/private/pk_private.h>
+#endif /* MBEDTLS_PK_HAVE_PRIVATE_HEADER */
 #include "mbedtls/pem.h"
 #include "crypto_oid.h"
 #include "mbedtls/ecp.h"


### PR DESCRIPTION
## Description

include private pk.h internally resolves https://github.com/Mbed-TLS/mbedtls/issues/10263 depends  https://github.com/Mbed-TLS/mbedtls/pull/10315

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10272
2. https://github.com/Mbed-TLS/mbedtls/pull/10315
3. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/357

## PR checklist
- [ ] **changelog** provided | not required because:  TBC
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls  https://github.com/Mbed-TLS/mbedtls/pull/10272
- [ ] **mbedtls 3.6 PR** not required because: No backports
- **tests**  not required because: No changes
