### PR TITLE
Fix default -Werror for non-GCC compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,9 +301,9 @@ function(tf_psa_crypto_set_clang_base_compile_options target)
     set_target_properties(${target} PROPERTIES LINK_FLAGS_TSANDBG "-fsanitize=thread")
     target_compile_options(${target} PRIVATE $<$<CONFIG:Check>:-Os>)
 
-    if(MBEDTLS_FATAL_WARNINGS)
+    if(TF_PSA_CRYPTO_FATAL_WARNINGS)
         target_compile_options(${target} PRIVATE -Werror)
-    endif(MBEDTLS_FATAL_WARNINGS)
+    endif(TF_PSA_CRYPTO_FATAL_WARNINGS)
 endfunction(tf_psa_crypto_set_clang_base_compile_options)
 
 function(tf_psa_crypto_set_iar_base_compile_options target)
@@ -311,18 +311,18 @@ function(tf_psa_crypto_set_iar_base_compile_options target)
     target_compile_options(${target} PRIVATE $<$<CONFIG:Release>:-Ohz>)
     target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:--debug -On>)
 
-    if(MBEDTLS_FATAL_WARNINGS)
+    if(TF_PSA_CRYPTO_FATAL_WARNINGS)
         target_compile_options(${target} PRIVATE --warnings_are_errors)
-    endif(MBEDTLS_FATAL_WARNINGS)
+    endif(TF_PSA_CRYPTO_FATAL_WARNINGS)
 endfunction(tf_psa_crypto_set_iar_base_compile_options)
 
 function(tf_psa_crypto_set_msvc_base_compile_options target)
     # Strictest warnings, UTF-8 source and execution charset
     target_compile_options(${target} PRIVATE /W3 /utf-8)
 
-    if(MBEDTLS_FATAL_WARNINGS)
+    if(TF_PSA_CRYPTO_FATAL_WARNINGS)
         target_compile_options(${target} PRIVATE /WX)
-    endif(MBEDTLS_FATAL_WARNINGS)
+    endif(TF_PSA_CRYPTO_FATAL_WARNINGS)
 endfunction(tf_psa_crypto_set_msvc_base_compile_options)
 
 function(tf_psa_crypto_set_config_files_compile_definitions target)


### PR DESCRIPTION
Update `MBEDTLS_FATAL_WARNINGS` -> `TF_PSA_CRYPTO_FATAL_WARNINGS`.

The Mbed TLS option was still used for compilers other than GCC. This caused -Werror to be turned off when using non-GCC compilers and building TF-PSA-Crypto as a standalone, since `MBEDTLS_FATAL_WARNINGS` was not defined.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided | not required because: 
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#217
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 