### PR TITLE
Forbid 192-bit without explicit choice

### DIFF
--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -601,5 +601,10 @@
 #error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
 
+#if (defined(PSA_WANT_ECC_SECP_K1_192) || defined(PSA_WANT_ECC_SECP_K1_192)) \
+    && !defined(TF_PSA_CRYPTO_ALLOW_REMOVED_MECHANISMS)
+#error "PSA_WANT_ECC_SECP_K1_192 and PSA_WANT_ECC_SECP_K1_192 are no longer supported"
+#endif
+
 /* *INDENT-ON* */
 #endif /* TF_PSA_CRYPTO_CHECK_CONFIG_H */

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -98,9 +98,8 @@
 #define PSA_WANT_ECC_SECP_R1_256                1
 #define PSA_WANT_ECC_SECP_R1_384                1
 #define PSA_WANT_ECC_SECP_R1_521                1
-/* These 2 curves are not part of the public API. They are kept for internal
- * testing only, but they might be removed in a future version of the
- * library. */
+/* These 2 curves are not part of the public API. They are kept temporarily for
+ * internal testing only and will removed in a future minor version. */
 //#define PSA_WANT_ECC_SECP_K1_192                1
 //#define PSA_WANT_ECC_SECP_R1_192                1
 
@@ -1980,4 +1979,8 @@
 //#define MBEDTLS_RSA_GEN_KEY_MIN_BITS            1024 /**<  Minimum RSA key size that can be generated in bits (Minimum possible value is 128 bits) */
 
 /** \} name SECTION: Builtin drivers */
+
+/* Do not enable except for testing. Will be removed in a future minor version.
+ */
+//#define TF_PSA_CRYPTO_ALLOW_REMOVED_MECHANISMS
 #endif /* PSA_CRYPTO_CONFIG_H */


### PR DESCRIPTION

## Description

Resolves #233

Pushed only for CI feedback so far.

## PR checklist

- [x] **changelog** not required because: already covered
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only (TLS part already done)
- [x] **mbedtls 3.6 PR** not required because: 1.0 only
- **tests**  do we need tests for this?
