### PR TITLE
Remove compat common.h

### DIFF
--- a/core/common.h
+++ b/core/common.h
@@ -1,2 +1,0 @@
-// Temporary header to maintain compatibility with Mbed TLS
-#include "tf_psa_crypto_common.h"

--- a/drivers/builtin/src/pk_rsa.c
+++ b/drivers/builtin/src/pk_rsa.c
@@ -5,7 +5,7 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-#include "common.h"
+#include "tf_psa_crypto_common.h"
 
 #include "mbedtls/pk.h"
 #include "mbedtls/error_common.h"


### PR DESCRIPTION
## Description

Remove the compatibility `common.h`

Fixes https://github.com/Mbed-TLS/mbedtls/issues/9862

## PR checklist
- [x] **changelog** not required because: Not a user-visible change
- [x] **mbedtls 3.6 PR** not required because: 4.0/1.0 roadmap work, no functional changes
- **tests** not required because: No functional changes
- The merge order of the PRs proceeds from top to bottom:
  - [x] **TF-PSA-Crypto PR**: #383
  - [x] **mbedtls development PR**: Mbed-TLS/mbedtls#10309
  - [x] **framework PR**: Mbed-TLS/mbedtls-framework#190
  - [x] **TF-PSA-Crypto PR**: #384 (This PR)
