### PR TITLE
Remove `include/mbedtls/private` from Doxygen

### DIFF
--- a/doxygen/tfpsacrypto.doxyfile.in
+++ b/doxygen/tfpsacrypto.doxyfile.in
@@ -8,6 +8,7 @@ EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = NO
 INPUT                  = ../include input
 FILE_PATTERNS          = *.h
+EXCLUDE                = ../include/mbedtls/private
 RECURSIVE              = YES
 EXCLUDE_SYMLINKS       = YES
 SOURCE_BROWSER         = YES


### PR DESCRIPTION
Don't render files in `include/mbedtls/private`

## PR checklist

- [x] **changelog** not required because:  documentation change
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10364
- [x] **mbedtls 3.6 PR** not required because: directory new in 4.0/1.0
- **tests**  not required because: documentation changes