### PR TITLE
Create threading_internal.h

### DIFF
--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -17,7 +17,7 @@
 
 #if defined(MBEDTLS_THREADING_C)
 
-#include "mbedtls/threading.h"
+#include "threading_internal.h"
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -1,5 +1,5 @@
 /**
- * \file threadinginternal.h
+ * \file threading_internal.h
  *
  * \brief Threading interfaces used by the test framework
  */

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -1,0 +1,28 @@
+/**
+ * \file threadinginternal.h
+ *
+ * \brief Threading interfaces used by the test framework
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef MBEDTLS_THREADING_INTERNAL_H
+#define MBEDTLS_THREADING_INTERNAL_H
+
+#include "tf_psa_crypto_common.h"
+
+#include <mbedtls/threading.h>
+
+/* A version number for the internal threading interface.
+ * This is meant to allow the framework to remain compatible with
+ * multiple versions, to facilitate transitions.
+ *
+ * Conventionally, this is the Mbed TLS version number when the
+ * threading interface was last changed in a way that may impact the
+ * test framework, with the lower byte incremented as necessary
+ * if multiple changes happened between releases. */
+#define MBEDTLS_THREADING_INTERNAL_VERSION 0x03060000
+
+#endif /* MBEDTLS_THREADING_INTERNAL_H */


### PR DESCRIPTION
This is meant to hold threading-related definitions that are not public, but are used in the test framework. Create this in all branches, so that the framework can start doing `#include "threading_internal.h"`.

## PR checklist

- [x] **changelog** provided | not required because: internal
- [x] **framework PR** not required (will follow)
- [x] **mbedtls development PR** not required because: internal
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10375
- **tests**  not required because: refactoring only
