### PR TITLE
Introduce generated config checks in crypto

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,4 +1,7 @@
 ###START_GENERATED_FILES###
 /psa_crypto_driver_wrappers.h
 /psa_crypto_driver_wrappers_no_static.c
+/tf_psa_crypto_config_check_before.h
+/tf_psa_crypto_config_check_final.h
+/tf_psa_crypto_config_check_user.h
 ###END_GENERATED_FILES###

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,23 +28,11 @@ if(GEN_FILES)
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
             ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
-            --list ""
+            --list-for-cmake "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_SOURCE_DIR}/..
         OUTPUT_VARIABLE
             TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS)
-    # Turn newline-terminated non-empty list into semicolon-separated list.
-    string(REPLACE "\n" ";"
-           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
-    string(REGEX REPLACE ";\$" ""
-           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
-    # Prepend the binary dir to all element of TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS,
-    # using features that exist in CMake 3.5.1.
-    string(REPLACE ";" ";${CMAKE_CURRENT_BINARY_DIR}/"
-           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS
-           "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
-    set(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS
-        "${CMAKE_CURRENT_BINARY_DIR}/${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
 
     add_custom_command(
         OUTPUT ${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,12 +24,47 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_DIR}/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
     )
 
-    add_custom_target(${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto_generated_files_target
+    execute_process(
+        COMMAND
+            ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+            ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+            --list ""
+        WORKING_DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}/..
+        OUTPUT_VARIABLE
+            TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS)
+    # Turn newline-terminated non-empty list into semicolon-separated list.
+    string(REPLACE "\n" ";"
+           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
+    string(REGEX REPLACE ";\$" ""
+           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
+    # Prepend the binary dir to all element of TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS,
+    # using features that exist in CMake 3.5.1.
+    string(REPLACE ";" ";${CMAKE_CURRENT_BINARY_DIR}/"
+           TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS
+           "${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
+    set(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS
+        "${CMAKE_CURRENT_BINARY_DIR}/${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}")
+
+    add_custom_command(
+        OUTPUT ${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}
+        COMMAND
+            ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+                ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+                ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
-            ${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers.h
-            ${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers_no_static.c
+            ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+            ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/config_checks_generator.py
     )
-endif()
+
+    add_custom_target(
+            ${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto_generated_files_target
+        DEPENDS
+            "${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers.h"
+            "${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers_no_static.c"
+            ${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}
+        )
+endif(GEN_FILES)
 
 if(CMAKE_COMPILER_IS_GNUCC)
     set(LIBS_C_FLAGS -Wmissing-declarations -Wmissing-prototypes)

--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+"""Generate C preprocessor code to check for bad configurations.
+"""
+
+import framework_scripts_path # pylint: disable=unused-import
+from mbedtls_framework.config_checks_generator import * \
+    #pylint: disable=wildcard-import,unused-wildcard-import
+
+CRYPTO_CHECKS = BranchData(
+    header_directory='core',
+    header_prefix='tf_psa_crypto_',
+    project_cpp_prefix='TF_PSA_CRYPTO',
+    checkers=[
+        Internal('MBEDTLS_MD_SOME_LEGACY'),
+        Internal('MBEDTLS_MD_SOME_PSA'),
+        Removed('MBEDTLS_PADLOCK_C', 'TF-PSA-Crypto 1.0'),
+    ],
+)
+
+if __name__ == '__main__':
+    main(CRYPTO_CHECKS)


### PR DESCRIPTION
Introduce `generate_config_checks.py` and instructions to use it in the build scripts. Do not yet consume the generated files, to avoid breaking the build in mbedtls (mbedtls needs to know how to generate the crypto files before crypto can start having them when it's built by mbedtls).

Contributes to https://github.com/Mbed-TLS/mbedtls/issues/10147. See https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/269 for what this will look like when consumed by the library.

Needs preceding PR: https://github.com/Mbed-TLS/mbedtls-framework/pull/196

## PR checklist

- [x] **changelog** not required because: internal stuff
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/196, https://github.com/Mbed-TLS/mbedtls-framework/pull/211, https://github.com/Mbed-TLS/mbedtls-framework/pull/212
- [x] **TF-PSA-Crypto PR** here
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10340
- [x] **3.6 PR** not required because: not getting done for 3.6
- **tests**  provided
