### PR TITLE
Introduce TF-PSA-Crypto config version

### DIFF
--- a/ChangeLog.d/config-version.txt
+++ b/ChangeLog.d/config-version.txt
@@ -1,0 +1,7 @@
+Features
+   * Users can set the macro TF_PSA_CRYPTO_CONFIG_VERSION in the TF-PSA-Crypto
+     config file to maximize backward compatibility in case of future changes
+     to how the config file is interpreted. TF-PSA-Crypto will maintain
+     backward compatibility on functional matters (except at major version
+     changes, e.g. from 1.x.y to 2.0), but the config version may influence
+     other aspect such as optimisations, or experimental options.

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -30,6 +30,15 @@
 #define PSA_CRYPTO_CONFIG_H
 
 /**
+ * This is an optional version symbol that enables compatibility handling of
+ * config files.
+ *
+ * It is equal to the #TF_PSA_CRYPTO_VERSION_NUMBER of the TF-PSA-Crypto
+ * version introduced the config format we want to be compatible with.
+ */
+#define TF_PSA_CRYPTO_CONFIG_VERSION 0x01000000
+
+/**
  * \name SECTION: SECTION Cryptographic mechanism selection (PSA API)
  *
  * This section sets PSA API settings.

--- a/include/tf-psa-crypto/build_info.h
+++ b/include/tf-psa-crypto/build_info.h
@@ -126,6 +126,13 @@
  */
 #define TF_PSA_CRYPTO_CONFIG_FILES_READ
 
+#if defined(TF_PSA_CRYPTO_CONFIG_VERSION)
+#if (TF_PSA_CRYPTO_CONFIG_VERSION < 0x01000000) ||                      \
+    (TF_PSA_CRYPTO_CONFIG_VERSION > TF_PSA_CRYPTO_VERSION_NUMBER)
+#error "Invalid config version, defined value of TF_PSA_CRYPTO_CONFIG_VERSION is unsupported"
+#endif
+#endif
+
 /* Auto-enable MBEDTLS_MD_C if needed by a module that didn't require it
  * in a previous release, to ensure backwards compatibility.
  */


### PR DESCRIPTION
`TF_PSA_CRYTPO_CONFIG_VERSION` replicates the existing (but so far unused) `MBEDTLS_CONFIG_VERSION`.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10404 + https://github.com/Mbed-TLS/mbedtls/pull/10407
- [x] **mbedtls 3.6 PR** not required because: only relevant for a major version
- **tests**  provided
