### PR TITLE
benchmark.c: Add a mbedtls_timing_hardclock variation with xtensa CCOUNT

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -361,6 +361,20 @@ static unsigned long mbedtls_timing_hardclock(void)
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __ia64__ */
 
+#if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&      \
+    defined(__GNUC__) && defined(__xtensa__)
+
+#define HAVE_HARDCLOCK
+
+static unsigned long mbedtls_timing_hardclock(void)
+{
+    unsigned int ccount;
+    asm volatile ("rsr %0, ccount" : "=r" (ccount));
+    return ccount;
+}
+#endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
+          __GNUC__ && __xtensa__ */
+
 #if !defined(HAVE_HARDCLOCK) && defined(_WIN32) && \
     !defined(EFIX64) && !defined(EFI32)
 


### PR DESCRIPTION
## Description

benchmark.c: Add a mbedtls_timing_hardclock variation with xtensa CCOUNT

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter
