### PR TITLE
Remove transitional headers for the "Move headers to a private directory" PR series

### DIFF
--- a/drivers/builtin/include/mbedtls/aes.h
+++ b/drivers/builtin/include/mbedtls/aes.h
@@ -1,1 +1,0 @@
-#include "private/aes.h"

--- a/drivers/builtin/include/mbedtls/aria.h
+++ b/drivers/builtin/include/mbedtls/aria.h
@@ -1,1 +1,0 @@
-#include "private/aria.h"

--- a/drivers/builtin/include/mbedtls/bignum.h
+++ b/drivers/builtin/include/mbedtls/bignum.h
@@ -1,1 +1,0 @@
-#include "private/bignum.h"

--- a/drivers/builtin/include/mbedtls/block_cipher.h
+++ b/drivers/builtin/include/mbedtls/block_cipher.h
@@ -1,1 +1,0 @@
-#include "private/block_cipher.h"

--- a/drivers/builtin/include/mbedtls/camellia.h
+++ b/drivers/builtin/include/mbedtls/camellia.h
@@ -1,1 +1,0 @@
-#include "private/camellia.h"

--- a/drivers/builtin/include/mbedtls/ccm.h
+++ b/drivers/builtin/include/mbedtls/ccm.h
@@ -1,1 +1,0 @@
-#include "private/ccm.h"

--- a/drivers/builtin/include/mbedtls/chacha20.h
+++ b/drivers/builtin/include/mbedtls/chacha20.h
@@ -1,1 +1,0 @@
-#include "private/chacha20.h"

--- a/drivers/builtin/include/mbedtls/chachapoly.h
+++ b/drivers/builtin/include/mbedtls/chachapoly.h
@@ -1,1 +1,0 @@
-#include "private/chachapoly.h"

--- a/drivers/builtin/include/mbedtls/cipher.h
+++ b/drivers/builtin/include/mbedtls/cipher.h
@@ -1,1 +1,0 @@
-#include "private/cipher.h"

--- a/drivers/builtin/include/mbedtls/cmac.h
+++ b/drivers/builtin/include/mbedtls/cmac.h
@@ -1,1 +1,0 @@
-#include "private/cmac.h"

--- a/drivers/builtin/include/mbedtls/config_adjust_legacy_from_psa.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_legacy_from_psa.h
@@ -1,1 +1,0 @@
-#include "private/config_adjust_legacy_from_psa.h"

--- a/drivers/builtin/include/mbedtls/config_adjust_psa_superset_legacy.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_psa_superset_legacy.h
@@ -1,1 +1,0 @@
-#include "private/config_adjust_psa_superset_legacy.h"

--- a/drivers/builtin/include/mbedtls/config_adjust_test_accelerators.h
+++ b/drivers/builtin/include/mbedtls/config_adjust_test_accelerators.h
@@ -1,1 +1,0 @@
-#include "private/config_adjust_test_accelerators.h"

--- a/drivers/builtin/include/mbedtls/config_psa.h
+++ b/drivers/builtin/include/mbedtls/config_psa.h
@@ -1,1 +1,0 @@
-#include "private/config_psa.h"

--- a/drivers/builtin/include/mbedtls/ctr_drbg.h
+++ b/drivers/builtin/include/mbedtls/ctr_drbg.h
@@ -1,1 +1,0 @@
-#include "private/ctr_drbg.h"

--- a/drivers/builtin/include/mbedtls/des.h
+++ b/drivers/builtin/include/mbedtls/des.h
@@ -1,1 +1,0 @@
-#include "private/des.h"

--- a/drivers/builtin/include/mbedtls/ecdh.h
+++ b/drivers/builtin/include/mbedtls/ecdh.h
@@ -1,1 +1,0 @@
-#include "private/ecdh.h"

--- a/drivers/builtin/include/mbedtls/ecdsa.h
+++ b/drivers/builtin/include/mbedtls/ecdsa.h
@@ -1,1 +1,0 @@
-#include "private/ecdsa.h"

--- a/drivers/builtin/include/mbedtls/ecjpake.h
+++ b/drivers/builtin/include/mbedtls/ecjpake.h
@@ -1,1 +1,0 @@
-#include "private/ecjpake.h"

--- a/drivers/builtin/include/mbedtls/ecp.h
+++ b/drivers/builtin/include/mbedtls/ecp.h
@@ -1,1 +1,0 @@
-#include "private/ecp.h"

--- a/drivers/builtin/include/mbedtls/entropy.h
+++ b/drivers/builtin/include/mbedtls/entropy.h
@@ -1,1 +1,0 @@
-#include "private/entropy.h"

--- a/drivers/builtin/include/mbedtls/error_common.h
+++ b/drivers/builtin/include/mbedtls/error_common.h
@@ -1,1 +1,0 @@
-#include "private/error_common.h"

--- a/drivers/builtin/include/mbedtls/gcm.h
+++ b/drivers/builtin/include/mbedtls/gcm.h
@@ -1,1 +1,0 @@
-#include "private/gcm.h"

--- a/drivers/builtin/include/mbedtls/hmac_drbg.h
+++ b/drivers/builtin/include/mbedtls/hmac_drbg.h
@@ -1,1 +1,0 @@
-#include "private/hmac_drbg.h"

--- a/drivers/builtin/include/mbedtls/md5.h
+++ b/drivers/builtin/include/mbedtls/md5.h
@@ -1,1 +1,0 @@
-#include "private/md5.h"

--- a/drivers/builtin/include/mbedtls/pkcs5.h
+++ b/drivers/builtin/include/mbedtls/pkcs5.h
@@ -1,1 +1,0 @@
-#include "private/pkcs5.h"

--- a/drivers/builtin/include/mbedtls/poly1305.h
+++ b/drivers/builtin/include/mbedtls/poly1305.h
@@ -1,1 +1,0 @@
-#include "private/poly1305.h"

--- a/drivers/builtin/include/mbedtls/ripemd160.h
+++ b/drivers/builtin/include/mbedtls/ripemd160.h
@@ -1,1 +1,0 @@
-#include "private/ripemd160.h"

--- a/drivers/builtin/include/mbedtls/rsa.h
+++ b/drivers/builtin/include/mbedtls/rsa.h
@@ -1,1 +1,0 @@
-#include "private/rsa.h"

--- a/drivers/builtin/include/mbedtls/sha1.h
+++ b/drivers/builtin/include/mbedtls/sha1.h
@@ -1,1 +1,0 @@
-#include "private/sha1.h"

--- a/drivers/builtin/include/mbedtls/sha256.h
+++ b/drivers/builtin/include/mbedtls/sha256.h
@@ -1,1 +1,0 @@
-#include "private/sha256.h"

--- a/drivers/builtin/include/mbedtls/sha3.h
+++ b/drivers/builtin/include/mbedtls/sha3.h
@@ -1,1 +1,0 @@
-#include "private/sha3.h"

--- a/drivers/builtin/include/mbedtls/sha512.h
+++ b/drivers/builtin/include/mbedtls/sha512.h
@@ -1,1 +1,0 @@
-#include "private/sha512.h"


### PR DESCRIPTION
## Description

Fixes https://github.com/Mbed-TLS/mbedtls/issues/10087

This PR removes the transitional headers, used in the aforementioned PR series.


## PR checklist

- [X] **changelog** not required 
- [x] **framework PR** not required: already merged
- [X] **mbedtls development PR** provided Mbed-TLS/mbedtls#10224
- [X] **mbedtls 3.6 PR** not required because: no backport required 
- **tests** this PR is only removing transitional headers, the CI is the testing 