### PR TITLE
Remove options parameter from mbedtls_pk_verify_ext

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -967,7 +967,7 @@ int mbedtls_pk_verify(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
 }
 
 /*
- * Verify a signature with options
+ * Verify a signature, with explicit selection of the signature algorithm.
  */
 int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type,
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -969,7 +969,7 @@ int mbedtls_pk_verify(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
 /*
  * Verify a signature with options
  */
-int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type
+int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type,
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                           const unsigned char *hash, size_t hash_len,
                           const unsigned char *sig, size_t sig_len)

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1058,9 +1058,9 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
 /*
  * Verify a signature
  */
-int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
-                          mbedtls_md_type_t md_alg, const unsigned char *hash,
-                          size_t hash_len, const unsigned char *sig, size_t sig_len)
+int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx, 
+		          mbedtls_md_type_t md_alg, const unsigned char *hash, 
+			  size_t hash_len, const unsigned char *sig, size_t sig_len)
 {
     return mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) type,
                                  NULL,

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1057,14 +1057,7 @@ int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
                           mbedtls_md_type_t md_alg, const unsigned char *hash,
                           size_t hash_len, const unsigned char *sig, size_t sig_len)
 {
-    return mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) type,
-                                 NULL,
-                                 ctx,
-                                 md_alg,
-                                 hash,
-                                 hash_len,
-                                 sig,
-                                 sig_len);
+    return mbedtls_pk_verify_ext(type, ctx, md_alg, hash, hash_len, sig, sig_len);
 }
 
 /*

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -969,7 +969,7 @@ int mbedtls_pk_verify(mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
 /*
  * Verify a signature with options
  */
-int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
+int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                           const unsigned char *hash, size_t hash_len,
                           const unsigned char *sig, size_t sig_len)
@@ -987,11 +987,6 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
     }
 
     if (type != MBEDTLS_PK_RSASSA_PSS) {
-        /* General case: no options */
-        if (options != NULL) {
-            return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
-        }
-
         return mbedtls_pk_verify(ctx, md_alg, hash, hash_len, sig, sig_len);
     }
 

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1053,9 +1053,9 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type
 /*
  * Verify a signature
  */
-int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx, 
-		          mbedtls_md_type_t md_alg, const unsigned char *hash, 
-			  size_t hash_len, const unsigned char *sig, size_t sig_len)
+int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
+                          mbedtls_md_type_t md_alg, const unsigned char *hash,
+                          size_t hash_len, const unsigned char *sig, size_t sig_len)
 {
     return mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) type,
                                  NULL,

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -12,8 +12,6 @@
 #define MBEDTLS_PK_H
 #define MBEDTLS_PK_HAVE_PRIVATE_HEADER
 
-#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
-
 #include "mbedtls/private_access.h"
 
 #include "tf-psa-crypto/build_info.h"

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -765,24 +765,16 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
  *                  If key type is different from MBEDTLS_PK_RSASSA_PSS it must
  *                  be NULL, otherwise it's just ignored.
  */
-int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
+int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                           const unsigned char *hash, size_t hash_len,
                           const unsigned char *sig, size_t sig_len);
 
 /**
-<<<<<<< HEAD
  * \brief           Verify signature, with explicit selection of the signature algorithm.
  *                  (Includes verification of the padding depending on type.)
  *
  * \param type      Signature type (inc. possible padding type) to verify
-=======
- * \brief           Verify signature, with options.
- *                  (Includes verification of the padding depending on type.)
- *
- * \param type      Signature type (inc. possible padding type) to verify
- * \param options   Pointer to type-specific options, or NULL
->>>>>>> ac0ac3c5a (Create new mbedtls_pk_verify_ext function mbedtls_pk_verify_new)
  * \param ctx       The PK context to use. It must have been set up.
  * \param md_alg    Hash algorithm used (see notes)
  * \param hash      Hash of the message to sign
@@ -804,16 +796,9 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
  *                  If key type is different from MBEDTLS_PK_RSASSA_PSS it must
  *                  be NULL, otherwise it's just ignored.
  */
-<<<<<<< HEAD
 int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
                           mbedtls_md_type_t md_alg, const unsigned char *hash,
                           size_t hash_len, const unsigned char *sig, size_t sig_len);
-=======
-int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx, 
-		          mbedtls_md_type_t md_alg, const unsigned char *hash, 
-			  size_t hash_len, const unsigned char *sig, size_t sig_len);
->>>>>>> ac0ac3c5a (Create new mbedtls_pk_verify_ext function mbedtls_pk_verify_new)
-
 
 /**
  * \brief           Make signature, including padding if relevant.

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -764,7 +764,7 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
  *                  If key type is different from MBEDTLS_PK_RSASSA_PSS it must
  *                  be NULL, otherwise it's just ignored.
  */
-int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type
+int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type,
                           mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                           const unsigned char *hash, size_t hash_len,
                           const unsigned char *sig, size_t sig_len);

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -739,7 +739,7 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
                                   mbedtls_pk_restart_ctx *rs_ctx);
 
 /**
- * \brief           Verify signature, with options.
+ * \brief           Verify signature, with explicit selection of the signature algorithm.
  *                  (Includes verification of the padding depending on type.)
  *
  * \param type      Signature type (inc. possible padding type) to verify

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -12,10 +12,6 @@
 #define MBEDTLS_PK_H
 #define MBEDTLS_PK_HAVE_PRIVATE_HEADER
 
-/*
- * This header is private and for internal
- * use only.
- */
 #define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 
 #include "mbedtls/private_access.h"

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -743,7 +743,6 @@ int mbedtls_pk_verify_restartable(mbedtls_pk_context *ctx,
  *                  (Includes verification of the padding depending on type.)
  *
  * \param type      Signature type (inc. possible padding type) to verify
- * \param options   Pointer to type-specific options, or NULL
  * \param ctx       The PK context to use. It must have been set up.
  * \param md_alg    Hash algorithm used (see notes)
  * \param hash      Hash of the message to sign

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -12,6 +12,12 @@
 #define MBEDTLS_PK_H
 #define MBEDTLS_PK_HAVE_PRIVATE_HEADER
 
+/*
+ * This header is private and for internal
+ * use only.
+ */
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+
 #include "mbedtls/private_access.h"
 
 #include "tf-psa-crypto/build_info.h"
@@ -771,10 +777,18 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
                           const unsigned char *sig, size_t sig_len);
 
 /**
+<<<<<<< HEAD
  * \brief           Verify signature, with explicit selection of the signature algorithm.
  *                  (Includes verification of the padding depending on type.)
  *
  * \param type      Signature type (inc. possible padding type) to verify
+=======
+ * \brief           Verify signature, with options.
+ *                  (Includes verification of the padding depending on type.)
+ *
+ * \param type      Signature type (inc. possible padding type) to verify
+ * \param options   Pointer to type-specific options, or NULL
+>>>>>>> ac0ac3c5a (Create new mbedtls_pk_verify_ext function mbedtls_pk_verify_new)
  * \param ctx       The PK context to use. It must have been set up.
  * \param md_alg    Hash algorithm used (see notes)
  * \param hash      Hash of the message to sign
@@ -796,9 +810,15 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type, const void *options,
  *                  If key type is different from MBEDTLS_PK_RSASSA_PSS it must
  *                  be NULL, otherwise it's just ignored.
  */
+<<<<<<< HEAD
 int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
                           mbedtls_md_type_t md_alg, const unsigned char *hash,
                           size_t hash_len, const unsigned char *sig, size_t sig_len);
+=======
+int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx, 
+		          mbedtls_md_type_t md_alg, const unsigned char *hash, 
+			  size_t hash_len, const unsigned char *sig, size_t sig_len);
+>>>>>>> ac0ac3c5a (Create new mbedtls_pk_verify_ext function mbedtls_pk_verify_new)
 
 
 /**

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -778,12 +778,12 @@ void pk_invalid_param()
                                              buf, buf_size,
                                              NULL));
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
-               mbedtls_pk_verify_ext(pk_type, NULL,
+               mbedtls_pk_verify_ext(pk_type,
                                      &ctx, MBEDTLS_MD_NONE,
                                      NULL, buf_size,
                                      buf, buf_size));
     TEST_EQUAL(MBEDTLS_ERR_PK_BAD_INPUT_DATA,
-               mbedtls_pk_verify_ext(pk_type, NULL,
+               mbedtls_pk_verify_ext(pk_type,
                                      &ctx, MBEDTLS_MD_SHA256,
                                      NULL, 0,
                                      buf, buf_size));
@@ -817,7 +817,6 @@ void valid_parameters()
     mbedtls_pk_context pk;
     unsigned char buf[1];
     size_t len;
-    void *options = NULL;
 
     mbedtls_pk_init(&pk);
     PSA_INIT();
@@ -865,7 +864,7 @@ void valid_parameters()
                                   buf, sizeof(buf)) ==
                 MBEDTLS_ERR_PK_BAD_INPUT_DATA);
 
-    TEST_ASSERT(mbedtls_pk_verify_ext(MBEDTLS_PK_NONE, options,
+    TEST_ASSERT(mbedtls_pk_verify_ext(MBEDTLS_PK_NONE,
                                       &pk,
                                       MBEDTLS_MD_NONE,
                                       NULL, 0,
@@ -1043,7 +1042,7 @@ void pk_rsa_verify_ext_test_vec(data_t *message_str, int digest,
     TEST_ASSERT(pk_fill_rsa_public_key_fields(&pk, mod, input_N->x, input_N->len,
                                               input_E->x, input_E->len) == 0);
 
-    ret = mbedtls_pk_verify_ext(pk_type, NULL, &pk,
+    ret = mbedtls_pk_verify_ext(pk_type, &pk,
                                 digest, message_str->x, message_str->len,
                                 result_str->x, sig_len);
 
@@ -1289,7 +1288,8 @@ void pk_rsa_overflow()
     TEST_EQUAL(mbedtls_pk_setup(&pk,
                                 mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)), 0);
 
-    TEST_EQUAL(mbedtls_pk_verify_ext(MBEDTLS_PK_RSASSA_PSS, NULL, &pk,
+#if defined(MBEDTLS_PKCS1_V21)
+    TEST_EQUAL(mbedtls_pk_verify_ext(MBEDTLS_PK_RSASSA_PSS, &pk,
                                      MBEDTLS_MD_NONE, hash, hash_len, sig, sig_len),
                MBEDTLS_ERR_PK_INVALID_ALG);
 
@@ -1490,7 +1490,7 @@ void pk_sign_ext(int pk_type, int curve_or_keybits, int key_pk_type, int md_alg)
     TEST_EQUAL(mbedtls_pk_sign_ext(key_pk_type, &pk, md_alg, hash, hash_len,
                                    sig, sizeof(sig), &sig_len), 0);
 
-    TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, NULL, &pk, md_alg,
+    TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pk, md_alg,
                                      hash, hash_len, sig, sig_len), 0);
 exit:
     mbedtls_pk_free(&pk);
@@ -1550,11 +1550,11 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
 
     /* verify_ext() is not supported when using an opaque context. */
     if (key_pk_type == MBEDTLS_PK_RSASSA_PSS) {
-        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, NULL, &pk, md_alg,
+        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pk, md_alg,
                                          hash, hash_len, sig, sig_len),
                    MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE);
     } else {
-        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, NULL, &pk, md_alg,
+        TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pk, md_alg,
                                          hash, hash_len, sig, sig_len),
                    MBEDTLS_ERR_PK_TYPE_MISMATCH);
     }
@@ -1566,7 +1566,7 @@ void pk_psa_wrap_sign_ext(int pk_type, int key_bits, int key_pk_type, int md_alg
     TEST_EQUAL(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(pk_type)), 0);
     TEST_EQUAL(mbedtls_pk_rsa_set_pubkey(&pk, pkey, pkey_len), 0);
 
-    TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, NULL, &pk, md_alg,
+    TEST_EQUAL(mbedtls_pk_verify_ext(key_pk_type, &pk, md_alg,
                                      hash, hash_len, sig, sig_len), 0);
 
 exit:

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1288,7 +1288,6 @@ void pk_rsa_overflow()
     TEST_EQUAL(mbedtls_pk_setup(&pk,
                                 mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)), 0);
 
-#if defined(MBEDTLS_PKCS1_V21)
     TEST_EQUAL(mbedtls_pk_verify_ext(MBEDTLS_PK_RSASSA_PSS, &pk,
                                      MBEDTLS_MD_NONE, hash, hash_len, sig, sig_len),
                MBEDTLS_ERR_PK_INVALID_ALG);


### PR DESCRIPTION
## Description

Remove options parameter from mbedtls_pk_verify_ext resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/349

## PR checklist

- [ ] **changelog** provided | not required because: TBC
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10291
- [ ] **mbedtls 3.6 PR** not required because: No backports
- **tests**  provided
