### PR TITLE
Finally remove the old psa_pake_get_implicit_key() function

### DIFF
--- a/ChangeLog.d/9322.txt
+++ b/ChangeLog.d/9322.txt
@@ -1,0 +1,7 @@
+Removals
+   * Removed the `psa_pake_get_implicit_key()` function. Removed to comply
+     with PSA API 1.2 PAKE extension.
+
+Changes
+   * Implemented the `psa_pake_get_shared_key()` function, compliant with the
+     PSA API 1.2 PAKE extension, replacement for `psa_pake_get_implicit_key()`

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -9377,7 +9377,7 @@ psa_status_t psa_pake_get_shared_key(psa_pake_operation_t *operation,
         goto exit;
     }
 
-    status = psa_driver_wrapper_pake_get_implicit_key(operation,
+    status = psa_driver_wrapper_pake_get_shared_key(operation,
                                                       shared_key,
                                                       sizeof(shared_key),
                                                       &shared_key_len);

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -9399,55 +9399,6 @@ exit:
     return status == PSA_SUCCESS ? abort_status : status;
 }
 
-psa_status_t psa_pake_get_implicit_key(
-    psa_pake_operation_t *operation,
-    psa_key_derivation_operation_t *output)
-{
-    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
-    uint8_t shared_key[MBEDTLS_PSA_JPAKE_BUFFER_SIZE];
-    size_t shared_key_len = 0;
-
-    if (operation->stage != PSA_PAKE_OPERATION_STAGE_COMPUTATION) {
-        status = PSA_ERROR_BAD_STATE;
-        goto exit;
-    }
-
-#if defined(PSA_WANT_ALG_JPAKE)
-    if (PSA_ALG_IS_JPAKE(operation->alg)) {
-        psa_jpake_computation_stage_t *computation_stage =
-            &operation->computation_stage.jpake;
-        if (computation_stage->round != PSA_JPAKE_FINISHED) {
-            status = PSA_ERROR_BAD_STATE;
-            goto exit;
-        }
-    } else
-#endif /* PSA_WANT_ALG_JPAKE */
-    {
-        status = PSA_ERROR_NOT_SUPPORTED;
-        goto exit;
-    }
-
-    status = psa_driver_wrapper_pake_get_implicit_key(operation,
-                                                      shared_key,
-                                                      sizeof(shared_key),
-                                                      &shared_key_len);
-
-    if (status != PSA_SUCCESS) {
-        goto exit;
-    }
-
-    status = psa_key_derivation_input_bytes(output,
-                                            PSA_KEY_DERIVATION_INPUT_SECRET,
-                                            shared_key,
-                                            shared_key_len);
-
-    mbedtls_platform_zeroize(shared_key, sizeof(shared_key));
-exit:
-    abort_status = psa_pake_abort(operation);
-    return status == PSA_SUCCESS ? abort_status : status;
-}
-
 psa_status_t psa_pake_abort(
     psa_pake_operation_t *operation)
 {

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1704,9 +1704,6 @@ psa_status_t psa_pake_get_shared_key(psa_pake_operation_t *operation,
                                      const psa_key_attributes_t *attributes,
                                      mbedtls_svc_key_id_t *key);
 
-psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
-                                       psa_key_derivation_operation_t *output);
-
 /** Abort a PAKE operation.
  *
  * Aborting an operation frees all associated resources except for the \c

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -2662,7 +2662,7 @@ static inline psa_status_t psa_driver_wrapper_pake_input(
     }
 }
 
-static inline psa_status_t psa_driver_wrapper_pake_get_implicit_key(
+static inline psa_status_t psa_driver_wrapper_pake_get_shared_key(
     psa_pake_operation_t *operation,
     uint8_t *output, size_t output_size,
     size_t *output_length )


### PR DESCRIPTION
## Description
This PR removes the old psa_pake_get_implicit_key() function, which mbedtls does not use anymore.
Depends on Mbed-TLS/mbedtls#10061

## PR checklist

- [X] **changelog** provided
- [X] **framework PR** not required
- [X] **mbedtls development PR** provided Mbed-TLS/mbedtls#10061 
- [X] **mbedtls 3.6 PR** not required because: no backport required
- **tests**  not required because: no tests necessary, just a removal