### PR TITLE
PK: remove `pk_context::pk_ctx`

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1131,8 +1131,7 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type,
         return mbedtls_pk_verify(ctx, md_alg, hash, hash_len, sig, sig_len);
     }
 
-    /* Ensure the PK context is of the right type otherwise mbedtls_pk_rsa()
-     * below would return a NULL pointer. */
+    /* Ensure the PK context is of the right type. */
     if (mbedtls_pk_get_type(ctx) != MBEDTLS_PK_RSA) {
         return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
     }

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -50,7 +50,6 @@ void mbedtls_pk_init(mbedtls_pk_context *ctx)
      * we need to add a call to this as the end of mbedtls_pk_free()!
      */
     ctx->pk_info = NULL;
-    ctx->pk_ctx = NULL;
     ctx->priv_id = MBEDTLS_SVC_KEY_ID_INIT;
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     memset(ctx->pub_raw, 0, sizeof(ctx->pub_raw));

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -71,10 +71,6 @@ void mbedtls_pk_free(mbedtls_pk_context *ctx)
         return;
     }
 
-    if ((ctx->pk_info != NULL) && (ctx->pk_info->ctx_free_func != NULL)) {
-        ctx->pk_info->ctx_free_func(ctx->pk_ctx);
-    }
-
     /* The ownership of the priv_id key for opaque keys is external of the PK
      * module. It's the user responsibility to clear it after use. */
     if ((ctx->pk_info != NULL) && (ctx->pk_info->type != MBEDTLS_PK_OPAQUE)) {
@@ -144,11 +140,6 @@ int mbedtls_pk_setup(mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info)
 {
     if (info == NULL || ctx->pk_info != NULL) {
         return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
-    }
-
-    if ((info->ctx_alloc_func != NULL) &&
-        ((ctx->pk_ctx = info->ctx_alloc_func()) == NULL)) {
-        return MBEDTLS_ERR_PK_ALLOC_FAILED;
     }
 
     ctx->pk_info = info;

--- a/drivers/builtin/src/pk_wrap.c
+++ b/drivers/builtin/src/pk_wrap.c
@@ -173,8 +173,6 @@ const mbedtls_pk_info_t mbedtls_rsa_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = rsa_check_pair_wrap,
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = rsa_debug,
 };
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
@@ -598,8 +596,6 @@ const mbedtls_pk_info_t mbedtls_eckey_info = {
 #endif /* PSA_HAVE_ALG_ECDSA_SIGN || PSA_HAVE_ALG_ECDSA_VERIFY */
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = eckey_debug,
 };
 
@@ -624,8 +620,6 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
     .sign_rs_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = eckey_debug,            /* Same underlying key structure */
 };
 
@@ -667,8 +661,6 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
 #endif /* PSA_HAVE_ALG_ECDSA_VERIFY || PSA_HAVE_ALG_ECDSA_SIGN */
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,   /* Compatible key structures */
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = eckey_debug,        /* Compatible key structures */
 };
 #endif /* PSA_HAVE_ALG_SOME_ECDSA */
@@ -717,8 +709,6 @@ const mbedtls_pk_info_t mbedtls_ecdsa_opaque_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = ecdsa_opaque_check_pair_wrap,
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = NULL,
 };
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
@@ -792,8 +782,6 @@ const mbedtls_pk_info_t mbedtls_rsa_opaque_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = NULL,
-    .ctx_alloc_func = NULL,
-    .ctx_free_func = NULL,
     .debug_func = NULL,
 };
 

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -71,12 +71,6 @@ struct mbedtls_pk_info_t {
     /** Check public-private key pair */
     int (*check_pair_func)(mbedtls_pk_context *pub, mbedtls_pk_context *prv);
 
-    /** Allocate a new context */
-    void * (*ctx_alloc_func)(void);
-
-    /** Free the given context */
-    void (*ctx_free_func)(void *ctx);
-
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     /** Allocate the restart context */
     void *(*rs_alloc_func)(mbedtls_pk_rs_op_t op_type);

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -137,18 +137,12 @@ typedef struct mbedtls_pk_info_t mbedtls_pk_info_t;
 typedef struct mbedtls_pk_context {
     /* Public key information. */
     const mbedtls_pk_info_t *MBEDTLS_PRIVATE(pk_info);
-    /* Previously: underlying public key context.
-     * Now unused (by public functions at least). */
-    void *MBEDTLS_PRIVATE(pk_ctx);
 
-    /* The following field is used to store the ID of a private key for:
-     * - EC keys (MBEDTLS_PK_ECKEY, MBEDTLS_PK_ECKEY_DH, MBEDTLS_PK_ECDSA)
-     * - Wrapped keys (EC or RSA).
+    /* The following field is used to store the ID of a private key.
      *
      * priv_id = MBEDTLS_SVC_KEY_ID_INIT when PK context wraps only the public
      * key.
-     *
-     * Other keys still use the pk_ctx to store their own context. */
+     */
     mbedtls_svc_key_id_t MBEDTLS_PRIVATE(priv_id);
 
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)

--- a/include/mbedtls/private/pk_private.h
+++ b/include/mbedtls/private/pk_private.h
@@ -171,53 +171,6 @@ const char *mbedtls_pk_get_name(const mbedtls_pk_context *ctx);
  */
 mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context *ctx);
 
-#if defined(MBEDTLS_RSA_C)
-/**
- * Quick access to an RSA context inside a PK context.
- *
- * \warning This function can only be used when the type of the context, as
- * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_RSA.
- * Ensuring that is the caller's responsibility.
- * Alternatively, you can check whether this function returns NULL.
- *
- * \return The internal RSA context held by the PK context, or NULL.
- */
-static inline mbedtls_rsa_context *mbedtls_pk_rsa(const mbedtls_pk_context pk)
-{
-    switch (mbedtls_pk_get_type(&pk)) {
-        case MBEDTLS_PK_RSA:
-            return (mbedtls_rsa_context *) (pk).MBEDTLS_PRIVATE(pk_ctx);
-        default:
-            return NULL;
-    }
-}
-#endif /* MBEDTLS_RSA_C */
-
-#if defined(MBEDTLS_ECP_C)
-/**
- * Quick access to an EC context inside a PK context.
- *
- * \warning This function can only be used when the type of the context, as
- * returned by mbedtls_pk_get_type(), is #MBEDTLS_PK_ECKEY,
- * #MBEDTLS_PK_ECKEY_DH, or #MBEDTLS_PK_ECDSA.
- * Ensuring that is the caller's responsibility.
- * Alternatively, you can check whether this function returns NULL.
- *
- * \return The internal EC context held by the PK context, or NULL.
- */
-static inline mbedtls_ecp_keypair *mbedtls_pk_ec(const mbedtls_pk_context pk)
-{
-    switch (mbedtls_pk_get_type(&pk)) {
-        case MBEDTLS_PK_ECKEY:
-        case MBEDTLS_PK_ECKEY_DH:
-        case MBEDTLS_PK_ECDSA:
-            return (mbedtls_ecp_keypair *) (pk).MBEDTLS_PRIVATE(pk_ctx);
-        default:
-            return NULL;
-    }
-}
-#endif /* MBEDTLS_ECP_C */
-
 #if defined(MBEDTLS_PK_PARSE_C)
 /**
  * \brief           Parse a SubjectPublicKeyInfo DER structure

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -5,12 +5,14 @@
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
+
 #define MAX_LEN 0x1000
 static uint8_t out_buf[MAX_LEN];
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
+
     int ret;
     mbedtls_pk_context pk;
 
@@ -38,10 +40,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 exit:
     mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
-#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
-    (void) Data;
-    (void) Size;
-#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
 
     return 0;
 }
+
+#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+    (void) Data;
+    (void) Size;
+    return 0;
+}
+#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
@@ -24,28 +23,22 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        fprintf(stderr, "Error: failed to initialize PSA\n");
         abort();
     }
 
     ret = mbedtls_pk_parse_key(&pk, Data, Size, NULL, 0);
     if (ret != 0) {
-        fprintf(stderr, "Error: key parsing failed\n");
         abort();
     }
 
     ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
     if (ret <= 0) {
-        fprintf(stderr, "Error: key writing failed\n");
         abort();
     }
 
     if (memcmp(Data, out_buf, Size) != 0) {
-        fprintf(stderr, "Error: exported key doesn´t match\n");
         abort();
     }
-
-    fprintf(stderr, "OK\n");
 
     mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -7,19 +7,17 @@
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
-//4 Kb should be enough for every bug ;-)
 #define MAX_LEN 0x1000
+static uint8_t out_buf[MAX_LEN];
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
 #if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
     int ret;
     mbedtls_pk_context pk;
-    uint8_t *out_buf = NULL;
 
     if (Size > MAX_LEN) {
-        //only work on small inputs
-        Size = MAX_LEN;
+        abort();
     }
 
     mbedtls_pk_init(&pk);
@@ -36,8 +34,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         abort();
     }
 
-    out_buf = malloc(Size);
-
     ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
     if (ret <= 0) {
         fprintf(stderr, "Error: key writing failed\n");
@@ -51,9 +47,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     fprintf(stderr, "OK\n");
 
-    if (out_buf != NULL) {
-        free(out_buf);
-    }
     mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
 #else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
@@ -33,10 +32,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
     if (ret <= 0) {
-        abort();
-    }
-
-    if (memcmp(Data, out_buf, Size) != 0) {
         abort();
     }
 

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -2,102 +2,64 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include "mbedtls/pk.h"
-#include "mbedtls/private/pk_private.h"
-#include "mbedtls/private/entropy.h"
-#include "mbedtls/private/ctr_drbg.h"
-#include "mbedtls/private/pk_private.h"
 #include "fuzz_common.h"
 
 //4 Kb should be enough for every bug ;-)
 #define MAX_LEN 0x1000
 
-#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_CTR_DRBG_C) && defined(MBEDTLS_ENTROPY_C)
-const char *pers = "fuzz_privkey";
-#endif // MBEDTLS_PK_PARSE_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_ENTROPY_C
-
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_CTR_DRBG_C) && defined(MBEDTLS_ENTROPY_C)
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
     int ret;
     mbedtls_pk_context pk;
-    mbedtls_ctr_drbg_context ctr_drbg;
-    mbedtls_entropy_context entropy;
+    uint8_t *out_buf = NULL;
 
     if (Size > MAX_LEN) {
         //only work on small inputs
         Size = MAX_LEN;
     }
 
-    mbedtls_ctr_drbg_init(&ctr_drbg);
-    mbedtls_entropy_init(&entropy);
     mbedtls_pk_init(&pk);
 
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        goto exit;
-    }
-
-    if (mbedtls_ctr_drbg_seed(&ctr_drbg, dummy_entropy, &entropy,
-                              (const unsigned char *) pers, strlen(pers)) != 0) {
-        goto exit;
+        fprintf(stderr, "Error: failed to initialize PSA\n");
+        abort();
     }
 
     ret = mbedtls_pk_parse_key(&pk, Data, Size, NULL, 0);
-    if (ret == 0) {
-#if defined(MBEDTLS_RSA_C)
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_RSA) {
-            mbedtls_mpi N, P, Q, D, E, DP, DQ, QP;
-            mbedtls_rsa_context *rsa;
-
-            mbedtls_mpi_init(&N); mbedtls_mpi_init(&P); mbedtls_mpi_init(&Q);
-            mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
-            mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
-
-            rsa = mbedtls_pk_rsa(pk);
-            if (mbedtls_rsa_export(rsa, &N, &P, &Q, &D, &E) != 0) {
-                abort();
-            }
-            if (mbedtls_rsa_export_crt(rsa, &DP, &DQ, &QP) != 0) {
-                abort();
-            }
-
-            mbedtls_mpi_free(&N); mbedtls_mpi_free(&P); mbedtls_mpi_free(&Q);
-            mbedtls_mpi_free(&D); mbedtls_mpi_free(&E); mbedtls_mpi_free(&DP);
-            mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);
-        } else
-#endif
-#if defined(MBEDTLS_ECP_C)
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY_DH) {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec(pk);
-            mbedtls_ecp_group_id grp_id = mbedtls_ecp_keypair_get_group_id(ecp);
-            const mbedtls_ecp_curve_info *curve_info =
-                mbedtls_ecp_curve_info_from_grp_id(grp_id);
-
-            /* If the curve is not supported, the key should not have been
-             * accepted. */
-            if (curve_info == NULL) {
-                abort();
-            }
-        } else
-#endif
-        {
-            /* The key is valid but is not of a supported type.
-             * This should not happen. */
-            abort();
-        }
+    if (ret != 0) {
+        fprintf(stderr, "Error: key parsing failed\n");
+        abort();
     }
-exit:
-    mbedtls_entropy_free(&entropy);
-    mbedtls_ctr_drbg_free(&ctr_drbg);
+
+    out_buf = malloc(Size);
+
+    ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
+    if (ret <= 0) {
+        fprintf(stderr, "Error: key writing failed\n");
+        abort();
+    }
+
+    if (memcmp(Data, out_buf, Size) != 0) {
+        fprintf(stderr, "Error: exported key doesn´t match\n");
+        abort();
+    }
+
+    fprintf(stderr, "OK\n");
+
+    if (out_buf != NULL) {
+        free(out_buf);
+    }
     mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
-#else // MBEDTLS_PK_PARSE_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_ENTROPY_C
+#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
     (void) Data;
     (void) Size;
-#endif // MBEDTLS_PK_PARSE_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_ENTROPY_C
+#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
 
     return 0;
 }

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -22,7 +22,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        abort();
+        goto exit;
     }
 
     ret = mbedtls_pk_parse_key(&pk, Data, Size, NULL, 0);
@@ -35,6 +35,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         abort();
     }
 
+exit:
     mbedtls_pk_free(&pk);
     mbedtls_psa_crypto_free();
 #else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -31,16 +31,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     ret = mbedtls_pk_parse_key(&pk, Data, Size, NULL, 0);
     if (ret == 0) {
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_RSA ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY_DH) {
-            ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
-            if (ret != 0) {
-                abort();
-            }
-        } else {
-            /* The key is valid but is not of a supported type.
-             * This should not happen. */
+        ret = mbedtls_pk_write_key_der(&pk, out_buf, Size);
+        if (ret != 0) {
             abort();
         }
     }

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -7,12 +7,18 @@
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
+#define MAX_LEN 0x1000
+static uint8_t out_buf[MAX_LEN];
+
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
 #if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
     int ret;
     mbedtls_pk_context pk;
-    uint8_t *out_buf = NULL;
+
+    if (Size > MAX_LEN) {
+        abort();
+    }
 
     mbedtls_pk_init(&pk);
     psa_status_t status = psa_crypto_init();
@@ -27,8 +33,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         abort();
     }
 
-    out_buf = malloc(Size);
-
     ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
     if (ret <= 0) {
         fprintf(stderr, "Error: key writing failed\n");
@@ -42,9 +46,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     fprintf(stderr, "OK\n");
 
-    if (out_buf != NULL) {
-        free(out_buf);
-    }
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);
 #else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
+#include "mbedtls/private/pk_private.h"
 
 #if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
 
@@ -15,26 +16,24 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     int ret;
     mbedtls_pk_context pk;
 
-    if (Size > MAX_LEN) {
-        abort();
-    }
-
     mbedtls_pk_init(&pk);
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         goto exit;
     }
-
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
-    if (ret != 0) {
-        abort();
+    if (ret == 0) {
+        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_RSA ||
+            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY ||
+            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY_DH) {
+            ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
+            if (ret <= 0) {
+                abort();
+            }
+        } else {
+            abort();
+        }
     }
-
-    ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
-    if (ret <= 0) {
-        abort();
-    }
-
 exit:
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
@@ -32,10 +31,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
     if (ret <= 0) {
-        abort();
-    }
-
-    if (memcmp(Data, out_buf, Size) != 0) {
         abort();
     }
 

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
@@ -23,28 +22,22 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_pk_init(&pk);
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        fprintf(stderr, "Error: failed to initialize PSA\n");
         abort();
     }
 
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
     if (ret != 0) {
-        fprintf(stderr, "Error: key parsing failed\n");
         abort();
     }
 
     ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
     if (ret <= 0) {
-        fprintf(stderr, "Error: key writing failed\n");
         abort();
     }
 
     if (memcmp(Data, out_buf, Size) != 0) {
-        fprintf(stderr, "Error: exported key doesn´t match\n");
         abort();
     }
-
-    fprintf(stderr, "OK\n");
 
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -5,12 +5,13 @@
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
 
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
+
 #define MAX_LEN 0x1000
 static uint8_t out_buf[MAX_LEN];
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
     int ret;
     mbedtls_pk_context pk;
 
@@ -37,10 +38,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 exit:
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);
-#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
-    (void) Data;
-    (void) Size;
-#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
 
     return 0;
 }
+
+#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+    (void) Data;
+    (void) Size;
+    return 0;
+}
+
+#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -21,7 +21,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     mbedtls_pk_init(&pk);
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        abort();
+        goto exit;
     }
 
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
@@ -34,6 +34,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         abort();
     }
 
+exit:
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);
 #else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -2,89 +2,55 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 #include "mbedtls/pk.h"
 #include "fuzz_common.h"
-#include "mbedtls/private/pk_private.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-#ifdef MBEDTLS_PK_PARSE_C
+#if defined(MBEDTLS_PK_PARSE_C) && defined(MBEDTLS_PK_WRITE_C)
     int ret;
     mbedtls_pk_context pk;
+    uint8_t *out_buf = NULL;
 
     mbedtls_pk_init(&pk);
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
-        goto exit;
+        fprintf(stderr, "Error: failed to initialize PSA\n");
+        abort();
     }
+
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
-    if (ret == 0) {
-#if defined(MBEDTLS_RSA_C)
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_RSA) {
-            mbedtls_mpi N, P, Q, D, E, DP, DQ, QP;
-            mbedtls_rsa_context *rsa;
-
-            mbedtls_mpi_init(&N); mbedtls_mpi_init(&P); mbedtls_mpi_init(&Q);
-            mbedtls_mpi_init(&D); mbedtls_mpi_init(&E); mbedtls_mpi_init(&DP);
-            mbedtls_mpi_init(&DQ); mbedtls_mpi_init(&QP);
-
-            rsa = mbedtls_pk_rsa(pk);
-            if (mbedtls_rsa_export(rsa, &N, NULL, NULL, NULL, &E) != 0) {
-                abort();
-            }
-            if (mbedtls_rsa_export(rsa, &N, &P, &Q, &D, &E) != MBEDTLS_ERR_RSA_BAD_INPUT_DATA) {
-                abort();
-            }
-            if (mbedtls_rsa_export_crt(rsa, &DP, &DQ, &QP) != MBEDTLS_ERR_RSA_BAD_INPUT_DATA) {
-                abort();
-            }
-
-            mbedtls_mpi_free(&N); mbedtls_mpi_free(&P); mbedtls_mpi_free(&Q);
-            mbedtls_mpi_free(&D); mbedtls_mpi_free(&E); mbedtls_mpi_free(&DP);
-            mbedtls_mpi_free(&DQ); mbedtls_mpi_free(&QP);
-
-        } else
-#endif
-#if defined(MBEDTLS_ECP_C)
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY_DH) {
-            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec(pk);
-            mbedtls_ecp_group_id grp_id = mbedtls_ecp_keypair_get_group_id(ecp);
-            const mbedtls_ecp_curve_info *curve_info =
-                mbedtls_ecp_curve_info_from_grp_id(grp_id);
-
-            /* If the curve is not supported, the key should not have been
-             * accepted. */
-            if (curve_info == NULL) {
-                abort();
-            }
-
-            /* It's a public key, so the private value should not have
-             * been changed from its initialization to 0. */
-            mbedtls_mpi d;
-            mbedtls_mpi_init(&d);
-            if (mbedtls_ecp_export(ecp, NULL, &d, NULL) != 0) {
-                abort();
-            }
-            if (mbedtls_mpi_cmp_int(&d, 0) != 0) {
-                abort();
-            }
-            mbedtls_mpi_free(&d);
-        } else
-#endif
-        {
-            /* The key is valid but is not of a supported type.
-             * This should not happen. */
-            abort();
-        }
+    if (ret != 0) {
+        fprintf(stderr, "Error: key parsing failed\n");
+        abort();
     }
-exit:
+
+    out_buf = malloc(Size);
+
+    ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
+    if (ret <= 0) {
+        fprintf(stderr, "Error: key writing failed\n");
+        abort();
+    }
+
+    if (memcmp(Data, out_buf, Size) != 0) {
+        fprintf(stderr, "Error: exported key doesn´t match\n");
+        abort();
+    }
+
+    fprintf(stderr, "OK\n");
+
+    if (out_buf != NULL) {
+        free(out_buf);
+    }
     mbedtls_psa_crypto_free();
     mbedtls_pk_free(&pk);
-#else
+#else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
     (void) Data;
     (void) Size;
-#endif //MBEDTLS_PK_PARSE_C
+#endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
 
     return 0;
 }

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -23,14 +23,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
     }
     ret = mbedtls_pk_parse_public_key(&pk, Data, Size);
     if (ret == 0) {
-        if (mbedtls_pk_get_type(&pk) == MBEDTLS_PK_RSA ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY ||
-            mbedtls_pk_get_type(&pk) == MBEDTLS_PK_ECKEY_DH) {
-            ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
-            if (ret <= 0) {
-                abort();
-            }
-        } else {
+        ret = mbedtls_pk_write_pubkey_der(&pk, out_buf, Size);
+        if (ret <= 0) {
             abort();
         }
     }

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1397,7 +1397,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_SHA_256:MBEDTLS_TEST_PK_PSA_SIGN */
+/* BEGIN_CASE depends_on:PSA_WANT_ALG_SHA_256:MBEDTLS_TEST_PK_PSA_SIGN */
 void pk_psa_sign(int psa_type, int bits, int psa_alg, int expected_ret)
 {
     mbedtls_pk_context pk;

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1450,24 +1450,9 @@ void pk_psa_sign(int psa_type, int bits, int psa_alg, int expected_ret)
             normal_pub_key + sizeof(normal_pub_key) - normal_pub_key_len,
             normal_pub_key_len);
 #else /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
-#if defined(PSA_HAVE_ALG_ECDSA_SIGN)
-    if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(psa_type)) {
-        TEST_ASSERT(sizeof(normal_pub_key) >= pk.pub_raw_len);
-        memcpy(normal_pub_key, pk.pub_raw, pk.pub_raw_len);
-        normal_pub_key_len = pk.pub_raw_len;
-    }
-#endif /* PSA_HAVE_ALG_ECDSA_SIGN */
-#if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
-    if (PSA_KEY_TYPE_IS_RSA(psa_type)) {
-        unsigned char *end = normal_pub_key + sizeof(normal_pub_key);
-        ret = mbedtls_rsa_write_pubkey(mbedtls_pk_rsa(pk), normal_pub_key, &end);
-        normal_pub_key_len = (size_t) ret;
-        TEST_ASSERT(normal_pub_key_len > 0);
-        /* mbedtls_rsa_write_pubkey() writes data backward in the buffer so
-         * we shift that to the origin of the buffer instead. */
-        memmove(normal_pub_key, end, normal_pub_key_len);
-    }
-#endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
+    TEST_ASSERT(sizeof(normal_pub_key) >= pk.pub_raw_len);
+    memcpy(normal_pub_key, pk.pub_raw, pk.pub_raw_len);
+    normal_pub_key_len = pk.pub_raw_len;
 #endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */
 
     /* Turn the PK context into an PSA-wrapping one. */
@@ -1540,8 +1525,7 @@ void pk_psa_sign(int psa_type, int bits, int psa_alg, int expected_ret)
 #if defined(MBEDTLS_RSA_C)
     if (PSA_KEY_TYPE_IS_RSA(psa_type)) {
         TEST_EQUAL(mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)), 0);
-        TEST_EQUAL(mbedtls_rsa_parse_pubkey(mbedtls_pk_rsa(pk), normal_pub_key,
-                                            normal_pub_key_len), 0);
+        TEST_EQUAL(mbedtls_pk_rsa_set_pubkey(&pk, normal_pub_key, normal_pub_key_len), 0);
     }
 #endif /* MBEDTLS_RSA_C */
 #endif /* MBEDTLS_PK_PARSE_C && MBEDTLS_PK_WRITE_C */


### PR DESCRIPTION
## Description

Resolves #489 
Might resolve #491

## PR checklist

- [x] **changelog** not required because: "pk_ctx" was a private element in PK structure and `mbedtls_pk_[rsa|ec]` were internal so none of these elements was accessible to the end user.
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **mbedtls 3.6 PR** not required because: no backport
- **tests**  not required because: removed code was already unused