### PR TITLE
Declare psa_can_do_cipher() publicly

### DIFF
--- a/ChangeLog.d/psa_can_do_cipher.txt
+++ b/ChangeLog.d/psa_can_do_cipher.txt
@@ -1,0 +1,5 @@
+API changes
+   * When building the library as a PSA client (MBEDTLS_PSA_CRYPTO_CLIENT
+     enabled and MBEDTLS_PSA_CRYPTO_C disabled), you need to provide the
+     function psa_can_do_cipher() in addition to psa_can_do_hash(). This
+     changed was made in Mbed TLS 3.6.0 but was not announced then.

--- a/core/psa_crypto_core.h
+++ b/core/psa_crypto_core.h
@@ -16,18 +16,6 @@
 #include "mbedtls/threading.h"
 #endif
 
-/**
- * Tell if PSA is ready for this cipher.
- *
- * \note            For now, only checks the state of the driver subsystem,
- *                  not the algorithm. Might do more in the future.
- *
- * \param cipher_alg  The cipher algorithm (ignored for now).
- *
- * \return 1 if the driver subsytem is ready, 0 otherwise.
- */
-int psa_can_do_cipher(psa_key_type_t key_type, psa_algorithm_t cipher_alg);
-
 typedef enum {
     PSA_SLOT_EMPTY = 0,
     PSA_SLOT_FILLING,

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -427,7 +427,7 @@ int psa_can_do_hash(psa_algorithm_t hash_alg);
  * \param key_type    The key type.
  * \param cipher_alg  The cipher algorithm.
  *
- * \return 1 if the PSA can handle \p hash_alg, 0 otherwise.
+ * \return 1 if the PSA can handle \p cipher_alg, 0 otherwise.
  */
 int psa_can_do_cipher(psa_key_type_t key_type, psa_algorithm_t cipher_alg);
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -405,9 +405,10 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  * This means that PSA core was built with the corresponding PSA_WANT_ALG_xxx
  * set and that psa_crypto_init has already been called.
  *
- * \note When using Mbed TLS version of PSA core (i.e. MBEDTLS_PSA_CRYPTO_C is
- *       set) for now this function only checks the state of the driver
- *       subsystem, not the algorithm. This might be improved in the future.
+ * \note When using the built-in version of the PSA core (i.e.
+ *       #MBEDTLS_PSA_CRYPTO_C is set), for now, this function only checks
+ *       the state of the driver subsystem, not the algorithm.
+ *       This might be improved in the future.
  *
  * \param hash_alg  The hash algorithm.
  *
@@ -418,12 +419,15 @@ int psa_can_do_hash(psa_algorithm_t hash_alg);
 /**
  * Tell if PSA is ready for this cipher.
  *
- * \note            For now, only checks the state of the driver subsystem,
- *                  not the algorithm. Might do more in the future.
+ * \note When using the built-in version of the PSA core (i.e.
+ *       #MBEDTLS_PSA_CRYPTO_C is set), for now, this function only checks
+ *       the state of the driver subsystem, not the key type and algorithm.
+ *       This might be improved in the future.
  *
- * \param cipher_alg  The cipher algorithm (ignored for now).
+ * \param key_type    The key type.
+ * \param cipher_alg  The cipher algorithm.
  *
- * \return 1 if the driver subsytem is ready, 0 otherwise.
+ * \return 1 if the PSA can handle \p hash_alg, 0 otherwise.
  */
 int psa_can_do_cipher(psa_key_type_t key_type, psa_algorithm_t cipher_alg);
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -415,6 +415,18 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
  */
 int psa_can_do_hash(psa_algorithm_t hash_alg);
 
+/**
+ * Tell if PSA is ready for this cipher.
+ *
+ * \note            For now, only checks the state of the driver subsystem,
+ *                  not the algorithm. Might do more in the future.
+ *
+ * \param cipher_alg  The cipher algorithm (ignored for now).
+ *
+ * \return 1 if the driver subsytem is ready, 0 otherwise.
+ */
+int psa_can_do_cipher(psa_key_type_t key_type, psa_algorithm_t cipher_alg);
+
 /**@}*/
 
 /** \addtogroup crypto_types


### PR DESCRIPTION
Fixes https://github.com/Mbed-TLS/mbedtls/issues/10341.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10401
- **tests**  provided
