### PR TITLE
Fix race condition in ECP self tests and improve testing with TSan

### DIFF
--- a/drivers/builtin/src/ecp.c
+++ b/drivers/builtin/src/ecp.c
@@ -48,7 +48,7 @@
 /* Traces that can be used to count or check the number of basic operations
  * (MPI multiply modulo, point addition, point doubling) in an
  * ECC operation. */
-#if defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_C)
 mbedtls_ecp_trace_counts_t *mbedtls_ecp_trace_counts_live = NULL;
 
 #define TRACE_POINT(where)                                              \

--- a/drivers/builtin/src/ecp.c
+++ b/drivers/builtin/src/ecp.c
@@ -45,15 +45,20 @@
 
 #include "mbedtls/platform.h"
 
-#if defined(MBEDTLS_SELF_TEST)
-/*
- * Counts of point addition and doubling, and field multiplications.
- * Used to test resistance of point multiplication to simple timing attacks.
- */
-#if defined(MBEDTLS_ECP_C)
-static unsigned long add_count, dbl_count;
-#endif /* MBEDTLS_ECP_C */
-static unsigned long mul_count;
+/* Traces that can be used to count or check the number of basic operations
+ * (MPI multiply modulo, point addition, point doubling) in an
+ * ECC operation. */
+#if defined(MBEDTLS_TEST_HOOKS)
+mbedtls_ecp_trace_counts_t *mbedtls_ecp_trace_counts_live = NULL;
+
+#define TRACE_POINT(where)                                              \
+    do {                                                                \
+        if (mbedtls_ecp_trace_counts_live != NULL) {                    \
+            ++mbedtls_ecp_trace_counts_live->where;                     \
+        }                                                               \
+    } while (0)
+#else
+#define TRACE_POINT(where) ((void) 0)
 #endif
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
@@ -1000,17 +1005,12 @@ cleanup:
 /*
  * Reduce a mbedtls_mpi mod p in-place, general case, to use after mbedtls_mpi_mul_mpi
  */
-#if defined(MBEDTLS_SELF_TEST)
-#define INC_MUL_COUNT   mul_count++;
-#else
-#define INC_MUL_COUNT
-#endif
 
 #define MOD_MUL(N)                                                    \
     do                                                                  \
     {                                                                   \
         MBEDTLS_MPI_CHK(ecp_modp(&(N), grp));                       \
-        INC_MUL_COUNT                                                   \
+        TRACE_POINT(mbedtls_mpi_mul_mod);                           \
     } while (0)
 
 static inline int mbedtls_mpi_mul_mod(const mbedtls_ecp_group *grp,
@@ -1428,9 +1428,7 @@ static int ecp_double_jac(const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                           const mbedtls_ecp_point *P,
                           mbedtls_mpi tmp[4])
 {
-#if defined(MBEDTLS_SELF_TEST)
-    dbl_count++;
-#endif
+    TRACE_POINT(ecp_double_jac);
 
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
@@ -1515,9 +1513,7 @@ static int ecp_add_mixed(const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                          const mbedtls_ecp_point *P, const mbedtls_ecp_point *Q,
                          mbedtls_mpi tmp[4])
 {
-#if defined(MBEDTLS_SELF_TEST)
-    add_count++;
-#endif
+    TRACE_POINT(ecp_add_mixed);
 
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
@@ -3369,6 +3365,12 @@ cleanup:
     return ret;
 }
 
+#if defined(MBEDTLS_TEST_HOOKS)
+void (*mbedtls_ecp_self_test_trace_counts_compare)(
+    const mbedtls_ecp_trace_counts_t *reference,
+    const mbedtls_ecp_trace_counts_t *live) = NULL;
+#endif /* MBEDTLS_TEST_HOOKS */
+
 /* Calculate R = m.P for each m in exponents. Check that the number of
  * basic operations doesn't depend on the value of m. */
 static int self_test_point(int verbose,
@@ -3381,33 +3383,38 @@ static int self_test_point(int verbose,
 {
     int ret = 0;
     size_t i = 0;
-    unsigned long add_c_prev, dbl_c_prev, mul_c_prev;
-    add_count = 0;
-    dbl_count = 0;
-    mul_count = 0;
+
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_reset(mbedtls_ecp_trace_counts_live);
+#endif
 
     MBEDTLS_MPI_CHK(mbedtls_mpi_read_string(m, 16, exponents[0]));
     MBEDTLS_MPI_CHK(self_test_adjust_exponent(grp, m));
     MBEDTLS_MPI_CHK(mbedtls_ecp_mul(grp, R, m, P, self_test_rng, NULL));
 
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_t reference_trace_counts;
+    if (mbedtls_ecp_trace_counts_live != NULL) {
+        reference_trace_counts = *mbedtls_ecp_trace_counts_live;
+    }
+#endif
+
     for (i = 1; i < n_exponents; i++) {
-        add_c_prev = add_count;
-        dbl_c_prev = dbl_count;
-        mul_c_prev = mul_count;
-        add_count = 0;
-        dbl_count = 0;
-        mul_count = 0;
+#if defined(MBEDTLS_TEST_HOOKS)
+        mbedtls_ecp_trace_counts_reset(mbedtls_ecp_trace_counts_live);
+#endif
 
         MBEDTLS_MPI_CHK(mbedtls_mpi_read_string(m, 16, exponents[i]));
         MBEDTLS_MPI_CHK(self_test_adjust_exponent(grp, m));
         MBEDTLS_MPI_CHK(mbedtls_ecp_mul(grp, R, m, P, self_test_rng, NULL));
 
-        if (add_count != add_c_prev ||
-            dbl_count != dbl_c_prev ||
-            mul_count != mul_c_prev) {
-            ret = 1;
-            break;
+#if defined(MBEDTLS_TEST_HOOKS)
+        if (mbedtls_ecp_trace_counts_live != NULL &&
+            mbedtls_ecp_self_test_trace_counts_compare != NULL) {
+            mbedtls_ecp_self_test_trace_counts_compare(
+                &reference_trace_counts, mbedtls_ecp_trace_counts_live);
         }
+#endif
     }
 
 cleanup:

--- a/drivers/builtin/src/ecp_invasive.h
+++ b/drivers/builtin/src/ecp_invasive.h
@@ -276,4 +276,32 @@ int mbedtls_ecp_modulus_setup(mbedtls_mpi_mod_modulus *N,
 
 #endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_LIGHT */
 
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_C)
+typedef struct {
+    unsigned long mbedtls_mpi_mul_mod;
+    unsigned long ecp_add_mixed;
+    unsigned long ecp_double_jac;
+} mbedtls_ecp_trace_counts_t;
+
+static inline void mbedtls_ecp_trace_counts_reset(
+    mbedtls_ecp_trace_counts_t *trace_counts)
+{
+    if (trace_counts != NULL) {
+        memset(trace_counts, 0, sizeof(*trace_counts));
+    }
+}
+
+/* If non-null, some functions in ecp.c increment the relevant counter
+ * each time they run. Not thread-safe! */
+extern mbedtls_ecp_trace_counts_t *mbedtls_ecp_trace_counts_live;
+
+#if defined(MBEDTLS_SELF_TEST)
+/* If non-null, invoked by the self tests to compare trace counts on the
+ * first iterations with test counts on subsequent iterations. */
+extern void (*mbedtls_ecp_self_test_trace_counts_compare)(
+    const mbedtls_ecp_trace_counts_t *reference,
+    const mbedtls_ecp_trace_counts_t *live);
+#endif /* MBEDTLS_SELF_TEST */
+#endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_C */
+
 #endif /* MBEDTLS_ECP_INVASIVE_H */

--- a/drivers/builtin/src/ecp_invasive.h
+++ b/drivers/builtin/src/ecp_invasive.h
@@ -274,6 +274,6 @@ int mbedtls_ecp_modulus_setup(mbedtls_mpi_mod_modulus *N,
                               const mbedtls_ecp_group_id id,
                               const mbedtls_ecp_modulus_type ctype);
 
-#endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_C */
+#endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_LIGHT */
 
 #endif /* MBEDTLS_ECP_INVASIVE_H */

--- a/tests/scripts/components-sanitizers.sh
+++ b/tests/scripts/components-sanitizers.sh
@@ -108,10 +108,6 @@ component_tf_psa_crypto_test_tsan () {
     scripts/config.py full
     scripts/config.py set MBEDTLS_THREADING_C
     scripts/config.py set MBEDTLS_THREADING_PTHREAD
-    # Self-tests are not thread-safe, and this affects ECC code even when
-    # not running the self-tests.
-    # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/443
-    scripts/config.py unset MBEDTLS_SELF_TEST
 
     cd $OUT_OF_SOURCE_DIR
     CC=clang cmake -DCMAKE_BUILD_TYPE:String=TSan "$TF_PSA_CRYPTO_ROOT_DIR"

--- a/tests/scripts/components-sanitizers.sh
+++ b/tests/scripts/components-sanitizers.sh
@@ -104,20 +104,20 @@ component_release_tf_psa_crypto_test_valgrind_constant_flow_psa () {
 }
 
 component_tf_psa_crypto_test_tsan () {
-    msg "build: TSan (clang)"
+    msg "build: full config, TSan (clang)"
     scripts/config.py full
     scripts/config.py set MBEDTLS_THREADING_C
     scripts/config.py set MBEDTLS_THREADING_PTHREAD
-    # Self-tests do not currently use multiple threads.
+    # Self-tests are not thread-safe, and this affects ECC code even when
+    # not running the self-tests.
+    # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/443
     scripts/config.py unset MBEDTLS_SELF_TEST
-    # Interruptible ECC tests are not thread safe
-    scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
 
     cd $OUT_OF_SOURCE_DIR
     CC=clang cmake -DCMAKE_BUILD_TYPE:String=TSan "$TF_PSA_CRYPTO_ROOT_DIR"
     make
 
-    msg "test: main suites (TSan)"
+    msg "test: full config, main suites (TSan)"
     make test
 }
 

--- a/tests/scripts/components-sanitizers.sh
+++ b/tests/scripts/components-sanitizers.sh
@@ -103,7 +103,24 @@ component_release_tf_psa_crypto_test_valgrind_constant_flow_psa () {
     make memcheck
 }
 
-component_tf_psa_crypto_test_tsan () {
+component_tf_psa_crypto_test_default_tsan () {
+    # Default config, with MBEDTLS_TEST_HOOKS (and thus the mutex usage
+    # verification framework, which affects concurrent behavior) disabled.
+    msg "build: default config, TSan (clang)"
+    scripts/config.py set MBEDTLS_THREADING_C
+    scripts/config.py set MBEDTLS_THREADING_PTHREAD
+
+    cd $OUT_OF_SOURCE_DIR
+    CC=clang cmake -DCMAKE_BUILD_TYPE:String=TSan "$TF_PSA_CRYPTO_ROOT_DIR"
+    make
+
+    msg "test: default config, main suites (TSan)"
+    make test
+}
+
+component_tf_psa_crypto_test_full_tsan () {
+    # Full config, with MBEDTLS_TEST_HOOKS (and thus the mutex usage
+    # verification framework, which affects concurrent behavior) enabled.
     msg "build: full config, TSan (clang)"
     scripts/config.py full
     scripts/config.py set MBEDTLS_THREADING_C

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -382,6 +382,9 @@ void ecp_test_vect(int id, char *dA_str, char *xA_str, char *yA_str,
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
 #if defined(MBEDTLS_TEST_HOOKS)
     reference_trace_counts_G = live_trace_counts;
+    TEST_LE_U(1, reference_trace_counts_G.mbedtls_mpi_mul_mod);
+    TEST_LE_U(1, reference_trace_counts_G.ecp_add_mixed);
+    TEST_LE_U(1, reference_trace_counts_G.ecp_double_jac);
 #endif
 
     mbedtls_ecp_trace_counts_reset(&live_trace_counts);
@@ -392,6 +395,9 @@ void ecp_test_vect(int id, char *dA_str, char *xA_str, char *yA_str,
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
 #if defined(MBEDTLS_TEST_HOOKS)
     reference_trace_counts_other = live_trace_counts;
+    TEST_LE_U(1, reference_trace_counts_other.mbedtls_mpi_mul_mod);
+    TEST_LE_U(1, reference_trace_counts_other.ecp_add_mixed);
+    TEST_LE_U(1, reference_trace_counts_other.ecp_double_jac);
 #endif
 
     mbedtls_ecp_trace_counts_reset(&live_trace_counts);
@@ -468,6 +474,9 @@ void ecp_test_vec_x(int id, char *dA_hex, char *xA_hex, char *dB_hex,
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xA) == 0);
 #if defined(MBEDTLS_TEST_HOOKS)
     reference_trace_counts_G = live_trace_counts;
+    TEST_LE_U(1, reference_trace_counts_G.mbedtls_mpi_mul_mod);
+    TEST_EQUAL(0, reference_trace_counts_G.ecp_add_mixed);
+    TEST_EQUAL(0, reference_trace_counts_G.ecp_double_jac);
 #endif
 
     mbedtls_ecp_trace_counts_reset(&live_trace_counts);
@@ -477,6 +486,9 @@ void ecp_test_vec_x(int id, char *dA_hex, char *xA_hex, char *dB_hex,
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xS) == 0);
 #if defined(MBEDTLS_TEST_HOOKS)
     reference_trace_counts_other = live_trace_counts;
+    TEST_LE_U(1, reference_trace_counts_other.mbedtls_mpi_mul_mod);
+    TEST_EQUAL(0, reference_trace_counts_other.ecp_add_mixed);
+    TEST_EQUAL(0, reference_trace_counts_other.ecp_double_jac);
 #endif
 
     mbedtls_ecp_trace_counts_reset(&live_trace_counts);

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -80,6 +80,9 @@ static void mbedtls_test_ecp_trace_counts_compare(
 exit:
     ;
 }
+#else /* MBEDTLS_TEST_HOOKS */
+#define mbedtls_ecp_trace_counts_reset(unusued) ((void) 0)
+#define mbedtls_test_ecp_trace_counts_compare(unused0, unused1) ((void) 0)
 #endif /* MBEDTLS_TEST_HOOKS */
 
 
@@ -343,6 +346,15 @@ void ecp_test_vect(int id, char *dA_str, char *xA_str, char *yA_str,
     mbedtls_ecp_point R;
     mbedtls_mpi dA, xA, yA, dB, xB, yB, xZ, yZ;
     mbedtls_test_rnd_pseudo_info rnd_info;
+#if defined(MBEDTLS_TEST_HOOKS)
+    /* Multiplication by the base point G uses an optimized path when
+     * MBEDTLS_ECP_FIXED_POINT_OPTIM is enabled, so we track separate
+     * trace counts for multiplication-by-G vs multiplication-by-other. */
+    mbedtls_ecp_trace_counts_t reference_trace_counts_G;
+    mbedtls_ecp_trace_counts_t reference_trace_counts_other;
+    mbedtls_ecp_trace_counts_t live_trace_counts;
+    mbedtls_ecp_trace_counts_live = &live_trace_counts;
+#endif
 
     mbedtls_ecp_group_init(&grp); mbedtls_ecp_point_init(&R);
     mbedtls_mpi_init(&dA); mbedtls_mpi_init(&xA); mbedtls_mpi_init(&yA); mbedtls_mpi_init(&dB);
@@ -362,32 +374,56 @@ void ecp_test_vect(int id, char *dA_str, char *xA_str, char *yA_str,
     TEST_ASSERT(mbedtls_test_read_mpi(&xZ, xZ_str) == 0);
     TEST_ASSERT(mbedtls_test_read_mpi(&yZ, yZ_str) == 0);
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dA, &grp.G,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xA) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.Y, &yA) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
+#if defined(MBEDTLS_TEST_HOOKS)
+    reference_trace_counts_G = live_trace_counts;
+#endif
+
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dB, &R,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xZ) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.Y, &yZ) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
+#if defined(MBEDTLS_TEST_HOOKS)
+    reference_trace_counts_other = live_trace_counts;
+#endif
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dB, &grp.G,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xB) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.Y, &yB) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_G,
+                                          &live_trace_counts);
+
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dA, &R,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xZ) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.Y, &yZ) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_other,
+                                          &live_trace_counts);
+
+#if !defined(MBEDTLS_ECP_FIXED_POINT_OPTIM)
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_G,
+                                          &reference_trace_counts_other);
+#endif
 
 exit:
     mbedtls_ecp_group_free(&grp); mbedtls_ecp_point_free(&R);
     mbedtls_mpi_free(&dA); mbedtls_mpi_free(&xA); mbedtls_mpi_free(&yA); mbedtls_mpi_free(&dB);
     mbedtls_mpi_free(&xB); mbedtls_mpi_free(&yB); mbedtls_mpi_free(&xZ); mbedtls_mpi_free(&yZ);
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_live = NULL;
+#endif
 }
 /* END_CASE */
 
@@ -399,6 +435,15 @@ void ecp_test_vec_x(int id, char *dA_hex, char *xA_hex, char *dB_hex,
     mbedtls_ecp_point R;
     mbedtls_mpi dA, xA, dB, xB, xS;
     mbedtls_test_rnd_pseudo_info rnd_info;
+#if defined(MBEDTLS_TEST_HOOKS)
+    /* Multiplication by the base point G uses an optimized path when
+     * MBEDTLS_ECP_FIXED_POINT_OPTIM is enabled, so we track separate
+     * trace counts for multiplication-by-G vs multiplication-by-other. */
+    mbedtls_ecp_trace_counts_t reference_trace_counts_G;
+    mbedtls_ecp_trace_counts_t reference_trace_counts_other;
+    mbedtls_ecp_trace_counts_t live_trace_counts;
+    mbedtls_ecp_trace_counts_live = &live_trace_counts;
+#endif
 
     mbedtls_ecp_group_init(&grp); mbedtls_ecp_point_init(&R);
     mbedtls_mpi_init(&dA); mbedtls_mpi_init(&xA);
@@ -416,31 +461,53 @@ void ecp_test_vec_x(int id, char *dA_hex, char *xA_hex, char *dB_hex,
     TEST_ASSERT(mbedtls_test_read_mpi(&xB, xB_hex) == 0);
     TEST_ASSERT(mbedtls_test_read_mpi(&xS, xS_hex) == 0);
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dA, &grp.G,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xA) == 0);
+#if defined(MBEDTLS_TEST_HOOKS)
+    reference_trace_counts_G = live_trace_counts;
+#endif
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dB, &R,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xS) == 0);
+#if defined(MBEDTLS_TEST_HOOKS)
+    reference_trace_counts_other = live_trace_counts;
+#endif
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dB, &grp.G,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xB) == 0);
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_G,
+                                          &live_trace_counts);
 
+    mbedtls_ecp_trace_counts_reset(&live_trace_counts);
     TEST_ASSERT(mbedtls_ecp_mul(&grp, &R, &dA, &R,
                                 &mbedtls_test_rnd_pseudo_rand, &rnd_info) == 0);
     TEST_ASSERT(mbedtls_ecp_check_pubkey(&grp, &R) == 0);
     TEST_ASSERT(mbedtls_mpi_cmp_mpi(&R.X, &xS) == 0);
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_other,
+                                          &live_trace_counts);
+
+#if !defined(MBEDTLS_ECP_FIXED_POINT_OPTIM)
+    mbedtls_test_ecp_trace_counts_compare(&reference_trace_counts_G,
+                                          &reference_trace_counts_other);
+#endif
 
 exit:
     mbedtls_ecp_group_free(&grp); mbedtls_ecp_point_free(&R);
     mbedtls_mpi_free(&dA); mbedtls_mpi_free(&xA);
     mbedtls_mpi_free(&dB); mbedtls_mpi_free(&xB);
     mbedtls_mpi_free(&xS);
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_live = NULL;
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -68,7 +68,7 @@ inline static int mbedtls_ecp_group_cmp(mbedtls_ecp_group *grp1,
     return 0;
 }
 
-#if defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_C)
 static void mbedtls_test_ecp_trace_counts_compare(
     const mbedtls_ecp_trace_counts_t *reference,
     const mbedtls_ecp_trace_counts_t *live)
@@ -80,10 +80,10 @@ static void mbedtls_test_ecp_trace_counts_compare(
 exit:
     ;
 }
-#else /* MBEDTLS_TEST_HOOKS */
+#else /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_C */
 #define mbedtls_ecp_trace_counts_reset(unusued) ((void) 0)
 #define mbedtls_test_ecp_trace_counts_compare(unused0, unused1) ((void) 0)
-#endif /* MBEDTLS_TEST_HOOKS */
+#endif /* MBEDTLS_TEST_HOOKS && MBEDTLS_ECP_C */
 
 
 /* END_HEADER */
@@ -1554,7 +1554,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ecp_selftest()
 {
-#if defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_C)
     mbedtls_ecp_trace_counts_t live_trace_counts;
     mbedtls_ecp_trace_counts_live = &live_trace_counts;
     mbedtls_ecp_self_test_trace_counts_compare = mbedtls_test_ecp_trace_counts_compare;
@@ -1564,7 +1564,7 @@ void ecp_selftest()
 
 exit:
     ;
-#if defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_ECP_C)
     mbedtls_ecp_trace_counts_live = NULL;
     mbedtls_ecp_self_test_trace_counts_compare = NULL;
 #endif

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -68,6 +68,21 @@ inline static int mbedtls_ecp_group_cmp(mbedtls_ecp_group *grp1,
     return 0;
 }
 
+#if defined(MBEDTLS_TEST_HOOKS)
+static void mbedtls_test_ecp_trace_counts_compare(
+    const mbedtls_ecp_trace_counts_t *reference,
+    const mbedtls_ecp_trace_counts_t *live)
+{
+    TEST_EQUAL(reference->mbedtls_mpi_mul_mod, live->mbedtls_mpi_mul_mod);
+    TEST_EQUAL(reference->ecp_add_mixed, live->ecp_add_mixed);
+    TEST_EQUAL(reference->ecp_double_jac, live->ecp_double_jac);
+
+exit:
+    ;
+}
+#endif /* MBEDTLS_TEST_HOOKS */
+
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -1460,7 +1475,20 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ecp_selftest()
 {
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_t live_trace_counts;
+    mbedtls_ecp_trace_counts_live = &live_trace_counts;
+    mbedtls_ecp_self_test_trace_counts_compare = mbedtls_test_ecp_trace_counts_compare;
+#endif
+
     TEST_ASSERT(mbedtls_ecp_self_test(1) == 0);
+
+exit:
+    ;
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_ecp_trace_counts_live = NULL;
+    mbedtls_ecp_self_test_trace_counts_compare = NULL;
+#endif
 }
 /* END_CASE */
 


### PR DESCRIPTION
* Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/443.
* Test with TSan both with `MBEDTLS_TEST_HOOKS` enabled and with it disabled.

## PR checklist

- [x] **changelog** not required because: self-tests are not an API feature in development (but 3.6 will need a changelog entry)
- [x] **framework PR** not required
- [ ] **mbedtls development PR** TODO (`all.sh` components only)
- [ ] **mbedtls 3.6 PR** TODO
- **tests**  provided
