### PR TITLE
C23 empty initializers

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -190,6 +190,22 @@ struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt,
                                      struct tm *tm_buf);
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
+/* C23 adds empty intializers which provide an explicit way of initializing
+ * structs and unions in the same way as objects of static storage duration,
+ * and that ensure that the entire object is initialized, not just some portion.
+ *
+ * GCC 15 (and some builds of clang 18) start leaving portions of
+ * structs uninitialized unless we use empty initializers. Fortunately
+ * they also support empty initializers even when not compiling
+ * in c23 mode.
+ */
+#if __STDC__VERSION__ >= 202311L || __GNUC__ >= 15 || __clang_major__ >= 18
+#define MBEDTLS_EMPTY_INITIALIZER(...) {}
+#else
+#warning not using empty initializers
+#define MBEDTLS_EMPTY_INITIALIZER(...) __VA_ARGS__
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/psa/crypto_builtin_composites.h
+++ b/include/psa/crypto_builtin_composites.h
@@ -57,7 +57,7 @@ typedef struct {
     uint8_t MBEDTLS_PRIVATE(opad)[PSA_HMAC_MAX_HASH_BLOCK_SIZE];
 } mbedtls_psa_hmac_operation_t;
 
-#define MBEDTLS_PSA_HMAC_OPERATION_INIT { 0, PSA_HASH_OPERATION_INIT, { 0 } }
+#define MBEDTLS_PSA_HMAC_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, PSA_HASH_OPERATION_INIT, { 0 } })
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
 
 typedef struct {
@@ -73,7 +73,7 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_mac_operation_t;
 
-#define MBEDTLS_PSA_MAC_OPERATION_INIT { 0, { 0 } }
+#define MBEDTLS_PSA_MAC_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, { 0 } })
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_GCM) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_CCM) || \
@@ -106,7 +106,7 @@ typedef struct {
 
 } mbedtls_psa_aead_operation_t;
 
-#define MBEDTLS_PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
+#define MBEDTLS_PSA_AEAD_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, 0, { 0 } })
 
 #include "mbedtls/private/ecdsa.h"
 
@@ -138,9 +138,9 @@ typedef struct {
 #if (defined(MBEDTLS_PSA_BUILTIN_ALG_ECDSA) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA)) && \
     defined(MBEDTLS_ECP_RESTARTABLE)
-#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { { 0 }, { 0 }, 0, 0, 0, 0, 0, 0 }
+#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ { 0 }, { 0 }, 0, 0, 0, 0, 0, 0 })
 #else
-#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define MBEDTLS_PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #endif
 
 /* Context structure for the Mbed TLS interruptible verify hash
@@ -174,10 +174,11 @@ typedef struct {
 #if (defined(MBEDTLS_PSA_BUILTIN_ALG_ECDSA) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_DETERMINISTIC_ECDSA)) && \
     defined(MBEDTLS_ECP_RESTARTABLE)
-#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { { 0 }, { 0 }, 0, 0, 0, 0, { 0 }, \
-        { 0 } }
+#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT \
+	MBEDTLS_EMPTY_INITIALIZER({ { 0 }, { 0 }, 0, 0, 0, 0, { 0 },	\
+        { 0 } })
 #else
-#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define MBEDTLS_VERIFY_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #endif
 
 
@@ -215,7 +216,7 @@ typedef struct {
 
 } mbedtls_psa_pake_operation_t;
 
-#define MBEDTLS_PSA_PAKE_OPERATION_INIT { { 0 } }
+#define MBEDTLS_PSA_PAKE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ { 0 } })
 
 typedef struct {
 #if defined(MBEDTLS_ECP_C)

--- a/include/psa/crypto_builtin_primitives.h
+++ b/include/psa/crypto_builtin_primitives.h
@@ -81,7 +81,7 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_hash_operation_t;
 
-#define MBEDTLS_PSA_HASH_OPERATION_INIT { 0, { 0 } }
+#define MBEDTLS_PSA_HASH_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, { 0 } })
 
 /*
  * Cipher multi-part operation definitions.
@@ -111,6 +111,6 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_cipher_operation_t;
 
-#define MBEDTLS_PSA_CIPHER_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define MBEDTLS_PSA_CIPHER_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, { 0 } })
 
 #endif /* PSA_CRYPTO_BUILTIN_PRIMITIVES_H */

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -842,10 +842,11 @@ typedef uint32_t psa_pake_primitive_t;
  * psa_pake_operation_t.
  */
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_PAKE_OPERATION_INIT { 0 }
+#define PSA_PAKE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_PAKE_OPERATION_INIT { 0, PSA_ALG_NONE, 0, PSA_PAKE_OPERATION_STAGE_SETUP, \
-                                  { 0 }, { { 0 } } }
+#define PSA_PAKE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER(		\
+		{ 0, PSA_ALG_NONE, 0, PSA_PAKE_OPERATION_STAGE_SETUP,	\
+		{ 0 }, { { 0 } } })
 #endif
 
 /**

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -49,6 +49,7 @@
 #ifndef PSA_CRYPTO_STRUCT_H
 #define PSA_CRYPTO_STRUCT_H
 #include "mbedtls/private_access.h"
+#include "mbedtls/platform_util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,9 +76,9 @@ struct psa_hash_operation_s {
 #endif
 };
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_HASH_OPERATION_INIT { 0 }
+#define PSA_HASH_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_HASH_OPERATION_INIT { 0, { 0 } }
+#define PSA_HASH_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, { 0 } })
 #endif
 static inline struct psa_hash_operation_s psa_hash_operation_init(void)
 {
@@ -107,9 +108,9 @@ struct psa_cipher_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_CIPHER_OPERATION_INIT { 0 }
+#define PSA_CIPHER_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_CIPHER_OPERATION_INIT { 0, 0, 0, 0, { 0 } }
+#define PSA_CIPHER_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, 0, { 0 } })
 #endif
 static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
 {
@@ -139,9 +140,9 @@ struct psa_mac_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_MAC_OPERATION_INIT { 0 }
+#define PSA_MAC_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_MAC_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define PSA_MAC_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, { 0 } })
 #endif
 static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 {
@@ -178,9 +179,9 @@ struct psa_aead_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_AEAD_OPERATION_INIT { 0 }
+#define PSA_AEAD_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_AEAD_OPERATION_INIT { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } }
+#define PSA_AEAD_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, { 0 } })
 #endif
 static inline struct psa_aead_operation_s psa_aead_operation_init(void)
 {
@@ -204,10 +205,10 @@ struct psa_key_derivation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0 }
+#define PSA_KEY_DERIVATION_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
 /* This only zeroes out the first byte in the union, the rest is unspecified. */
-#define PSA_KEY_DERIVATION_OPERATION_INIT { 0, 0, 0, { 0 } }
+#define PSA_KEY_DERIVATION_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, 0, 0, { 0 } })
 #endif
 static inline struct psa_key_derivation_s psa_key_derivation_operation_init(
     void)
@@ -423,9 +424,9 @@ struct psa_sign_hash_interruptible_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
+#define PSA_SIGN_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, { 0 }, 0, 0 })
 #endif
 
 static inline struct psa_sign_hash_interruptible_operation_s
@@ -461,9 +462,9 @@ struct psa_verify_hash_interruptible_operation_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0 }
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT { 0, { 0 }, 0, 0 }
+#define PSA_VERIFY_HASH_INTERRUPTIBLE_OPERATION_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, { 0 }, 0, 0 })
 #endif
 
 static inline struct psa_verify_hash_interruptible_operation_s
@@ -499,10 +500,11 @@ struct psa_key_agreement_iop_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_KEY_AGREEMENT_IOP_INIT { 0 }
+#define PSA_KEY_AGREEMENT_IOP_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_KEY_AGREEMENT_IOP_INIT { 0, MBEDTLS_PSA_KEY_AGREEMENT_IOP_INIT, 0, \
-                                     PSA_KEY_ATTRIBUTES_INIT, 0 }
+#define PSA_KEY_AGREEMENT_IOP_INIT MBEDTLS_EMPTY_INITIALIZER(		\
+	{ 0, MBEDTLS_PSA_KEY_AGREEMENT_IOP_INIT, 0,			\
+		  PSA_KEY_ATTRIBUTES_INIT, 0 })
 #endif
 
 static inline struct psa_key_agreement_iop_s
@@ -537,10 +539,11 @@ struct psa_generate_key_iop_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_GENERATE_KEY_IOP_INIT { 0 }
+#define PSA_GENERATE_KEY_IOP_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_GENERATE_KEY_IOP_INIT { 0, MBEDTLS_PSA_GENERATE_KEY_IOP_INIT, PSA_KEY_ATTRIBUTES_INIT, \
-                                    0, 0 }
+#define PSA_GENERATE_KEY_IOP_INIT MBEDTLS_EMPTY_INITIALIZER(		\
+		{ 0, MBEDTLS_PSA_GENERATE_KEY_IOP_INIT, PSA_KEY_ATTRIBUTES_INIT, \
+		  0, 0 })
 #endif
 
 static inline struct psa_generate_key_iop_s
@@ -574,9 +577,9 @@ struct psa_export_public_key_iop_s {
 };
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT { 0 }
+#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT MBEDTLS_EMPTY_INITIALIZER({ 0 })
 #else
-#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT { 0, MBEDTLS_PSA_EXPORT_PUBLIC_KEY_IOP_INIT, 0, 0 }
+#define PSA_EXPORT_PUBLIC_KEY_IOP_INIT MBEDTLS_EMPTY_INITIALIZER({ 0, MBEDTLS_PSA_EXPORT_PUBLIC_KEY_IOP_INIT, 0, 0 })
 #endif
 
 static inline struct psa_export_public_key_iop_s


### PR DESCRIPTION
Add MBEDTLS_EMPTY_INITIALIZER macro for GCC 15 and clang 18 fixes

C23 defines the empty initializer, {}, with different semantics than a partial initializer containing only zero values (like {0}):

> If an object that has automatic storage duration is initialized with an empty initializer, its value is the same as the initialization of a static storage duration object." §6.7.10

Reading further, we find that this will effectively set the entire object to zero, including padding.

GCC 15 (and some builds of clang 18) start leaving portions of structs uninitialized unless we use empty initializers. Fortunately they both support empty initializers even when not compiling in c23 mode.

Because empty initializers are a new feature in C23, we cannot use them with previous versions of language, so this new macro takes a parameter to use as the initializer value for the struct when building with a pre-C23 compiler.

One unfortunate effect of using this macro is that we cannot use explicit initializer values for any members lest we lose the empty initializer semantics for the whole object. This places an implicit dependency on the representation for any symbolic initializers. Capturing that in some fashion (perhaps using a static assertion) might be a nice enhancement to this change.