### PR TITLE
Return int from platform mutex_init 

### DIFF
--- a/ChangeLog.d/threading.txt
+++ b/ChangeLog.d/threading.txt
@@ -1,0 +1,10 @@
+Features
+   * The threading platform abstraction now exposes condition variables
+     in addition to mutexes.
+
+Requirement changes
+   * Implementations of MBEDTLS_THREADING_ALT must now provide condition
+     variables in addition to mutexes. Furthermore, the type of mutex
+     objects provided by the platform functions is now called
+     mbedtls_platform_mutex_t, distinct from the API type
+     mbedtls_threading_mutex_t.

--- a/ChangeLog.d/threading.txt
+++ b/ChangeLog.d/threading.txt
@@ -4,7 +4,9 @@ Features
 
 Requirement changes
    * Implementations of MBEDTLS_THREADING_ALT must now provide condition
-     variables in addition to mutexes. Furthermore, the type of mutex
-     objects provided by the platform functions is now called
-     mbedtls_platform_mutex_t, distinct from the API type
-     mbedtls_threading_mutex_t.
+     variables in addition to mutexes. The mutex functions have changed
+     in minor ways:
+     - The type of mutex objects provided by the platform functions is
+       now called mbedtls_platform_mutex_t, distinct from the API type
+       mbedtls_threading_mutex_t.
+     - The mutex_init function now returns an error code.

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -69,6 +69,7 @@
 #include "mbedtls/private/sha512.h"
 #include "psa_util_internal.h"
 #include "mbedtls/threading.h"
+#include "threading_internal.h"
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF) ||          \
     defined(MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT) ||  \

--- a/core/psa_crypto_slot_management.c
+++ b/core/psa_crypto_slot_management.c
@@ -22,6 +22,7 @@
 #include "mbedtls/platform.h"
 #if defined(MBEDTLS_THREADING_C)
 #include "mbedtls/threading.h"
+#include "threading_internal.h"
 #endif
 
 

--- a/docs/4.0-migration-guide/threading.md
+++ b/docs/4.0-migration-guide/threading.md
@@ -1,18 +1,24 @@
 ## Threading platform abstraction
 
-The threading abstraction now includes primitives for condition variables in addition to mutexes.
+### Extension to condition variables
 
-The type of mutex objects provided by the platform functions is now called `mbedtls_platform_mutex_t`, distinct from the API type `mbedtls_threading_mutex_t`.
+The threading abstraction now includes primitives for condition variables in addition to mutexes.
 
 As before, implementations of `MBEDTLS_THREADING_ALT` need to provide a header file `"threading_alt.h"`, and to call the function `mbedtls_threading_set_alt()` before any call to other TF-PSA-Crypto or Mbed TLS functions. The header file `"threading_alt.h"` now needs to define the following elements:
 
 * The type `mbedtls_platform_mutex_t`, which is the type of mutex arguments passed to the platform functions. This type is now distinct from the type `mbedtls_threading_mutex_t` which library code and applications use.
 * The type `mbedtls_platform_condition_variable_t`, which is the type of condition variable arguments passed to the platform functions.
 
-The documentation in `include/mbedtls/threading.h` now clarifies the expectations on mutex primitives. These expectations are unchanged from what they were in previous versions, they have just been made explicit.
+### Changes to the mutex primitives
+
+The type of mutex objects provided by the platform functions is now called `mbedtls_platform_mutex_t`, distinct from the API type `mbedtls_threading_mutex_t`.
+
+The documentation in `include/mbedtls/threading.h` now clarifies the expectations on mutex primitives. These expectations are slightly changed from the mostly undocumented expectations in previous versions.
 
 Platform threading primitives should now return the following error codes:
 
 * `MBEDTLS_ERR_THREADING_USAGE_ERROR` to report a runtime failure (renamed from `MBEDTLS_ERR_THREADING_MUTEX_ERROR`, which is now an alias provided only for backward compatibility).
 * `PSA_ERROR_BAD_STATE` only to report a library state error. If an error is detected in the state of a synchronization object, please return `MBEDTLS_ERR_THREADING_USAGE_ERROR` instead.
 * `PSA_ERROR_INSUFFICIENT_MEMORY` to report resource exhaustion.
+
+The `mutex_init` primitive now returns a status code instead of `void`.

--- a/docs/4.0-migration-guide/threading.md
+++ b/docs/4.0-migration-guide/threading.md
@@ -9,7 +9,7 @@ As before, implementations of `MBEDTLS_THREADING_ALT` need to provide a header f
 * The type `mbedtls_platform_mutex_t`, which is the type of mutex arguments passed to the platform functions. This type is now distinct from the type `mbedtls_threading_mutex_t` which library code and applications use.
 * The type `mbedtls_platform_condition_variable_t`, which is the type of condition variable arguments passed to the platform functions.
 
-The documentation in `include/mbedtls/threading.h` now clarifies the expecations on mutex primitives. These expectations are unchanged from what they were in previous versions, they have just been made explicit.
+The documentation in `include/mbedtls/threading.h` now clarifies the expectations on mutex primitives. These expectations are unchanged from what they were in previous versions, they have just been made explicit.
 
 Platform threading primitives should now return the following error codes:
 

--- a/docs/4.0-migration-guide/threading.md
+++ b/docs/4.0-migration-guide/threading.md
@@ -1,0 +1,18 @@
+## Threading platform abstraction
+
+The threading abstraction now includes primitives for condition variables in addition to mutexes.
+
+The type of mutex objects provided by the platform functions is now called `mbedtls_platform_mutex_t`, distinct from the API type `mbedtls_threading_mutex_t`.
+
+As before, implementations of `MBEDTLS_THREADING_ALT` need to provide a header file `"threading_alt.h"`, and to call the function `mbedtls_threading_set_alt()` before any call to other TF-PSA-Crypto or Mbed TLS functions. The header file `"threading_alt.h"` now needs to define the following elements:
+
+* The type `mbedtls_platform_mutex_t`, which is the type of mutex arguments passed to the platform functions. This type is now distinct from the type `mbedtls_threading_mutex_t` which library code and applications use.
+* The type `mbedtls_platform_condition_variable_t`, which is the type of condition variable arguments passed to the platform functions.
+
+The documentation in `include/mbedtls/threading.h` now clarifies the expecations on mutex primitives. These expectations are unchanged from what they were in previous versions, they have just been made explicit.
+
+Platform threading primitives should now return the following error codes:
+
+* `MBEDTLS_ERR_THREADING_USAGE_ERROR` to report a runtime failure (renamed from `MBEDTLS_ERR_THREADING_MUTEX_ERROR`, which is now an alias provided only for backward compatibility).
+* `PSA_ERROR_BAD_STATE` only to report a library state error. If an error is detected in the state of a synchronization object, please return `MBEDTLS_ERR_THREADING_USAGE_ERROR` instead.
+* `PSA_ERROR_INSUFFICIENT_MEMORY` to report resource exhaustion.

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -62,15 +62,10 @@ static int err_from_posix(int posix_ret)
     }
 }
 
-static void threading_mutex_init_pthread(mbedtls_platform_mutex_t *mutex)
+static int threading_mutex_init_pthread(mbedtls_platform_mutex_t *mutex)
 {
-    /* One problem here is that calling lock on a pthread mutex without first
-     * having initialised it is undefined behaviour. Obviously we cannot check
-     * this here in a thread safe manner without a significant performance
-     * hit, so state transitions are checked in tests only via the state
-     * variable. Please make sure any new mutex that gets added is exercised in
-     * tests; see framework/tests/src/threading_helpers.c for more details. */
-    (void) pthread_mutex_init(mutex, NULL);
+    int posix_ret = pthread_mutex_init(mutex, NULL);
+    return err_from_posix(posix_ret);
 }
 
 static void threading_mutex_free_pthread(mbedtls_platform_mutex_t *mutex)
@@ -90,7 +85,7 @@ static int threading_mutex_unlock_pthread(mbedtls_platform_mutex_t *mutex)
     return err_from_posix(posix_ret);
 }
 
-void (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_init_pthread;
+int (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_init_pthread;
 void (*mbedtls_mutex_free_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_free_pthread;
 int (*mbedtls_mutex_lock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_lock_pthread;
 int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_unlock_pthread;
@@ -98,7 +93,7 @@ int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_un
 /*
  * With pthreads we can statically initialize mutexes
  */
-#define MUTEX_INIT  = { PTHREAD_MUTEX_INITIALIZER, 1 }
+#define MUTEX_INIT  = { PTHREAD_MUTEX_INITIALIZER, 1, 1 }
 
 int mbedtls_condition_variable_init(
     mbedtls_threading_condition_variable_t *cond)
@@ -149,7 +144,7 @@ static void threading_mutex_dummy(mbedtls_platform_mutex_t *mutex)
     return;
 }
 
-void (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_dummy;
+int (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_fail;
 void (*mbedtls_mutex_free_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_dummy;
 int (*mbedtls_mutex_lock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_fail;
 int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_fail;
@@ -158,12 +153,14 @@ int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_fa
 
 void mbedtls_mutex_init(mbedtls_threading_mutex_t *mutex)
 {
-    (*mbedtls_mutex_init_ptr)(&mutex->mutex);
+    int ret = (*mbedtls_mutex_init_ptr)(&mutex->mutex);
+    mutex->initialized = (ret == 0);
 }
 
 void mbedtls_mutex_free(mbedtls_threading_mutex_t *mutex)
 {
     (*mbedtls_mutex_free_ptr)(&mutex->mutex);
+    mutex->initialized = 0;
 }
 
 int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex)
@@ -241,7 +238,7 @@ int mbedtls_condition_variable_wait(
  * Set functions pointers and initialize global mutexes
  */
 void mbedtls_threading_set_alt(
-    void (*mutex_init)(mbedtls_platform_mutex_t *),
+    int (*mutex_init)(mbedtls_platform_mutex_t *),
     void (*mutex_free)(mbedtls_platform_mutex_t *),
     int (*mutex_lock)(mbedtls_platform_mutex_t *),
     int (*mutex_unlock)(mbedtls_platform_mutex_t *),

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -19,6 +19,8 @@
 
 #include "threading_internal.h"
 
+#include <psa/crypto_values.h>
+
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 
 #if !defined(_WIN32) && (defined(unix) || \
@@ -104,7 +106,7 @@ int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_un
 static int threading_mutex_fail(mbedtls_platform_mutex_t *mutex)
 {
     ((void) mutex);
-    return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
+    return PSA_ERROR_BAD_STATE;
 }
 static void threading_mutex_dummy(mbedtls_platform_mutex_t *mutex)
 {

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -50,6 +50,16 @@
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
+static int err_from_posix(int posix_ret)
+{
+    switch (posix_ret) {
+        case 0:
+            return 0;
+        default:
+            return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
+    }
+}
+
 static void threading_mutex_init_pthread(mbedtls_platform_mutex_t *mutex)
 {
     if (mutex == NULL) {
@@ -80,11 +90,8 @@ static int threading_mutex_lock_pthread(mbedtls_platform_mutex_t *mutex)
         return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
     }
 
-    if (pthread_mutex_lock(mutex) != 0) {
-        return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
-    }
-
-    return 0;
+    int posix_ret = pthread_mutex_lock(mutex);
+    return err_from_posix(posix_ret);
 }
 
 static int threading_mutex_unlock_pthread(mbedtls_platform_mutex_t *mutex)
@@ -93,11 +100,8 @@ static int threading_mutex_unlock_pthread(mbedtls_platform_mutex_t *mutex)
         return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
     }
 
-    if (pthread_mutex_unlock(mutex) != 0) {
-        return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
-    }
-
-    return 0;
+    int posix_ret = pthread_mutex_unlock(mutex);
+    return err_from_posix(posix_ret);
 }
 
 void (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *) = threading_mutex_init_pthread;

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -58,7 +58,7 @@ static int err_from_posix(int posix_ret)
         case 0:
             return 0;
         default:
-            return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
+            return MBEDTLS_ERR_THREADING_USAGE_ERROR;
     }
 }
 

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -62,10 +62,6 @@ static int err_from_posix(int posix_ret)
 
 static void threading_mutex_init_pthread(mbedtls_platform_mutex_t *mutex)
 {
-    if (mutex == NULL) {
-        return;
-    }
-
     /* One problem here is that calling lock on a pthread mutex without first
      * having initialised it is undefined behaviour. Obviously we cannot check
      * this here in a thread safe manner without a significant performance
@@ -77,29 +73,17 @@ static void threading_mutex_init_pthread(mbedtls_platform_mutex_t *mutex)
 
 static void threading_mutex_free_pthread(mbedtls_platform_mutex_t *mutex)
 {
-    if (mutex == NULL) {
-        return;
-    }
-
     (void) pthread_mutex_destroy(mutex);
 }
 
 static int threading_mutex_lock_pthread(mbedtls_platform_mutex_t *mutex)
 {
-    if (mutex == NULL) {
-        return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
-    }
-
     int posix_ret = pthread_mutex_lock(mutex);
     return err_from_posix(posix_ret);
 }
 
 static int threading_mutex_unlock_pthread(mbedtls_platform_mutex_t *mutex)
 {
-    if (mutex == NULL) {
-        return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
-    }
-
     int posix_ret = pthread_mutex_unlock(mutex);
     return err_from_posix(posix_ret);
 }

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -24,7 +24,7 @@
  * threading interface was last changed in a way that may impact the
  * test framework, with the lower byte incremented as necessary
  * if multiple changes happened between releases. */
-#define MBEDTLS_THREADING_INTERNAL_VERSION 0x04000000
+#define MBEDTLS_THREADING_INTERNAL_VERSION 0x04000001
 
 #if defined(MBEDTLS_THREADING_C)
 
@@ -34,7 +34,7 @@
  * They are exposed for the sake of the mutex usage verification framework
  * (see framework/tests/src/threading_helpers.c).
  */
-extern void (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *mutex);
+extern int (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *mutex);
 extern void (*mbedtls_mutex_free_ptr)(mbedtls_platform_mutex_t *mutex);
 extern int (*mbedtls_mutex_lock_ptr)(mbedtls_platform_mutex_t *mutex);
 extern int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *mutex);

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -1,7 +1,8 @@
 /**
  * \file threading_internal.h
  *
- * \brief Threading interfaces used by the test framework
+ * \brief Threading interfaces used internally in the library and
+ *        by the test framework.
  */
 /*
  *  Copyright The Mbed TLS Contributors

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -25,16 +25,20 @@
  * if multiple changes happened between releases. */
 #define MBEDTLS_THREADING_INTERNAL_VERSION 0x04000000
 
+#if defined(MBEDTLS_THREADING_C)
+
 /*
  * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
  *
  * They are exposed for the sake of the mutex usage verification framework
  * (see framework/tests/src/threading_helpers.c).
  */
-extern void (*mbedtls_mutex_init_ptr)(mbedtls_threading_mutex_t *mutex);
-extern void (*mbedtls_mutex_free_ptr)(mbedtls_threading_mutex_t *mutex);
-extern int (*mbedtls_mutex_lock_ptr)(mbedtls_threading_mutex_t *mutex);
-extern int (*mbedtls_mutex_unlock_ptr)(mbedtls_threading_mutex_t *mutex);
+extern void (*mbedtls_mutex_init_ptr)(mbedtls_platform_mutex_t *mutex);
+extern void (*mbedtls_mutex_free_ptr)(mbedtls_platform_mutex_t *mutex);
+extern int (*mbedtls_mutex_lock_ptr)(mbedtls_platform_mutex_t *mutex);
+extern int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *mutex);
 
+
+#endif /* MBEDTLS_THREADING_C */
 
 #endif /* MBEDTLS_THREADING_INTERNAL_H */

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -23,6 +23,18 @@
  * threading interface was last changed in a way that may impact the
  * test framework, with the lower byte incremented as necessary
  * if multiple changes happened between releases. */
-#define MBEDTLS_THREADING_INTERNAL_VERSION 0x03060000
+#define MBEDTLS_THREADING_INTERNAL_VERSION 0x04000000
+
+/*
+ * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
+ *
+ * They are exposed for the sake of the mutex usage verification framework
+ * (see framework/tests/src/threading_helpers.c).
+ */
+extern void (*mbedtls_mutex_init_ptr)(mbedtls_threading_mutex_t *mutex);
+extern void (*mbedtls_mutex_free_ptr)(mbedtls_threading_mutex_t *mutex);
+extern int (*mbedtls_mutex_lock_ptr)(mbedtls_threading_mutex_t *mutex);
+extern int (*mbedtls_mutex_unlock_ptr)(mbedtls_threading_mutex_t *mutex);
+
 
 #endif /* MBEDTLS_THREADING_INTERNAL_H */

--- a/drivers/builtin/src/threading_internal.h
+++ b/drivers/builtin/src/threading_internal.h
@@ -38,6 +38,36 @@ extern void (*mbedtls_mutex_free_ptr)(mbedtls_platform_mutex_t *mutex);
 extern int (*mbedtls_mutex_lock_ptr)(mbedtls_platform_mutex_t *mutex);
 extern int (*mbedtls_mutex_unlock_ptr)(mbedtls_platform_mutex_t *mutex);
 
+/*
+ * Global mutexes
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/*
+ * A mutex used to make the PSA subsystem thread safe.
+ *
+ * key_slot_mutex protects the registered_readers and
+ * state variable for all key slots in &global_data.key_slots.
+ *
+ * This mutex must be held when any read from or write to a state or
+ * registered_readers field is performed, i.e. when calling functions:
+ * psa_key_slot_state_transition(), psa_register_read(), psa_unregister_read(),
+ * psa_key_slot_has_readers() and psa_wipe_key_slot(). */
+extern mbedtls_threading_mutex_t mbedtls_threading_key_slot_mutex;
+
+/*
+ * A mutex used to make the non-rng PSA global_data struct members thread safe.
+ *
+ * This mutex must be held when reading or writing to any of the PSA global_data
+ * structure members, other than the rng_state or rng struct. */
+extern mbedtls_threading_mutex_t mbedtls_threading_psa_globaldata_mutex;
+
+/*
+ * A mutex used to make the PSA global_data rng data thread safe.
+ *
+ * This mutex must be held when reading or writing to the PSA
+ * global_data rng_state or rng struct members. */
+extern mbedtls_threading_mutex_t mbedtls_threading_psa_rngdata_mutex;
+#endif
 
 #endif /* MBEDTLS_THREADING_C */
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -144,11 +144,14 @@ void mbedtls_mutex_init(mbedtls_threading_mutex_t *mutex);
  * again on \p mutex.
  *
  * \note            The behavior is undefined if:
- *                  - \p mutex has not been initialized with
- *                    mbedtls_mutex_init();
  *                  - this function is called concurrently on the same
  *                    object from multiple threads;
  *                  - \p mutex is locked.
+ *
+ * \note            This function does nothing if:
+ *                  - \p mutex is all-bits-zero or `{0}`.
+ *                  - The last function called on \p mutex is
+ *                    mbedtls_mutex_free() (i.e. a double free is safe).
  *
  * \param mutex     The mutex to destroy.
  */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -24,23 +24,15 @@ extern "C" {
 /** Locking / unlocking / free failed with error code. */
 #define MBEDTLS_ERR_THREADING_MUTEX_ERROR                 -0x001E
 
+#if defined(MBEDTLS_THREADING_C)
+
 #if defined(MBEDTLS_THREADING_PTHREAD)
 #include <pthread.h>
-typedef struct mbedtls_threading_mutex_t {
-    pthread_mutex_t MBEDTLS_PRIVATE(mutex);
-
-    /* WARNING - state should only be accessed when holding the mutex lock in
-     * framework/tests/src/threading_helpers.c, otherwise corruption can occur.
-     * state will be 0 after a failed init or a free, and nonzero after a
-     * successful init. This field is for testing only and thus not considered
-     * part of the public API of Mbed TLS and may change without notice.*/
-    char MBEDTLS_PRIVATE(state);
-
-} mbedtls_threading_mutex_t;
+typedef pthread_mutex_t mbedtls_platform_mutex_t;
 #endif
 
 #if defined(MBEDTLS_THREADING_ALT)
-/* You should define the mbedtls_threading_mutex_t type in your header */
+/* You should define the mbedtls_platform_mutex_t type in your header */
 #include "threading_alt.h"
 
 /**
@@ -61,10 +53,10 @@ typedef struct mbedtls_threading_mutex_t {
  * \param mutex_lock    the lock function implementation
  * \param mutex_unlock  the unlock function implementation
  */
-void mbedtls_threading_set_alt(void (*mutex_init)(mbedtls_threading_mutex_t *),
-                               void (*mutex_free)(mbedtls_threading_mutex_t *),
-                               int (*mutex_lock)(mbedtls_threading_mutex_t *),
-                               int (*mutex_unlock)(mbedtls_threading_mutex_t *));
+void mbedtls_threading_set_alt(void (*mutex_init)(mbedtls_platform_mutex_t *),
+                               void (*mutex_free)(mbedtls_platform_mutex_t *),
+                               int (*mutex_lock)(mbedtls_platform_mutex_t *),
+                               int (*mutex_unlock)(mbedtls_platform_mutex_t *));
 
 /**
  * \brief               Free global mutexes.
@@ -72,7 +64,18 @@ void mbedtls_threading_set_alt(void (*mutex_init)(mbedtls_threading_mutex_t *),
 void mbedtls_threading_free_alt(void);
 #endif /* MBEDTLS_THREADING_ALT */
 
-#if defined(MBEDTLS_THREADING_C)
+typedef struct mbedtls_threading_mutex_t {
+    mbedtls_platform_mutex_t MBEDTLS_PRIVATE(mutex);
+
+    /* WARNING - state should only be accessed when holding the mutex lock in
+     * framework/tests/src/threading_helpers.c, otherwise corruption can occur.
+     * state will be 0 after a failed init or a free, and nonzero after a
+     * successful init. This field is for testing only and thus not considered
+     * part of the public API of Mbed TLS and may change without notice.*/
+    char MBEDTLS_PRIVATE(state);
+
+} mbedtls_threading_mutex_t;
+
 void mbedtls_mutex_init(mbedtls_threading_mutex_t *mutex);
 void mbedtls_mutex_free(mbedtls_threading_mutex_t *mutex);
 int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex);

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -98,34 +98,6 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
-/*
- * A mutex used to make the PSA subsystem thread safe.
- *
- * key_slot_mutex protects the registered_readers and
- * state variable for all key slots in &global_data.key_slots.
- *
- * This mutex must be held when any read from or write to a state or
- * registered_readers field is performed, i.e. when calling functions:
- * psa_key_slot_state_transition(), psa_register_read(), psa_unregister_read(),
- * psa_key_slot_has_readers() and psa_wipe_key_slot(). */
-extern mbedtls_threading_mutex_t mbedtls_threading_key_slot_mutex;
-
-/*
- * A mutex used to make the non-rng PSA global_data struct members thread safe.
- *
- * This mutex must be held when reading or writing to any of the PSA global_data
- * structure members, other than the rng_state or rng struct. */
-extern mbedtls_threading_mutex_t mbedtls_threading_psa_globaldata_mutex;
-
-/*
- * A mutex used to make the PSA global_data rng data thread safe.
- *
- * This mutex must be held when reading or writing to the PSA
- * global_data rng_state or rng struct members. */
-extern mbedtls_threading_mutex_t mbedtls_threading_psa_rngdata_mutex;
-#endif
-
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -73,15 +73,10 @@ void mbedtls_threading_free_alt(void);
 #endif /* MBEDTLS_THREADING_ALT */
 
 #if defined(MBEDTLS_THREADING_C)
-/*
- * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
- *
- * All these functions are expected to work or the result will be undefined.
- */
-extern void (*mbedtls_mutex_init)(mbedtls_threading_mutex_t *mutex);
-extern void (*mbedtls_mutex_free)(mbedtls_threading_mutex_t *mutex);
-extern int (*mbedtls_mutex_lock)(mbedtls_threading_mutex_t *mutex);
-extern int (*mbedtls_mutex_unlock)(mbedtls_threading_mutex_t *mutex);
+void mbedtls_mutex_init(mbedtls_threading_mutex_t *mutex);
+void mbedtls_mutex_free(mbedtls_threading_mutex_t *mutex);
+int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex);
+int mbedtls_mutex_unlock(mbedtls_threading_mutex_t *mutex);
 
 /*
  * Global mutexes

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -19,8 +19,6 @@
 extern "C" {
 #endif
 
-/** Bad input parameters to function. */
-#define MBEDTLS_ERR_THREADING_BAD_INPUT_DATA              -0x001C
 /** Locking / unlocking / free failed with error code. */
 #define MBEDTLS_ERR_THREADING_MUTEX_ERROR                 -0x001E
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -19,8 +19,17 @@
 extern "C" {
 #endif
 
-/** Locking / unlocking / free failed with error code. */
-#define MBEDTLS_ERR_THREADING_MUTEX_ERROR                 -0x001E
+/** Detected error in mutex or condition variable usage.
+ *
+ * Note that depending on the platform, many usage errors of
+ * synchronization primitives have undefined behavior. But where
+ * it is practical to detect usage errors at runtime, mutex and
+ * condition primitives can return this error code.
+ */
+#define MBEDTLS_ERR_THREADING_USAGE_ERROR                 -0x001E
+
+/** A historical alias for #MBEDTLS_ERR_THREADING_USAGE_ERROR. */
+#define MBEDTLS_ERR_THREADING_MUTEX_ERROR MBEDTLS_ERR_THREADING_USAGE_ERROR
 
 #if defined(MBEDTLS_THREADING_C)
 
@@ -43,7 +52,7 @@ typedef pthread_cond_t mbedtls_platform_condition_variable_t;
  *                  mbedtls_threading_free_alt() must be called once in the main
  *                  thread after all other Mbed TLS functions.
  *
- * \note            Functions should return #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \note            Functions should return #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  if a mutex usage error is detected. However, it is
  *                  acceptable for usage errors to result in undefined behavior
  *                  (including deadlocks and crashes) if detecting usage errors
@@ -150,7 +159,7 @@ void mbedtls_mutex_free(mbedtls_threading_mutex_t *mutex);
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  mbedtls_mutex_init() failed,
  *                  or a mutex usage error was detected.
  *                  Note that depending on the platform, a mutex usage
@@ -181,7 +190,7 @@ int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex);
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  mbedtls_mutex_init() failed,
  *                  or a mutex usage error was detected.
  *                  Note that depending on the platform, a mutex usage
@@ -205,7 +214,7 @@ int mbedtls_mutex_unlock(mbedtls_threading_mutex_t *mutex);
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  The condition variable is already initialized
  *                  (on platforms where this can be detected),
  *                  or an unpecified error occurred.
@@ -249,7 +258,7 @@ void mbedtls_condition_variable_free(
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  A usage error was detected.
  *                  Note that depending on the platform, a condition variable
  *                  usage error may result in a deadlock, a crash or other
@@ -273,7 +282,7 @@ int mbedtls_condition_variable_signal(
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  A usage error was detected.
  *                  Note that depending on the platform, a condition variable
  *                  usage error may result in a deadlock, a crash or other
@@ -306,7 +315,7 @@ int mbedtls_condition_variable_broadcast(
  *
  * \retval 0
  *                  Success.
- * \retval #MBEDTLS_ERR_THREADING_MUTEX_ERROR
+ * \retval #MBEDTLS_ERR_THREADING_USAGE_ERROR
  *                  A usage error was detected.
  *                  Note that depending on the platform, a condition variable
  *                  usage error may result in a deadlock, a crash or other

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -143,6 +143,10 @@ void mbedtls_mutex_free(mbedtls_threading_mutex_t *mutex);
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  *                  There were insufficient resources to initialize or
  *                  lock the mutex.
+ * \retval #PSA_ERROR_BAD_STATE
+ *                  The compilation option #MBEDTLS_THREADING_ALT is
+ *                  enabled, and mbedtls_threading_set_alt() has not
+ *                  been called.
  */
 int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex);
 
@@ -167,6 +171,10 @@ int mbedtls_mutex_lock(mbedtls_threading_mutex_t *mutex);
  *                  Note that depending on the platform, a mutex usage
  *                  error may result in a deadlock, a crash or other
  *                  undesirable behavior instead of returning an error.
+ * \retval #PSA_ERROR_BAD_STATE
+ *                  The compilation option #MBEDTLS_THREADING_ALT is
+ *                  enabled, and mbedtls_threading_set_alt() has not
+ *                  been called.
  */
 int mbedtls_mutex_unlock(mbedtls_threading_mutex_t *mutex);
 

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -406,7 +406,21 @@
 /**
  * \def MBEDTLS_THREADING_ALT
  *
- * Provide your own alternate threading implementation.
+ * Provide your own alternate implementation of threading primitives:
+ * mutexes and condition variables. If you enable this option:
+ *
+ * - Provide a header file `"threading_alt.h"`, defining the following
+ *  elements:
+ *     - The type `mbedtls_platform_mutex_t` of mutex objects.
+ *     - The type `mbedtls_platform_condition_variable_t` of
+ *       condition variable objects.
+ *
+ * - Call the function mbedtls_threading_set_alt() in your application
+ *   before calling any other library function (in particular before
+ *   calling psa_crypto_init()).
+ *
+ * See mbedtls/threading.h for more details, especially the documentation
+ * of mbedtls_threading_set_alt().
  *
  * Requires: MBEDTLS_THREADING_C
  *
@@ -438,11 +452,11 @@
  *
  * Module:  library/threading.c
  *
- * This allows different threading implementations (self-implemented or
- * provided).
+ * This allows different threading implementations (built-in or
+ * provided externally).
  *
- * You will have to enable either MBEDTLS_THREADING_ALT or
- * MBEDTLS_THREADING_PTHREAD.
+ * You will have to enable either #MBEDTLS_THREADING_ALT or
+ * #MBEDTLS_THREADING_PTHREAD.
  *
  * Enable this layer to allow use of mutexes within Mbed TLS
  */

--- a/tests/suites/test_suite_platform_threading.data
+++ b/tests/suites/test_suite_platform_threading.data
@@ -1,0 +1,8 @@
+Mutex usage: init, free
+mutex_usage_nominal:0
+
+Mutex usage: lock 1
+mutex_usage_nominal:1
+
+Mutex usage: lock 2
+mutex_usage_nominal:2

--- a/tests/suites/test_suite_platform_threading.data
+++ b/tests/suites/test_suite_platform_threading.data
@@ -7,6 +7,12 @@ mutex_usage_nominal:1
 Mutex usage: lock 2
 mutex_usage_nominal:2
 
+Mutex usage: no init
+mutex_usage_no_init:
+
+Mutex usage: double free
+mutex_usage_double_free:
+
 Condition variable usage: init, free
 condition_usage_nominal:0
 

--- a/tests/suites/test_suite_platform_threading.data
+++ b/tests/suites/test_suite_platform_threading.data
@@ -6,3 +6,12 @@ mutex_usage_nominal:1
 
 Mutex usage: lock 2
 mutex_usage_nominal:2
+
+Condition variable usage: init, free
+condition_usage_nominal:0
+
+Condition variable usage: signal
+condition_usage_nominal:1
+
+Condition variable usage: broadcast
+condition_usage_nominal:2

--- a/tests/suites/test_suite_platform_threading.function
+++ b/tests/suites/test_suite_platform_threading.function
@@ -1,0 +1,32 @@
+/* BEGIN_HEADER */
+/* Basic tests for the threading interface.
+ */
+
+#include "mbedtls/threading.h"
+
+#include "test/threading_helpers.h"
+
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_THREADING_C
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mutex_usage_nominal(int lock_cycles)
+{
+    mbedtls_threading_mutex_t mutex;
+
+    mbedtls_mutex_init(&mutex);
+
+    for (int i = 0; i < lock_cycles; i++) {
+        mbedtls_test_set_step(i);
+        TEST_EQUAL(mbedtls_mutex_lock(&mutex), 0);
+        TEST_EQUAL(mbedtls_mutex_unlock(&mutex), 0);
+    }
+
+exit:
+    mbedtls_mutex_free(&mutex);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_platform_threading.function
+++ b/tests/suites/test_suite_platform_threading.function
@@ -32,6 +32,38 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
+void mutex_usage_no_init()
+{
+    mbedtls_threading_mutex_t mutex;
+    memset(&mutex, 0, sizeof(mutex));
+
+    TEST_EQUAL(mbedtls_mutex_lock(&mutex), MBEDTLS_ERR_THREADING_USAGE_ERROR);
+    TEST_EQUAL(mbedtls_mutex_unlock(&mutex), MBEDTLS_ERR_THREADING_USAGE_ERROR);
+    mbedtls_mutex_free(&mutex);
+
+exit:
+    mbedtls_mutex_free(&mutex);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void mutex_usage_double_free()
+{
+    mbedtls_threading_mutex_t mutex;
+
+    mbedtls_mutex_init(&mutex);
+    mbedtls_mutex_free(&mutex);
+
+    TEST_EQUAL(mbedtls_mutex_lock(&mutex), MBEDTLS_ERR_THREADING_USAGE_ERROR);
+    TEST_EQUAL(mbedtls_mutex_unlock(&mutex), MBEDTLS_ERR_THREADING_USAGE_ERROR);
+    mbedtls_mutex_free(&mutex);
+
+exit:
+    mbedtls_mutex_free(&mutex);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 /* There is no single-threaded test for wait() on a condition variable
  * because that can't work: wait() blocks until another thread signals,
  * so a minimum of two threads are necessary. */

--- a/tests/suites/test_suite_platform_threading.function
+++ b/tests/suites/test_suite_platform_threading.function
@@ -30,3 +30,34 @@ exit:
     mbedtls_mutex_free(&mutex);
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+/* There is no single-threaded test for wait() on a condition variable
+ * because that can't work: wait() blocks until another thread signals,
+ * so a minimum of two threads are necessary. */
+void condition_usage_nominal(int what)
+{
+    mbedtls_threading_condition_variable_t cond;
+
+    mbedtls_condition_variable_init(&cond);
+
+    switch (what) {
+        case 0:
+            break;
+
+        case 1:
+            TEST_EQUAL(mbedtls_condition_variable_signal(&cond), 0);
+            break;
+
+        case 2:
+            TEST_EQUAL(mbedtls_condition_variable_broadcast(&cond), 0);
+            break;
+
+        default:
+            TEST_FAIL("Unknown thing to do");
+    }
+
+exit:
+    mbedtls_condition_variable_free(&cond);
+}
+/* END_CASE */


### PR DESCRIPTION
Change the platform `mutex_init` function to return an error code. This allows us to keep track of whether a mutex has been initialized, and thus to react safely if mutex initialization failed. This isn't an issue in pthread, but it is one with many other threading implementations. With this change, we don't have to hope that the platform functions are doing this for us.

Continues https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/434.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/205
- [x] **mbedtls development PR** not required because: crypto (platform) only
- [x] **mbedtls 3.6 PR** not required because: new stuff
- **tests**  provided
