### PR TITLE
Remove duplicate definition.

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -155,11 +155,6 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
 /*
  * Initialise a PSA-wrapping context
  */
-int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
-                            const mbedtls_svc_key_id_t key)
-{
-    return mbedtls_pk_wrap_psa(ctx, key);
-}
 int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                         const mbedtls_svc_key_id_t key)
 {

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -298,7 +298,7 @@ void mbedtls_pk_init(mbedtls_pk_context *ctx);
  *                  If this is \c NULL, this function does nothing.
  *
  * \note            For contexts that have been set up with
- *                  mbedtls_pk_setup_opaque(), this does not free the underlying
+ *                  mbedtls_pk_wrap_psa(), this does not free the underlying
  *                  PSA key and you still need to call psa_destroy_key()
  *                  independently if you want to destroy that key.
  */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -376,45 +376,6 @@ int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
                         const mbedtls_svc_key_id_t key);
 
 /**
- * \brief Initialize a PK context to wrap a PSA key.
- *
- * This function creates a PK context which wraps a PSA key. The PSA wrapped
- * key must be an EC or RSA key pair (DH is not suported in the PK module).
- *
- * Under the hood PSA functions will be used to perform the required
- * operations and, based on the key type, used algorithms will be:
- * * EC:
- *     * verify, verify_ext, sign, sign_ext: ECDSA.
- * * RSA:
- *     * sign: use the primary algorithm in the wrapped PSA key;
- *     * sign_ext: RSA PSS if the pk_type is #MBEDTLS_PK_RSASSA_PSS, otherwise
- *       it falls back to the sign() case;
- *     * verify, verify_ext: not supported.
- *
- * In order for the above operations to succeed, the policy of the wrapped PSA
- * key must allow the specified algorithm.
- *
- * Opaque PK contexts wrapping an EC keys also support \c mbedtls_pk_check_pair(),
- * whereas RSA ones do not.
- *
- * \warning The PSA wrapped key must remain valid as long as the wrapping PK
- *          context is in use, that is at least between the point this function
- *          is called and the point mbedtls_pk_free() is called on this context.
- *
- * \param ctx The context to initialize. It must be empty (type NONE).
- * \param key The PSA key to wrap, which must hold an ECC or RSA key pair.
- *
- * \return    \c 0 on success.
- * \return    #MBEDTLS_ERR_PK_BAD_INPUT_DATA on invalid input (context already
- *            used, invalid key identifier).
- * \return    #MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE if the key is not an ECC or
- *            RSA key pair.
- * \return    #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
- */
-int mbedtls_pk_setup_opaque(mbedtls_pk_context *ctx,
-                            const mbedtls_svc_key_id_t key);
-
-/**
  * \brief           Get the size in bits of the underlying key
  *
  * \param ctx       The context to query. It must have been initialized.


### PR DESCRIPTION
## Description

Remove duplicate definition to complete the rename of mbedtls_pk_setup_opaque depends https://github.com/Mbed-TLS/mbedtls/pull/10274 resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/350.

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/358
2. https://github.com/Mbed-TLS/mbedtls/pull/10274
3. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/368

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10274
- [ ] **mbedtls 3.6 PR** not required because: No backports
- **tests**  not required because: No changes.
