### PR TITLE
Remove DES test cases from test_suite_pkparse.data (Issue #374)

### DIFF
--- a/tests/suites/test_suite_pkparse.data
+++ b/tests/suites/test_suite_pkparse.data
@@ -10,14 +10,6 @@ Parse RSA Key #3 (Wrong password)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_AES_C
 pk_parse_keyfile_rsa:"../framework/data_files/test-ca.key":"PolarSSLWRONG":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #4 (DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_1024_des.pem":"testkey":0
-
-Parse RSA Key #5 (3DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_1024_3des.pem":"testkey":0
-
 Parse RSA Key #6 (AES-128 Encrypted)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_AES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_1024_aes128.pem":"testkey":0
@@ -30,14 +22,6 @@ Parse RSA Key #8 (AES-256 Encrypted)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_AES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_1024_aes256.pem":"testkey":0
 
-Parse RSA Key #9 (2048-bit, DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_2048_des.pem":"testkey":0
-
-Parse RSA Key #10 (2048-bit, 3DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_2048_3des.pem":"testkey":0
-
 Parse RSA Key #11 (2048-bit, AES-128 Encrypted)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_AES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_2048_aes128.pem":"testkey":0
@@ -49,14 +33,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_2048_aes192.pem":"testke
 Parse RSA Key #13 (2048-bit, AES-256 Encrypted)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_AES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_2048_aes256.pem":"testkey":0
-
-Parse RSA Key #14 (4096-bit, DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_4096_des.pem":"testkey":0
-
-Parse RSA Key #15 (4096-bit, 3DES Encrypted)
-depends_on:PSA_WANT_ALG_MD5:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs1_4096_3des.pem":"testkey":0
 
 Parse RSA Key #16 (4096-bit, AES-128 Encrypted)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_AES_C:MBEDTLS_PEM_PARSE_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -74,10 +50,6 @@ Parse RSA Key #19 (PKCS#8 wrapped)
 depends_on:PSA_WANT_ALG_MD5:MBEDTLS_PEM_PARSE_C
 pk_parse_keyfile_rsa:"../framework/data_files/format_gen.key":"":0
 
-Parse RSA Key #38 (PKCS#8 encrypted v2 PBKDF2 3DES)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.pem":"PolarSSLTest":0
-
 Parse RSA Key #38.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc.pem":"PolarSSLTest":0
@@ -89,10 +61,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #38.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.pem":"PolarSSLTest":0
-
-Parse RSA Key #38.1 (PKCS#8 encrypted v2 PBKDF2 3DES, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #38.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -106,10 +74,6 @@ Parse RSA Key #38.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #38.2 (PKCS#8 encrypted v2 PBKDF2 3DES, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #38.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -121,10 +85,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #38.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #39 (PKCS#8 encrypted v2 PBKDF2 3DES, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.pem":"PolarSSLTest":0
 
 Parse RSA Key #39.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -138,10 +98,6 @@ Parse RSA Key #39.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.pem":"PolarSSLTest":0
 
-Parse RSA Key #39.1 (PKCS#8 encrypted v2 PBKDF2 3DES, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #39.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -153,10 +109,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #39.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #39.2 (PKCS#8 encrypted v2 PBKDF2 3DES, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
 Parse RSA Key #39.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -170,10 +122,6 @@ Parse RSA Key #39.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
-Parse RSA Key #40 (PKCS#8 encrypted v2 PBKDF2 3DES, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.pem":"PolarSSLTest":0
-
 Parse RSA Key #40.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc.pem":"PolarSSLTest":0
@@ -185,10 +133,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #40.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.pem":"PolarSSLTest":0
-
-Parse RSA Key #40.1 (PKCS#8 encrypted v2 PBKDF2 3DES, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #40.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -202,10 +146,6 @@ Parse RSA Key #40.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #40.2 (PKCS#8 encrypted v2 PBKDF2 3DES, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #40.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -217,10 +157,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #40.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #41 (PKCS#8 encrypted v2 PBKDF2 3DES DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.der":"PolarSSLTest":0
 
 Parse RSA Key #41.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -234,10 +170,6 @@ Parse RSA Key #41.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.der":"PolarSSLTest":0
 
-Parse RSA Key #41.1 (PKCS#8 encrypted v2 PBKDF2 3DES DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #41.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -249,10 +181,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #41.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #41.2 (PKCS#8 encrypted v2 PBKDF2 3DES DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #41.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -266,10 +194,6 @@ Parse RSA Key #41.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #42 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.der":"PolarSSLTest":0
-
 Parse RSA Key #42.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc.der":"PolarSSLTest":0
@@ -281,10 +205,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #42.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.der":"PolarSSLTest":0
-
-Parse RSA Key #42.1 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #42.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -298,10 +218,6 @@ Parse RSA Key #42.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 2048-bit, wrong
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #42.2 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #42.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -313,10 +229,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #42.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #43 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.der":"PolarSSLTest":0
 
 Parse RSA Key #43.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -330,10 +242,6 @@ Parse RSA Key #43.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.der":"PolarSSLTest":0
 
-Parse RSA Key #43.1 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #43.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -345,10 +253,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #43.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #43.2 (PKCS#8 encrypted v2 PBKDF2 3DES DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #43.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -362,82 +266,6 @@ Parse RSA Key #43.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC DER, 4096-bit, no PW
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #44 (PKCS#8 encrypted v2 PBKDF2 DES)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.pem":"PolarSSLTest":0
-
-Parse RSA Key #44.1 (PKCS#8 encrypted v2 PBKDF2 DES, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #44.2 (PKCS#8 encrypted v2 PBKDF2 DES, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #45 (PKCS#8 encrypted v2 PBKDF2 DES, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.pem":"PolarSSLTest":0
-
-Parse RSA Key #45.1 (PKCS#8 encrypted v2 PBKDF2 DES, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #45.2 (PKCS#8 encrypted v2 PBKDF2 DES, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #46 (PKCS#8 encrypted v2 PBKDF2 DES, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.pem":"PolarSSLTest":0
-
-Parse RSA Key #46.1 (PKCS#8 encrypted v2 PBKDF2 DES, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #46.2 (PKCS#8 encrypted v2 PBKDF2 DES, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #47 (PKCS#8 encrypted v2 PBKDF2 DES DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.der":"PolarSSLTest":0
-
-Parse RSA Key #47.1 (PKCS#8 encrypted v2 PBKDF2 DES DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #47.2 (PKCS#8 encrypted v2 PBKDF2 DES DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #48 (PKCS#8 encrypted v2 PBKDF2 DES DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.der":"PolarSSLTest":0
-
-Parse RSA Key #48.1 (PKCS#8 encrypted v2 PBKDF2 DES DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #48.2 (PKCS#8 encrypted v2 PBKDF2 DES DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #49 (PKCS#8 encrypted v2 PBKDF2 DES DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.der":"PolarSSLTest":0
-
-Parse RSA Key #49.1 (PKCS#8 encrypted v2 PBKDF2 DES DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #49.2 (PKCS#8 encrypted v2 PBKDF2 DES DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_1:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #50 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.pem":"PolarSSLTest":0
-
 Parse RSA Key #50.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha224.pem":"PolarSSLTest":0
@@ -449,10 +277,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #50.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.pem":"PolarSSLTest":0
-
-Parse RSA Key #50.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #50.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -466,10 +290,6 @@ Parse RSA Key #50.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, wron
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #50.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #50.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -481,10 +301,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #50.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #51 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.pem":"PolarSSLTest":0
 
 Parse RSA Key #51.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -498,10 +314,6 @@ Parse RSA Key #51.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.pem":"PolarSSLTest":0
 
-Parse RSA Key #51.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #51.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -513,10 +325,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #51.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #51.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
 Parse RSA Key #51.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -530,10 +338,6 @@ Parse RSA Key #51.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
-Parse RSA Key #52 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.pem":"PolarSSLTest":0
-
 Parse RSA Key #52.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha224.pem":"PolarSSLTest":0
@@ -545,10 +349,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #52.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.pem":"PolarSSLTest":0
-
-Parse RSA Key #52.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #52.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -562,10 +362,6 @@ Parse RSA Key #52.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 4096
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #52.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #52.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -577,10 +373,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #52.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #53 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.der":"PolarSSLTest":0
 
 Parse RSA Key #53.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -594,10 +386,6 @@ Parse RSA Key #53.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.der":"PolarSSLTest":0
 
-Parse RSA Key #53.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #53.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -609,10 +397,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #53.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #53.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #53.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -626,10 +410,6 @@ Parse RSA Key #53.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #54 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.der":"PolarSSLTest":0
-
 Parse RSA Key #54.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha224.der":"PolarSSLTest":0
@@ -641,10 +421,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #54.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.der":"PolarSSLTest":0
-
-Parse RSA Key #54.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #54.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -658,10 +434,6 @@ Parse RSA Key #54.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #54.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #54.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -673,10 +445,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #54.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #55 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.der":"PolarSSLTest":0
 
 Parse RSA Key #55.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -690,10 +458,6 @@ Parse RSA Key #55.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.der":"PolarSSLTest":0
 
-Parse RSA Key #55.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #55.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -705,10 +469,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #55.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #55.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA224 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #55.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA224 DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -722,82 +482,6 @@ Parse RSA Key #55.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA224 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #56 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.pem":"PolarSSLTest":0
-
-Parse RSA Key #56.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #56.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #57 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.pem":"PolarSSLTest":0
-
-Parse RSA Key #57.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #57.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #58 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.pem":"PolarSSLTest":0
-
-Parse RSA Key #58.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #58.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #59 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.der":"PolarSSLTest":0
-
-Parse RSA Key #59.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #59.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #60 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.der":"PolarSSLTest":0
-
-Parse RSA Key #60.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #60.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #61 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.der":"PolarSSLTest":0
-
-Parse RSA Key #61.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #61.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA224 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_224:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha224.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #62 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.pem":"PolarSSLTest":0
-
 Parse RSA Key #62.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha256.pem":"PolarSSLTest":0
@@ -809,10 +493,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #62.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.pem":"PolarSSLTest":0
-
-Parse RSA Key #62.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #62.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -826,10 +506,6 @@ Parse RSA Key #62.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, wron
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #62.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #62.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -841,10 +517,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #62.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #63 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.pem":"PolarSSLTest":0
 
 Parse RSA Key #63.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -858,10 +530,6 @@ Parse RSA Key #63.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.pem":"PolarSSLTest":0
 
-Parse RSA Key #63.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #63.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -873,10 +541,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #63.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #63.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
 Parse RSA Key #63.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -890,10 +554,6 @@ Parse RSA Key #63.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
-Parse RSA Key #64 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.pem":"PolarSSLTest":0
-
 Parse RSA Key #64.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha256.pem":"PolarSSLTest":0
@@ -905,10 +565,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #64.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.pem":"PolarSSLTest":0
-
-Parse RSA Key #64.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #64.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -922,10 +578,6 @@ Parse RSA Key #64.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 4096
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #64.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #64.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -937,10 +589,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #64.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #65 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.der":"PolarSSLTest":0
 
 Parse RSA Key #65.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -954,10 +602,6 @@ Parse RSA Key #65.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.der":"PolarSSLTest":0
 
-Parse RSA Key #65.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #65.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -969,10 +613,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #65.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #65.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #65.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -986,10 +626,6 @@ Parse RSA Key #65.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #66 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.der":"PolarSSLTest":0
-
 Parse RSA Key #66.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha256.der":"PolarSSLTest":0
@@ -1001,10 +637,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #66.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.der":"PolarSSLTest":0
-
-Parse RSA Key #66.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #66.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -1018,10 +650,6 @@ Parse RSA Key #66.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #66.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #66.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -1033,10 +661,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #66.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #67 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.der":"PolarSSLTest":0
 
 Parse RSA Key #67.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1050,10 +674,6 @@ Parse RSA Key #67.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.der":"PolarSSLTest":0
 
-Parse RSA Key #68.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #68.2 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1065,10 +685,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #68.4 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #68.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA256 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #68.5 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA256 DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1082,82 +698,6 @@ Parse RSA Key #68.7 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA256 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #69 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.pem":"PolarSSLTest":0
-
-Parse RSA Key #69.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #69.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #70 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.pem":"PolarSSLTest":0
-
-Parse RSA Key #70.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #70.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #71 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.pem":"PolarSSLTest":0
-
-Parse RSA Key #71.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #71.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #72 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.der":"PolarSSLTest":0
-
-Parse RSA Key #72.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #72.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #73 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.der":"PolarSSLTest":0
-
-Parse RSA Key #73.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #73.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #74 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.der":"PolarSSLTest":0
-
-Parse RSA Key #74.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #74.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA256 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_256:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha256.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #75 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.pem":"PolarSSLTest":0
-
 Parse RSA Key #75.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha384.pem":"PolarSSLTest":0
@@ -1169,10 +709,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #75.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.pem":"PolarSSLTest":0
-
-Parse RSA Key #75.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #75.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -1186,10 +722,6 @@ Parse RSA Key #75.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, wron
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #75.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #75.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -1201,10 +733,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #75.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #76 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.pem":"PolarSSLTest":0
 
 Parse RSA Key #76.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1218,10 +746,6 @@ Parse RSA Key #76.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.pem":"PolarSSLTest":0
 
-Parse RSA Key #76.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #76.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1233,10 +757,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #76.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #76.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
 Parse RSA Key #76.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -1250,10 +770,6 @@ Parse RSA Key #76.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
-Parse RSA Key #77 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.pem":"PolarSSLTest":0
-
 Parse RSA Key #77.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha384.pem":"PolarSSLTest":0
@@ -1265,10 +781,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #77.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.pem":"PolarSSLTest":0
-
-Parse RSA Key #77.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #77.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1282,10 +794,6 @@ Parse RSA Key #77.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 4096
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #77.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #77.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -1297,10 +805,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #77.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #78 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.der":"PolarSSLTest":0
 
 Parse RSA Key #78.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1314,10 +818,6 @@ Parse RSA Key #78.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.der":"PolarSSLTest":0
 
-Parse RSA Key #78.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #78.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1329,10 +829,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #78.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #78.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #78.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -1346,10 +842,6 @@ Parse RSA Key #78.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #79 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.der":"PolarSSLTest":0
-
 Parse RSA Key #79.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha384.der":"PolarSSLTest":0
@@ -1361,10 +853,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #79.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.der":"PolarSSLTest":0
-
-Parse RSA Key #79.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #79.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -1378,10 +866,6 @@ Parse RSA Key #79.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #79.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #79.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -1393,10 +877,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #79.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #80 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.der":"PolarSSLTest":0
 
 Parse RSA Key #80.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1410,10 +890,6 @@ Parse RSA Key #80.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.der":"PolarSSLTest":0
 
-Parse RSA Key #80.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #80.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1425,10 +901,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #80.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #80.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA384 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #80.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA384 DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1442,82 +914,6 @@ Parse RSA Key #80.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA384 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #81 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.pem":"PolarSSLTest":0
-
-Parse RSA Key #81.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #81.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #82 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.pem":"PolarSSLTest":0
-
-Parse RSA Key #82.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #82.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #83 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.pem":"PolarSSLTest":0
-
-Parse RSA Key #83.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #83.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #84 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.der":"PolarSSLTest":0
-
-Parse RSA Key #84.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #85.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #86 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.der":"PolarSSLTest":0
-
-Parse RSA Key #86.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #86.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #87 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.der":"PolarSSLTest":0
-
-Parse RSA Key #87.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #87.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA384 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_384:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #88 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.pem":"PolarSSLTest":0
-
 Parse RSA Key #88.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha512.pem":"PolarSSLTest":0
@@ -1529,10 +925,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #88.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.pem":"PolarSSLTest":0
-
-Parse RSA Key #88.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #88.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -1546,10 +938,6 @@ Parse RSA Key #88.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, wron
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #88.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #88.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -1561,10 +949,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #88.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #89 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.pem":"PolarSSLTest":0
 
 Parse RSA Key #89.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1578,10 +962,6 @@ Parse RSA Key #89.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.pem":"PolarSSLTest":0
 
-Parse RSA Key #89.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #89.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1593,10 +973,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #89.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #89.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
 Parse RSA Key #89.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -1610,10 +986,6 @@ Parse RSA Key #89.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 2048
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
 
-Parse RSA Key #90 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.pem":"PolarSSLTest":0
-
 Parse RSA Key #90.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha512.pem":"PolarSSLTest":0
@@ -1625,10 +997,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #90.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.pem":"PolarSSLTest":0
-
-Parse RSA Key #90.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #90.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1642,10 +1010,6 @@ Parse RSA Key #90.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 4096
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #90.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
 Parse RSA Key #90.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
@@ -1657,10 +1021,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #90.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #91 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.der":"PolarSSLTest":0
 
 Parse RSA Key #91.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1674,10 +1034,6 @@ Parse RSA Key #91.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.der":"PolarSSLTest":0
 
-Parse RSA Key #91.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #91.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes128cbc_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1689,10 +1045,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes192
 Parse RSA Key #91.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #91.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_3des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 Parse RSA Key #91.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
@@ -1706,10 +1058,6 @@ Parse RSA Key #91.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_aes256cbc_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
-Parse RSA Key #92 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.der":"PolarSSLTest":0
-
 Parse RSA Key #92.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha512.der":"PolarSSLTest":0
@@ -1721,10 +1069,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #92.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 2048-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.der":"PolarSSLTest":0
-
-Parse RSA Key #92.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
 Parse RSA Key #92.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 2048-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -1738,10 +1082,6 @@ Parse RSA Key #92.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #92.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_3des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #92.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes128cbc_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -1753,10 +1093,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes192
 Parse RSA Key #92.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 2048-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_aes256cbc_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #93 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.der":"PolarSSLTest":0
 
 Parse RSA Key #93.1 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 4096-bit)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
@@ -1770,10 +1106,6 @@ Parse RSA Key #93.3 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.der":"PolarSSLTest":0
 
-Parse RSA Key #93.1 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
 Parse RSA Key #93.4 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 4096-bit, wrong PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
@@ -1786,10 +1118,6 @@ Parse RSA Key #93.6 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
 
-Parse RSA Key #93.2 (PKCS#8 encrypted v2 PBKDF2 3DES hmacWithSHA512 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_3des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
 Parse RSA Key #93.7 (PKCS#8 encrypted v2 PBKDF2 AES-128-CBC hmacWithSHA512 DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes128cbc_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
@@ -1801,78 +1129,6 @@ pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes192
 Parse RSA Key #93.9 (PKCS#8 encrypted v2 PBKDF2 AES-256-CBC hmacWithSHA512 DER, 4096-bit, no PW)
 depends_on:MBEDTLS_AES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
 pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_aes256cbc_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #94 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.pem":"PolarSSLTest":0
-
-Parse RSA Key #94.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #94.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #95 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.pem":"PolarSSLTest":0
-
-Parse RSA Key #95.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #95.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #96 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.pem":"PolarSSLTest":0
-
-Parse RSA Key #96.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.pem":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #96.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PEM_PARSE_C:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.pem":"":MBEDTLS_ERR_PK_PASSWORD_REQUIRED
-
-Parse RSA Key #97 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.der":"PolarSSLTest":0
-
-Parse RSA Key #97.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #97.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_1024_des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #98 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 2048-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.der":"PolarSSLTest":0
-
-Parse RSA Key #98.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 2048-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #98.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 2048-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_2048_des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Parse RSA Key #99 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 4096-bit)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.der":"PolarSSLTest":0
-
-Parse RSA Key #99.1 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 4096-bit, wrong PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.der":"PolarSSLTes":MBEDTLS_ERR_PK_PASSWORD_MISMATCH
-
-Parse RSA Key #99.2 (PKCS#8 encrypted v2 PBKDF2 DES hmacWithSHA512 DER, 4096-bit, no PW)
-depends_on:MBEDTLS_DES_C:PSA_WANT_ALG_SHA_512:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C:MBEDTLS_TEST_PK_ALLOW_RSA_KEY_PAIR_4096
-pk_parse_keyfile_rsa:"../framework/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha512.der":"":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
 
 # Test keys with non-word-aligned sizes.
 # We use sizes that are large enough to exercise PKCS#1 v1.5 signature with
@@ -1997,10 +1253,6 @@ pk_parse_keyfile_ec:"../framework/data_files/ec_prv.sec1.pem":"NULL":0
 Parse EC Key #2a (SEC1 PEM, secp192r1, compressed)
 depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_PK_PARSE_EC_COMPRESSED:MBEDTLS_ECP_DP_SECP192R1_ENABLED
 pk_parse_keyfile_ec:"../framework/data_files/ec_prv.sec1.comp.pem":"NULL":0
-
-Parse EC Key #3 (SEC1 PEM encrypted)
-depends_on:MBEDTLS_DES_C:MBEDTLS_PEM_PARSE_C:PSA_WANT_ECC_SECP_R1_192:MBEDTLS_CIPHER_MODE_CBC:PSA_WANT_ALG_MD5
-pk_parse_keyfile_ec:"../framework/data_files/ec_prv.sec1.pw.pem":"polar":0
 
 Parse EC Key #4 (PKCS8 DER)
 depends_on:PSA_WANT_ECC_SECP_R1_192
@@ -2136,10 +1388,6 @@ pk_parse_key:"3051020101300506032b656e04220420b06d829655543a51cba36e53522bc0acfd
 Key ASN1 (OneAsymmetricKey X25519, unsupported version 2 with public key and unsupported attributes)
 depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:PSA_WANT_ECC_MONTGOMERY_255
 pk_parse_key:"3072020101300506032b656e04220420b06d829655543a51cba36e53522bc0acfd60af59466555fb3e1e796872ab1a59a01f301d060a2a864886f70d01090914310f0c0d437572646c65204368616972738121009bc3b0e93d8233fe6a8ba6138948cc12a91362d5c2ed81584db05ab5419c9d11":MBEDTLS_ERR_PK_KEY_INVALID_FORMAT
-
-Key ASN1 (Encrypted key PKCS5, trailing garbage data)
-depends_on:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY:PSA_WANT_ECC_MONTGOMERY_255:PSA_WANT_ALG_SHA_1:MBEDTLS_CIPHER_C:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_PKCS5_C:MBEDTLS_CIPHER_C
-pk_parse_key_encrypted:"307C304006092A864886F70D01050D3033301B06092A864886F70D01050C300E04082ED7F24A1D516DD702020800301406082A864886F70D030704088A4FCC9DCC3949100438AD100BAC552FD0AE70BECAFA60F5E519B6180C77E8DB0B9ECC6F23FEDD30AB9BDCA2AF9F97BC470FC3A82DCA2364E22642DE0AF9275A82CB":"AAAAAAAAAAAAAAAAAA":MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT, MBEDTLS_ERR_ASN1_LENGTH_MISMATCH)
 
 # From RFC8410 Appendix A but made into version 0
 OneAsymmetricKey X25519, doesn't match masking requirements #1


### PR DESCRIPTION
## Description
This PR completes Issue #374.

Remove DES test cases from `test_suite_pkparse.data` now that [#409](https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/409) has been [completed](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/417).

## PR checklist
- [ ] **changelog** not required because this only removes redundant test cases.
- [ ] **framework PR** not required because this PR does not touch the Framework submodule.
- [ ] **mbedtls development PR** not required because the pkparse DES cases are only in TF-PSA-Crypto.
- [ ] **mbedtls 3.6 PR** not required because DES is not being removed in 3.6.
- **tests** not required because this PR only removes obsolete tests (covered by AES equivalents).