### PR TITLE
Fix whitespace in crypto_extra.h

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -706,8 +706,8 @@ typedef uint32_t psa_pake_primitive_t;
  */
 #define PSA_PAKE_PRIMITIVE(pake_type, pake_family, pake_bits) \
     (((pake_bits & 0xFFFF) != pake_bits) ? 0 :                 \
-    ((psa_pake_primitive_t) (((pake_type) << 24 |             \
-                              (pake_family) << 16) | (pake_bits))))
+     ((psa_pake_primitive_t) (((pake_type) << 24 |             \
+                               (pake_family) << 16) | (pake_bits))))
 
 /** The key share being sent to or received from the peer.
  *


### PR DESCRIPTION
## Description

This should fix the code-style errors from uncrustify.

## PR checklist

- [x] **changelog** not required because: No functional changes
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required:
- [x] **mbedtls 3.6 PR** not required
- **tests** not required