### PR TITLE
Cleanup following the simplification of entropy and RNG options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,17 +126,6 @@ if(USE_STATIC_TF_PSA_CRYPTO_LIBRARY AND USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
     string(APPEND tfpsacrypto_static_target "_static")
 endif()
 
-# Warning string - created as a list for compatibility with CMake 2.8
-set(CTR_DRBG_128_BIT_KEY_WARN_L1 "****  WARNING!  MBEDTLS_CTR_DRBG_USE_128_BIT_KEY defined!\n")
-set(CTR_DRBG_128_BIT_KEY_WARN_L2 "****  Using 128-bit keys for CTR_DRBG limits the security of generated\n")
-set(CTR_DRBG_128_BIT_KEY_WARN_L3 "****  keys and operations that use random values generated to 128-bit security\n")
-
-set(CTR_DRBG_128_BIT_KEY_WARNING "${WARNING_BORDER}"
-                         "${CTR_DRBG_128_BIT_KEY_WARN_L1}"
-                         "${CTR_DRBG_128_BIT_KEY_WARN_L2}"
-                         "${CTR_DRBG_128_BIT_KEY_WARN_L3}"
-                         "${WARNING_BORDER}")
-
 # Python 3 is only needed here to check for configuration warnings.
 if(NOT CMAKE_VERSION VERSION_LESS 3.15.0)
     set(Python3_FIND_STRATEGY LOCATION)
@@ -149,22 +138,6 @@ else()
     if(PYTHONINTERP_FOUND)
         set(TF_PSA_CRYPTO_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE})
     endif()
-endif()
-
-if(TF_PSA_CRYPTO_PYTHON_EXECUTABLE)
-    # If 128-bit keys are configured for CTR_DRBG, display an appropriate warning
-    execute_process(
-        COMMAND
-            ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE} ${TF_PSA_CRYPTO_DIR}/scripts/config.py
-            -f ${TF_PSA_CRYPTO_DIR}/include/psa/crypto_config.h
-            get MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
-        RESULT_VARIABLE
-            result
-    )
-    if(${result} EQUAL 0)
-        message(WARNING ${CTR_DRBG_128_BIT_KEY_WARNING})
-    endif()
-
 endif()
 
 # We now potentially need to link all executables against PThreads, if available

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -8641,7 +8641,7 @@ static psa_status_t mbedtls_psa_crypto_init_subsystem(mbedtls_psa_crypto_subsyst
 
             /* Initialize and seed the random generator. */
             if (global_data.rng_state == RNG_NOT_INITIALIZED && driver_wrappers_initialized) {
-#if !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+#if !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) && !defined(MBEDTLS_STATIC_ASSERT_SUPPORT)
                 if (MBEDTLS_PSA_CRYPTO_RNG_HASH != PSA_ALG_SHA_256 &&
                     MBEDTLS_PSA_CRYPTO_RNG_HASH != PSA_ALG_SHA_512) {
                     status = PSA_ERROR_INSUFFICIENT_ENTROPY;

--- a/core/psa_crypto_random_impl.h
+++ b/core/psa_crypto_random_impl.h
@@ -128,6 +128,7 @@ static inline int mbedtls_psa_drbg_seed(mbedtls_psa_drbg_context_t *drbg_ctx,
                                         mbedtls_entropy_context *entropy,
                                         const unsigned char *custom, size_t len)
 {
+#if !defined(MBEDTLS_STATIC_ASSERT_SUPPORT)
     if (PSA_BYTES_TO_BITS(PSA_HASH_LENGTH(MBEDTLS_PSA_CRYPTO_RNG_HASH)) <
         MBEDTLS_PSA_CRYPTO_RNG_STRENGTH) {
         /* MBEDTLS_PSA_CRYPTO_RNG_HASH size (in bits) must be at least
@@ -135,6 +136,7 @@ static inline int mbedtls_psa_drbg_seed(mbedtls_psa_drbg_context_t *drbg_ctx,
          */
         return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
     }
+#endif
 #if defined(MBEDTLS_CTR_DRBG_C)
     return mbedtls_ctr_drbg_seed(drbg_ctx, mbedtls_entropy_func, entropy, custom, len);
 #elif defined(MBEDTLS_HMAC_DRBG_C)

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -196,16 +196,12 @@
       * disable #MBEDTLS_ENTROPY_C and use #MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
       * instead.
       */
-/* Error suppressed until we fix up our test scripts.
- * https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/370 */
-//#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no sources"
+#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no sources"
 #  elif MBEDTLS_ENTROPY_TRUE_SOURCES == 0 && !defined(MBEDTLS_ENTROPY_NO_SOURCES_OK)
      /* Having only the NV seed as an entropy source weakens security.
       * To indicate that this is acceptable, define
       * MBEDTLS_ENTROPY_NO_SOURCES_OK. */
-/* Error suppressed until we fix up our test scripts.
- * https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/370 */
-//#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no true sources"
+#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no true sources"
 #  endif
 #endif
 

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -517,7 +517,9 @@
 #endif
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED) &&\
-    !defined(MBEDTLS_PLATFORM_C)
+    (!defined(MBEDTLS_PSA_CRYPTO_C) || \
+     defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) || \
+     !defined(MBEDTLS_PLATFORM_C))
 #error "MBEDTLS_ENTROPY_NV_SEED defined, but not all prerequisites"
 #endif
 

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -203,11 +203,6 @@
         * MBEDTLS_ENTROPY_NO_SOURCES_OK. */
 #      error "Entropy module enabled, but no true sources"
 #    endif
-#    if defined(MBEDTLS_PSA_RNG_RESEED_INTERVAL)
-       /* Periodic re-seeding does not improve security in the absence of a
-        * true entropy source. */
-#      error "Setting a low reseed interval does not improve security without a true entropy source."
-#    endif
 #  endif
 #endif
 

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -193,15 +193,21 @@
       * or #MBEDTLS_ENTROPY_NV_SEED.
       *
       * If your platform has a cryptographic-quality random generator,
-      * disable #MBEDTLS_ENTROPY_C and use #MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
-      * instead.
+      * enable #MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
       */
 #    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no sources"
-#  elif MBEDTLS_ENTROPY_TRUE_SOURCES == 0 && !defined(MBEDTLS_ENTROPY_NO_SOURCES_OK)
-     /* Having only the NV seed as an entropy source weakens security.
-      * To indicate that this is acceptable, define
-      * MBEDTLS_ENTROPY_NO_SOURCES_OK. */
-#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no true sources"
+#  elif MBEDTLS_ENTROPY_TRUE_SOURCES == 0
+#    if !defined(MBEDTLS_ENTROPY_NO_SOURCES_OK)
+       /* Having only the NV seed as an entropy source weakens security.
+        * To indicate that this is acceptable, define
+        * MBEDTLS_ENTROPY_NO_SOURCES_OK. */
+#      error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no true sources"
+#    endif
+#    if defined(MBEDTLS_PSA_RNG_RESEED_INTERVAL)
+       /* Periodic re-seeding does not improve security in the absence of a
+        * true entropy source. */
+#      error "Cannot set MBEDTLS_PSA_RNG_RESEED_INTERVAL explicitly without a true entropy source"
+#    endif
 #  endif
 #endif
 

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -195,18 +195,18 @@
       * If your platform has a cryptographic-quality random generator,
       * enable #MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG.
       */
-#    error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no sources"
+#    error "Entropy module enabled, but no sources"
 #  elif MBEDTLS_ENTROPY_TRUE_SOURCES == 0
 #    if !defined(MBEDTLS_ENTROPY_NO_SOURCES_OK)
        /* Having only the NV seed as an entropy source weakens security.
         * To indicate that this is acceptable, define
         * MBEDTLS_ENTROPY_NO_SOURCES_OK. */
-#      error "Entropy module enabled (MBEDTLS_ENTROPY_C), but no true sources"
+#      error "Entropy module enabled, but no true sources"
 #    endif
 #    if defined(MBEDTLS_PSA_RNG_RESEED_INTERVAL)
        /* Periodic re-seeding does not improve security in the absence of a
         * true entropy source. */
-#      error "Cannot set MBEDTLS_PSA_RNG_RESEED_INTERVAL explicitly without a true entropy source"
+#      error "Setting a low reseed interval does not improve security without a true entropy source."
 #    endif
 #  endif
 #endif

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -517,10 +517,12 @@
 #endif
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED) &&\
-    (!defined(MBEDTLS_PSA_CRYPTO_C) || \
-     defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) || \
-     !defined(MBEDTLS_PLATFORM_C))
+    (!defined(MBEDTLS_PSA_CRYPTO_C) || !defined(MBEDTLS_PLATFORM_C))
 #error "MBEDTLS_ENTROPY_NV_SEED defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_ENTROPY_NV_SEED) && defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+#error "Providing a non-volatile entropy seed does not enhance the security of an external RNG"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_NV_SEED_ALT) &&\

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -522,7 +522,7 @@
 #endif
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED) && defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
-#error "Providing a non-volatile entropy seed does not enhance the security of an external RNG"
+#error "MBEDTLS_ENTROPY_NV_SEED has no effect when MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG is enabled"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_NV_SEED_ALT) &&\

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -363,10 +363,12 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
  * compiler version should suffice.
  * For non GCC compilers we check that C>=11 is used since C11 introduced _Static_assert.
  */
+#define MBEDTLS_STATIC_ASSERT_SUPPORT
 #elif !defined(__cplusplus) && \
     ((defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4)) || \
     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L))
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    _Static_assert(expr, msg)
+#define MBEDTLS_STATIC_ASSERT_SUPPORT
 #else
 /* Make sure `MBEDTLS_STATIC_ASSERT(expr, msg);` is valid both inside and
  * outside a function. We choose a struct declaration, which can be repeated

--- a/drivers/builtin/include/mbedtls/private/ctr_drbg.h
+++ b/drivers/builtin/include/mbedtls/private/ctr_drbg.h
@@ -94,7 +94,15 @@
 /**< The amount of entropy used per seed by default, in bytes. */
 
 #if !defined(MBEDTLS_PSA_RNG_RESEED_INTERVAL)
-#define MBEDTLS_PSA_RNG_RESEED_INTERVAL    10000
+#  if MBEDTLS_ENTROPY_TRUE_SOURCES == 0
+/* If there is no true entropy source, effectively disable re-seeding by setting
+ * a very large re-seed interval. There is no security benefit to re-seeding
+ * without a true entropy source.
+ */
+#    define MBEDTLS_PSA_RNG_RESEED_INTERVAL    INT_MAX
+#  else
+#    define MBEDTLS_PSA_RNG_RESEED_INTERVAL    10000
+#  endif
 /**< The interval before reseed is performed by default. */
 #endif
 

--- a/drivers/builtin/include/mbedtls/private/ctr_drbg.h
+++ b/drivers/builtin/include/mbedtls/private/ctr_drbg.h
@@ -94,15 +94,7 @@
 /**< The amount of entropy used per seed by default, in bytes. */
 
 #if !defined(MBEDTLS_PSA_RNG_RESEED_INTERVAL)
-#  if MBEDTLS_ENTROPY_TRUE_SOURCES == 0
-/* If there is no true entropy source, effectively disable re-seeding by setting
- * a very large re-seed interval. There is no security benefit to re-seeding
- * without a true entropy source.
- */
-#    define MBEDTLS_PSA_RNG_RESEED_INTERVAL    INT_MAX
-#  else
-#    define MBEDTLS_PSA_RNG_RESEED_INTERVAL    10000
-#  endif
+#define MBEDTLS_PSA_RNG_RESEED_INTERVAL    10000
 /**< The interval before reseed is performed by default. */
 #endif
 

--- a/include/psa/crypto_adjust_config_synonyms.h
+++ b/include/psa/crypto_adjust_config_synonyms.h
@@ -46,13 +46,4 @@
 #define PSA_WANT_ALG_RSA_PSS_ANY_SALT PSA_WANT_ALG_RSA_PSS
 #endif
 
-/* Temporary alias with incompatible behavior.
- * We only keep this until the Mbed TLS scripts are updated.
- * https://github.com/Mbed-TLS/mbedtls/issues/10300
- */
-#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT)
-#define MBEDTLS_PSA_DRIVER_GET_ENTROPY
-#undef MBEDTLS_PSA_BUILTIN_GET_ENTROPY
-#endif
-
 #endif /* PSA_CRYPTO_ADJUST_CONFIG_SYNONYMS_H */

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -937,13 +937,6 @@
  * This section sets PSA specific settings.
  * \{
  */
-
-/* Temporary alias of MBEDTLS_PSA_DRIVER_GET_ENTROPY with incompatible
- * behavior. We only keep this until the Mbed TLS scripts are updated.
- * https://github.com/Mbed-TLS/mbedtls/issues/10300
- */
-//#define MBEDTLS_PLATFORM_GET_ENTROPY_ALT
-
 /**
  * \def MBEDTLS_ENTROPY_NO_SOURCES_OK
  *

--- a/tests/scripts/components-configuration-platform.sh
+++ b/tests/scripts/components-configuration-platform.sh
@@ -43,9 +43,6 @@ component_test_entropy_nv_seed_only () {
     scripts/config.py full
     scripts/config.py unset MBEDTLS_PSA_BUILTIN_GET_ENTROPY
     scripts/config.py set MBEDTLS_ENTROPY_NO_SOURCES_OK
-    # Disable the temporary alias while it exists.
-    # https://github.com/Mbed-TLS/mbedtls/issues/10300
-    scripts/config.py unset MBEDTLS_PLATFORM_GET_ENTROPY_ALT
 
     cd $OUT_OF_SOURCE_DIR
     cmake -DCMAKE_C_COMPILER=gcc "$TF_PSA_CRYPTO_ROOT_DIR"

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -41,7 +41,7 @@ class CryptoTestConfigChecks(unittest_config_checks.TestConfigChecks):
                       #define MBEDTLS_ENTROPY_NV_SEED
                       #undef MBEDTLS_ENTROPY_NO_SOURCES_OK
                       ''',
-                      error=(r'Entropy module enabled \(MBEDTLS_ENTROPY_C\), but no true sources'))
+                      error=(r'Entropy module enabled, but no true sources'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -31,17 +31,38 @@ class CryptoTestConfigChecks(unittest_config_checks.TestConfigChecks):
         self.good_case('',
                        '#error "mbedtls_config.h was read"')
 
-    def test_crypto_nv_seed_only(self) -> None:
-        """An error expected from tf_psa_crypto_check_config.h with an
-        NV-seed-only configuration but MBEDTLS_ENTROPY_NO_SOURCES_OK not
-        defined.
+    def test_crypto_nv_seed_only_with_entropy_no_sources_ok(self) -> None:
+        """NV-seed-only configuration with MBEDTLS_ENTROPY_NO_SOURCES_OK defined
+        to acknowledge that there is no true entropy source and that the
+        loss of security is acceptable.
+        """
+        self.good_case('''
+                       #undef MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+                       #define MBEDTLS_ENTROPY_NV_SEED
+                       #define MBEDTLS_ENTROPY_NO_SOURCES_OK
+                       ''')
+
+    def test_crypto_nv_seed_only_without_entropy_no_sources_ok(self) -> None:
+        """NV-seed-only configuration without MBEDTLS_ENTROPY_NO_SOURCES_OK defined
+        An error expected from tf_psa_crypto_check_config.h.
         """
         self.bad_case('''
                       #undef MBEDTLS_PSA_BUILTIN_GET_ENTROPY
                       #define MBEDTLS_ENTROPY_NV_SEED
-                      #undef MBEDTLS_ENTROPY_NO_SOURCES_OK
                       ''',
                       error=(r'Entropy module enabled, but no true sources'))
+
+    def test_crypto_external_rng_with_nv_seed(self) -> None:
+        """External RNG and NV seed
+        An error expected from tf_psa_crypto_check_config.h.
+        """
+        self.bad_case('''
+                      #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+                      #define MBEDTLS_ENTROPY_NV_SEED
+                      ''',
+                      error=(
+                          r'Providing a non-volatile entropy seed does not enhance the security of an external RNG' # pylint: disable=line-too-long
+                      ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -61,7 +61,7 @@ class CryptoTestConfigChecks(unittest_config_checks.TestConfigChecks):
                       #define MBEDTLS_ENTROPY_NV_SEED
                       ''',
                       error=(
-                          r'Providing a non-volatile entropy seed does not enhance the security of an external RNG' # pylint: disable=line-too-long
+                          r'MBEDTLS_ENTROPY_NV_SEED has no effect when MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG is enabled' # pylint: disable=line-too-long
                       ))
 
 if __name__ == '__main__':

--- a/tests/scripts/test_config_checks.py
+++ b/tests/scripts/test_config_checks.py
@@ -31,5 +31,17 @@ class CryptoTestConfigChecks(unittest_config_checks.TestConfigChecks):
         self.good_case('',
                        '#error "mbedtls_config.h was read"')
 
+    def test_crypto_nv_seed_only(self) -> None:
+        """An error expected from tf_psa_crypto_check_config.h with an
+        NV-seed-only configuration but MBEDTLS_ENTROPY_NO_SOURCES_OK not
+        defined.
+        """
+        self.bad_case('''
+                      #undef MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+                      #define MBEDTLS_ENTROPY_NV_SEED
+                      #undef MBEDTLS_ENTROPY_NO_SOURCES_OK
+                      ''',
+                      error=(r'Entropy module enabled \(MBEDTLS_ENTROPY_C\), but no true sources'))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/suites/test_suite_config.crypto_combinations.data
+++ b/tests/suites/test_suite_config.crypto_combinations.data
@@ -23,3 +23,11 @@ pass:
 Config: ECC: Montgomery curves only
 depends_on:!MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED:MBEDTLS_ECP_MONTGOMERY_ENABLED
 pass:
+
+Config: built-in RNG and support for static assertions
+depends_on:MBEDTLS_PSA_CRYPTO_C:!MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG:MBEDTLS_STATIC_ASSERT_SUPPORT
+pass:
+
+Config: built-in RNG and no support for static assertions
+depends_on:MBEDTLS_PSA_CRYPTO_C:!MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG:!MBEDTLS_STATIC_ASSERT_SUPPORT
+pass:


### PR DESCRIPTION
## Description
Cleanup following the simplification of entropy and RNG options
Address partially:
- https://github.com/Mbed-TLS/mbedtls/issues/10300 (removal of MBEDTLS_PLATFORM_GET_ENTROPY_ALT, test to validate that an NV-seed-only configuration requires MBEDTLS_ENTROPY_NO_SOURCES_OK)
- https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/370 (error out at compile time if no entropy source, compile-time checks related to prediction resistance).

Address the two remaining comments from @yanesca in #419:
- https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/419#discussion_r2329549902
- https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/419#discussion_r2329802201

This PR requires both Mbed-TLS/mbedtls-framework#208 and Mbed-TLS/mbedtls#10393 to be merged to pass CI.

It has been validated by https://mbedtls.trustedfirmware.org/job/mbed-tls-restricted-pr-test-parametrized/197/ though.

## PR checklist
- [x] **changelog** not required
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#208
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10393
- [x] **mbedtls 3.6 PR** not required because: 4.0/1.0 only work
- **tests** provided
