### PR TITLE
Rename mbedtls_pk_setup_opaque to mbedtls_pk_wrap_psa

### DIFF
--- a/ChangeLog.d/rename-mbedtls_pk_setup_opaque.txt
+++ b/ChangeLog.d/rename-mbedtls_pk_setup_opaque.txt
@@ -1,0 +1,3 @@
+API changes
+   * Rename mbedtls_pk_setup_opaque to mbedtls_pk_wrap_psa.
+

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -151,6 +151,11 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
 /*
  * Initialise a PSA-wrapping context
  */
+int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
+                        const mbedtls_svc_key_id_t key)
+{
+    return mbedtls_pk_wrap_psa(ctx,key);
+}
 int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                         const mbedtls_svc_key_id_t key)
 {

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -151,7 +151,7 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
 /*
  * Initialise a PSA-wrapping context
  */
-int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
+int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                             const mbedtls_svc_key_id_t key)
 {
     const mbedtls_pk_info_t *info = NULL;

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -152,9 +152,9 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
  * Initialise a PSA-wrapping context
  */
 int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
-                        const mbedtls_svc_key_id_t key)
+                            const mbedtls_svc_key_id_t key)
 {
-    return mbedtls_pk_wrap_psa(ctx,key);
+    return mbedtls_pk_wrap_psa(ctx, key);
 }
 int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                         const mbedtls_svc_key_id_t key)

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -152,7 +152,7 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
  * Initialise a PSA-wrapping context
  */
 int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
-                            const mbedtls_svc_key_id_t key)
+                        const mbedtls_svc_key_id_t key)
 {
     const mbedtls_pk_info_t *info = NULL;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -316,7 +316,7 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  *            RSA key pair.
  * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
-int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
+int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                             const mbedtls_svc_key_id_t key);
 
 /**

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -320,6 +320,45 @@ int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                         const mbedtls_svc_key_id_t key);
 
 /**
+ * \brief Initialize a PK context to wrap a PSA key.
+ *
+ * This function creates a PK context which wraps a PSA key. The PSA wrapped
+ * key must be an EC or RSA key pair (DH is not suported in the PK module).
+ *
+ * Under the hood PSA functions will be used to perform the required
+ * operations and, based on the key type, used algorithms will be:
+ * * EC:
+ *     * verify, verify_ext, sign, sign_ext: ECDSA.
+ * * RSA:
+ *     * sign: use the primary algorithm in the wrapped PSA key;
+ *     * sign_ext: RSA PSS if the pk_type is #MBEDTLS_PK_RSASSA_PSS, otherwise
+ *       it falls back to the sign() case;
+ *     * verify, verify_ext: not supported.
+ *
+ * In order for the above operations to succeed, the policy of the wrapped PSA
+ * key must allow the specified algorithm.
+ *
+ * Opaque PK contexts wrapping an EC keys also support \c mbedtls_pk_check_pair(),
+ * whereas RSA ones do not.
+ *
+ * \warning The PSA wrapped key must remain valid as long as the wrapping PK
+ *          context is in use, that is at least between the point this function
+ *          is called and the point mbedtls_pk_free() is called on this context.
+ *
+ * \param ctx The context to initialize. It must be empty (type NONE).
+ * \param key The PSA key to wrap, which must hold an ECC or RSA key pair.
+ *
+ * \return    \c 0 on success.
+ * \return    #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input (context already
+ *            used, invalid key identifier).
+ * \return    #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an ECC or
+ *            RSA key pair.
+ * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
+ */
+int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
+                        const mbedtls_svc_key_id_t key);
+
+/**
  * \brief           Get the size in bits of the underlying key
  *
  * \param ctx       The context to query. It must have been initialized.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -177,7 +177,7 @@ typedef struct mbedtls_pk_context {
 
     /* The following field is used to store the ID of a private key for:
      * - EC keys (MBEDTLS_PK_ECKEY, MBEDTLS_PK_ECKEY_DH, MBEDTLS_PK_ECDSA)
-     * - Opaque keys (EC or RSA).
+     * - Wrapped keys (EC or RSA).
      *
      * priv_id = MBEDTLS_SVC_KEY_ID_INIT when PK context wraps only the public
      * key.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -317,7 +317,7 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
 int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
-                            const mbedtls_svc_key_id_t key);
+                        const mbedtls_svc_key_id_t key);
 
 /**
  * \brief           Get the size in bits of the underlying key

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -356,7 +356,7 @@ int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
  * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
 int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
-                        const mbedtls_svc_key_id_t key);
+                            const mbedtls_svc_key_id_t key);
 
 /**
  * \brief           Get the size in bits of the underlying key

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -90,7 +90,7 @@ typedef enum {
  *
  * The resulting value can be 0, for example if MBEDTLS_ECDH_C is enabled
  * (which allows the pk module to be included) but neither MBEDTLS_ECDSA_C
- * nor MBEDTLS_RSA_C nor any opaque signature mechanism (PSA).
+ * nor MBEDTLS_RSA_C nor any PSA signature mechanism (PSA).
  */
 #define MBEDTLS_PK_SIGNATURE_MAX_SIZE 0
 
@@ -299,7 +299,7 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info);
  * In order for the above operations to succeed, the policy of the wrapped PSA
  * key must allow the specified algorithm.
  *
- * Opaque PK contexts wrapping an EC keys also support \c mbedtls_pk_check_pair(),
+ * PK contexts wrapping an EC keys also support \c mbedtls_pk_check_pair(),
  * whereas RSA ones do not.
  *
  * \warning The PSA wrapped key must remain valid as long as the wrapping PK

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -588,7 +588,7 @@ void pk_psa_utils(int key_is_rsa)
     mbedtls_pk_init(&pk2);
     PSA_INIT();
 
-    TEST_ASSERT(mbedtls_pk_setup_opaque(&pk, MBEDTLS_SVC_KEY_ID_INIT) ==
+    TEST_ASSERT(mbedtls_pk_wrap_psa(&pk, MBEDTLS_SVC_KEY_ID_INIT) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
     mbedtls_pk_free(&pk);
@@ -609,7 +609,7 @@ void pk_psa_utils(int key_is_rsa)
         goto exit;
     }
 
-    TEST_ASSERT(mbedtls_pk_setup_opaque(&pk, key) == 0);
+    TEST_ASSERT(mbedtls_pk_wrap_psa(&pk, key) == 0);
 
     TEST_ASSERT(mbedtls_pk_get_type(&pk) == MBEDTLS_PK_OPAQUE);
     TEST_ASSERT(strcmp(mbedtls_pk_get_name(&pk), name) == 0);
@@ -684,7 +684,7 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
             goto exit;
         }
 
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key), 0);
 
         TEST_EQUAL(mbedtls_pk_get_type(&pk), MBEDTLS_PK_OPAQUE);
     } else {
@@ -910,7 +910,7 @@ void mbedtls_pk_check_pair(char *pub_file, char *prv_file, int ret)
     TEST_EQUAL(mbedtls_pk_import_into_psa(&prv, &opaque_key_attr, &opaque_key_id), 0);
     mbedtls_pk_free(&prv);
     mbedtls_pk_init(&prv);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&prv, opaque_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&prv, opaque_key_id), 0);
     /* Test check_pair() between the opaque key we just created and the public PK counterpart.
      * Note: opaque EC keys support check_pair(), whereas RSA ones do not. */
     if (is_ec_key) {
@@ -1353,7 +1353,7 @@ void pk_psa_sign(int psa_type, int bits, int rsa_padding)
     TEST_EQUAL(mbedtls_pk_import_into_psa(&pk, &attributes, &key_id), 0);
     mbedtls_pk_free(&pk);
     mbedtls_pk_init(&pk);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key_id), 0);
 
     PSA_ASSERT(psa_get_key_attributes(key_id, &attributes));
     TEST_EQUAL(psa_get_key_type(&attributes), (psa_key_type_t) psa_type);
@@ -1498,7 +1498,7 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
     TEST_EQUAL(mbedtls_pk_import_into_psa(&pk, &key_attr, &key_id), 0);
     mbedtls_pk_free(&pk);
     mbedtls_pk_init(&pk);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, key_id), 0);
 
     memset(hash, 0x2a, sizeof(hash));
     memset(sig, 0, sizeof(sig));
@@ -1719,7 +1719,7 @@ void pk_import_into_psa_lifetime(int from_opaque,
         PSA_ASSERT(pk_psa_setup(from_psa_type, MBEDTLS_TEST_PSA_ECC_ONE_CURVE_BITS,
                                 psa_key_usage, PSA_ALG_ECDH, PSA_ALG_NONE,
                                 persistent_key_id, &old_key_id));
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, old_key_id), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, old_key_id), 0);
         psa_reset_key_attributes(&attributes);
     } else {
         psa_key_type_t psa_type_according_to_setup;
@@ -1791,7 +1791,7 @@ void pk_get_psa_attributes_opaque(int from_type_arg, int from_bits_arg,
 
     PSA_ASSERT(pk_psa_setup(from_type, bits, from_usage, alg, 42,
                             MBEDTLS_SVC_KEY_ID_INIT, &old_key_id));
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, old_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, old_key_id), 0);
 
     psa_key_type_t expected_psa_type =
         to_pair ? from_type : PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(from_type);
@@ -1884,7 +1884,7 @@ void pk_import_into_psa_opaque(int from_type, int from_bits,
 
     PSA_ASSERT(pk_psa_setup(from_type, from_bits, from_usage, from_alg, PSA_ALG_NONE,
                             MBEDTLS_SVC_KEY_ID_INIT, &from_key_id));
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&pk, from_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&pk, from_key_id), 0);
 
     psa_set_key_type(&to_attributes, to_type);
     psa_set_key_bits(&to_attributes, to_bits);

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -133,7 +133,7 @@ static void pk_write_check_common(char *key_file, int is_public_key, int is_der)
         TEST_EQUAL(mbedtls_pk_import_into_psa(&key, &key_attr, &opaque_id), 0);
         mbedtls_pk_free(&key);
         mbedtls_pk_init(&key);
-        TEST_EQUAL(mbedtls_pk_setup_opaque(&key, opaque_id), 0);
+        TEST_EQUAL(mbedtls_pk_wrap_psa(&key, opaque_id), 0);
         start_buf = buf;
         buf_len = check_buf_len;
         /* Intentionally pass a wrong size for the provided output buffer and check
@@ -212,7 +212,7 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     TEST_EQUAL(mbedtls_pk_import_into_psa(&priv_key, &key_attr, &opaque_key_id), 0);
     mbedtls_pk_free(&priv_key);
     mbedtls_pk_init(&priv_key);
-    TEST_EQUAL(mbedtls_pk_setup_opaque(&priv_key, opaque_key_id), 0);
+    TEST_EQUAL(mbedtls_pk_wrap_psa(&priv_key, opaque_key_id), 0);
 
     TEST_EQUAL(mbedtls_pk_write_pubkey_der(&priv_key, derived_key_raw,
                                            derived_key_len), pub_key_len);


### PR DESCRIPTION
## Description

Rename mbedtls_pk_setup_opaque to mbedtls_pk_wrap_psa contributes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/350

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/358
2. https://github.com/Mbed-TLS/mbedtls/pull/10274
3. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/368

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10274
- [ ] **mbedtls 3.6 PR**not required because:  No backports
- **tests**  provided