### PR TITLE
Updates to the 0e plans

### DIFF
--- a/docs/architecture/0e-plans.md
+++ b/docs/architecture/0e-plans.md
@@ -1088,7 +1088,7 @@ For the choice of DRBG, we preserve the existing behavior: pick CTR\_DRBG if ena
 We can deduce the sizes used in entropy and for DRBG internals from just two settings:
 
 * `MBEDTLS_PSA_CRYPTO_RNG_STRENGTH` indicating the minimum strength of the RNG. Only 128 and 256 are meant to be useful values. Default to 256.
-* `MBEDTLS_PSA_CRYPTO_RNG_HASH` indicating which hash algorithm to use for the entropy module, and for HMAC\_DRBG if configured. Default to SHA-256.
+* `MBEDTLS_PSA_CRYPTO_RNG_HASH` indicating which hash algorithm to use for the entropy module, and for HMAC\_DRBG if configured. This is a `PSA_ALG_xxx` macro. Default to SHA-256.
 
 For CTR\_DRBG, use AES-256 if `MBEDTLS_PSA_CRYPTO_RNG_STRENGTH > 128` and AES-128 otherwise.
 
@@ -1143,6 +1143,8 @@ The new configuration checks ensure that the RNG configuration options achieve t
 * If CTR\_DRBG is used, the AES key size is chosen based on the strength. A strength of more than 256 is an error.
 * If HMAC\_DRBG is used, the size of the hash must be at least `MBEDTLS_PSA_CRYPTO_RNG_STRENGTH`.
 * The size of the hash `MBEDTLS_PSA_CRYPTO_RNG_HASH` must be at least 256 bits (32 bytes). We could in principle support smaller hashes, but we would need more complex strength calculations, and nobody needs this in 2025.
+
+The checks that depend on `MBEDTLS_PSA_CRYPTO_RNG_HASH` can't be done with preprocessor conditions, since the definition of `PSA_ALG_xxx` are compile-time constants but not preprocessor constants (they contain casts). They need to be static asserts. Since `check_config.h` only has preprocessor checks, it seems reasonable to put the static asserts in `psa_crypto_random_impl.h` instead. The existing or new preprocessor checks can also go into `psa_crypto_random_impl.h` for consistency.
 
 #### Builds without entropy
 

--- a/docs/architecture/pk-4.md
+++ b/docs/architecture/pk-4.md
@@ -235,7 +235,7 @@ We should change the meaning of the usage flag to indicate what operations can a
 * `PSA_KEY_USAGE_DECRYPT` means a key pair that can be used to decrypt;
 * `PSA_KEY_USAGE_ENCRYPT` means a public key or key pair that can be used to encrypt;
 * `PSA_KEY_USAGE_DERIVE` means a key pair that can be used as the private side in a key agreement;
-* `PSA_KEY_USAGE_DERIVE_PUBLIC`: flag for a key pair or public key that can be used as the public side in a key agreement. This flag does not currently exist in PSA, and [may be added as part of adding s similar function to the PSA API](https://github.com/ARM-software/psa-api/issues/279). In the meantime, give it the value 0x80000000. Note that changing the value will be an ABI change.
+* `PSA_KEY_USAGE_DERIVE_PUBLIC`: flag for a key pair or public key that can be used as the public side in a key agreement. This flag does not currently exist in PSA, and [may be added as part of adding s similar function to the PSA API](https://github.com/ARM-software/psa-api/issues/279). In the meantime, give it the value 0x00800000. (We are considering reserving the top 8 bits of usage flags for platform-specific use, so avoid those bits to avoid potential confusion). Note that changing the value will be an ABI change.
 
 This will be closer to how `mbedtls_pk_get_psa_attributes()` works.
 

--- a/docs/architecture/pk-4.md
+++ b/docs/architecture/pk-4.md
@@ -235,7 +235,7 @@ We should change the meaning of the usage flag to indicate what operations can a
 * `PSA_KEY_USAGE_DECRYPT` means a key pair that can be used to decrypt;
 * `PSA_KEY_USAGE_ENCRYPT` means a public key or key pair that can be used to encrypt;
 * `PSA_KEY_USAGE_DERIVE` means a key pair that can be used as the private side in a key agreement;
-* `PSA_KEY_USAGE_DERIVE_PUBLIC`: flag for a key pair or public key that can be used as the public side in a key agreement. This flag does not currently exist in PSA, and [may be added as part of adding s similar function to the PSA API](https://github.com/ARM-software/psa-api/issues/279). In the meantime, give it the value 0x00800000. (We are considering reserving the top 8 bits of usage flags for platform-specific use, so avoid those bits to avoid potential confusion). Note that changing the value will be an ABI change.
+* `PSA_KEY_USAGE_DERIVE_PUBLIC`: flag for a key pair or public key that can be used as the public side in a key agreement. This flag does not currently exist in PSA, but [will be added as part of adding a similar function to the PSA API](https://github.com/ARM-software/psa-api/issues/279). Use the value 0x00000080.
 
 This will be closer to how `mbedtls_pk_get_psa_attributes()` works.
 


### PR DESCRIPTION
Updates to the specification for API changes based on the implementation work: change things that need changing, or clarify things that were unclear. I propose to keep accumulating changes here during development.

* Expand on `MBEDTLS_PSA_CRYPTO_RNG_HASH` and how to check it.
* Expand on DES removal.
* Expand on the `md.h` split.
* Tweak the value of `PSA_KEY_USAGE_DERIVE_PUBLIC`.

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: doc only
- [x] **mbedtls 3.6 PR** not required because: new stuff
- **tests**  not required because: doc only
