### PR TITLE
Update value of PSA_KEY_USAGE_DERIVE_PUBLIC

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -1702,6 +1702,17 @@ psa_status_t psa_export_public_key_iop_abort(psa_export_public_key_iop_t *operat
  */
 static psa_status_t psa_validate_key_policy(const psa_key_policy_t *policy)
 {
+    /* Do not allow PSA_KEY_USAGE_DERIVE_PUBLIC until its numerical value
+     * is enshrined in an official specification. This way, it's ok if
+     * the value changes. Once we start allowing persistent keys with
+     * a numerical value, we're locked into the meaning of that numerical
+     * value, so don't do that if there's a risk that the value might change.
+     *
+     * We introduced PSA_KEY_USAGE_DERIVE_PUBLIC for the sake of
+     * mbedtls_pk_can_do_psa() and psa_check_key_usage(). At this point,
+     * it is never checked by an operation, so there is no compelling
+     * reason to set this flag in a key policy.
+     */
     if ((policy->usage & ~(PSA_KEY_USAGE_EXPORT |
                            PSA_KEY_USAGE_COPY |
                            PSA_KEY_USAGE_ENCRYPT |

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -325,22 +325,6 @@ int mbedtls_pk_wrap_psa(mbedtls_pk_context *ctx,
  */
 size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context *ctx);
 
-/** Whether the key pair or public key can be used as the public side in a
- * key agreement.
- *
- * This is not an usage flag tied to the key, but it's the permisson to call
- * psa_export_public_key() on a key which is always present. The reason is that,
- * in order to use such a key in a public-side key agreement, the public key
- * needs to be exported. That's different from other usages where it's possible
- * to call for an operation directly on the key object.
- * An important consequence of this is that for this usage to be valid a key
- * doesn't need to have PSA_ALG_ECDH as main/enrollment algorithm. It only
- * need to be an ECC key.
- *
- * \warning This is temporary until PSA Crypto API officially supports it.
- */
-#define PSA_KEY_USAGE_DERIVE_PUBLIC         ((psa_key_usage_t) 0x00800000)
-
 /**
  * \brief           Tell if the key wrapped in the PK context is able to perform
  *                  the \p usage operation using the \p alg algorithm. This should

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -327,10 +327,20 @@ size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context *ctx);
 
 /**
  * \brief           Tell if the key wrapped in the PK context is able to perform
- *                  the \p usage operation using the \p alg algorithm. This should
- *                  not necessarily be supported by PK APIs, but more in
- *                  general by importing the key into PSA and then performing
- *                  the operation.
+ *                  the \p usage operation using the \p alg algorithm.
+ *
+ *                  The operation may be a PK function, a PSA operation on
+ *                  the underlying PSA key if the PK object wraps a PSA key,
+ *                  or a PSA operation on a key obtained with
+ *                  mbedtls_pk_import_into_psa().
+ *
+ * \note            As of TF-PSA-Crypto 1.0.0, this function returns \c 0
+ *                  if the key type and policy are suitable for the
+ *                  requested algorithm and usage, even if the key would
+ *                  not work for some other reason, for example an RSA
+ *                  key that is too small for OAEP with the specified hash.
+ *                  This behavior may change without notice in future
+ *                  versions of the library.
  *
  * \param pk        The context to query. It must have been initialized.
  * \param alg       PSA algorithm to check against.

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -2551,6 +2551,25 @@ static inline int mbedtls_svc_key_id_is_null(mbedtls_svc_key_id_t key)
  */
 #define PSA_KEY_USAGE_COPY                      ((psa_key_usage_t) 0x00000002)
 
+/** Whether the key may be used the public side of a key agreement or PAKE.
+ *
+ * This macro can be used when checking a key's capabilities, for example
+ * with mbedtls_pk_can_do_psa().
+ *
+ * \note Currently, no API function requires this flag.
+ *       Key agreement functions (psa_raw_key_agreement(), psa_key_agreement(),
+ *       psa_key_derivation_key_agreement()) and psa_pake_input() take the
+ *       public key in exported form, not as a key object, so no usage flag
+ *       is involved.
+ *       For PAKE algorithms with a verifier role such as SPAKE2+,
+ *       psa_pake_setup() requires #PSA_KEY_USAGE_DERIVE even when passing
+ *       a public key in the verifier role.
+ *
+ * \note The value of this macro is determined by a draft version of the
+ *       PSA Cryptography API, and may change before this draft is finalized.
+ */
+#define PSA_KEY_USAGE_DERIVE_PUBLIC            ((psa_key_usage_t) 0x00000080)
+
 /** Whether the key may be used to encrypt a message.
  *
  * This flag allows the key to be used for a symmetric encryption operation,


### PR DESCRIPTION
Update the value of `PSA_KEY_USAGE_DERIVE_PUBLIC` based on the [API draft](https://github.com/ARM-software/psa-api/pull/282).

Needs preceding PR:
* [x] https://github.com/Mbed-TLS/mbedtls-framework/pull/218

## PR checklist

- [x] **changelog** not required because: no API change
- [x] **framework PR** https://github.com/Mbed-TLS/mbedtls-framework/pull/218
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: feature not in 3.6
- **tests**  provided
