### PR TITLE
Remove the RSA key mutex

### DIFF
--- a/drivers/builtin/include/mbedtls/private/rsa.h
+++ b/drivers/builtin/include/mbedtls/private/rsa.h
@@ -22,10 +22,6 @@
 #include "mbedtls/private/bignum.h"
 #include "mbedtls/md.h"
 
-#if defined(MBEDTLS_THREADING_C)
-#include "mbedtls/threading.h"
-#endif
-
 /*
  * RSA Error codes
  */
@@ -111,10 +107,6 @@ typedef struct mbedtls_rsa_context {
                                                     as specified in md.h for use in the MGF
                                                     mask generating function used in the
                                                     EME-OAEP and EMSA-PSS encodings. */
-#if defined(MBEDTLS_THREADING_C)
-    /* Invariant: the mutex is initialized iff ver != 0. */
-    mbedtls_threading_mutex_t MBEDTLS_PRIVATE(mutex);    /*!<  Thread-safety mutex. */
-#endif
 }
 mbedtls_rsa_context;
 

--- a/drivers/builtin/include/mbedtls/private/rsa.h
+++ b/drivers/builtin/include/mbedtls/private/rsa.h
@@ -75,10 +75,6 @@ extern "C" {
  * \brief   The RSA context structure.
  */
 typedef struct mbedtls_rsa_context {
-    int MBEDTLS_PRIVATE(ver);                    /*!<  Reserved for internal purposes.
-                                                  *    Do not set this field in application
-                                                  *    code. Its meaning might change without
-                                                  *    notice. */
     size_t MBEDTLS_PRIVATE(len);                 /*!<  The size of \p N in Bytes. */
 
     mbedtls_mpi MBEDTLS_PRIVATE(N);              /*!<  The public modulus. */

--- a/drivers/builtin/src/rsa.c
+++ b/drivers/builtin/src/rsa.c
@@ -954,13 +954,6 @@ void mbedtls_rsa_init(mbedtls_rsa_context *ctx)
 
     ctx->padding = MBEDTLS_RSA_PKCS_V15;
     ctx->hash_id = MBEDTLS_MD_NONE;
-
-#if defined(MBEDTLS_THREADING_C)
-    /* Set ctx->ver to nonzero to indicate that the mutex has been
-     * initialized and will need to be freed. */
-    ctx->ver = 1;
-    mbedtls_mutex_init(&ctx->mutex);
-#endif
 }
 
 /*
@@ -1244,12 +1237,6 @@ int mbedtls_rsa_public(mbedtls_rsa_context *ctx,
 
     mbedtls_mpi_init(&T);
 
-#if defined(MBEDTLS_THREADING_C)
-    if ((ret = mbedtls_mutex_lock(&ctx->mutex)) != 0) {
-        return ret;
-    }
-#endif
-
     MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary(&T, input, ctx->len));
 
     if (mbedtls_mpi_cmp_mpi(&T, &ctx->N) >= 0) {
@@ -1262,11 +1249,6 @@ int mbedtls_rsa_public(mbedtls_rsa_context *ctx,
     MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(&T, output, olen));
 
 cleanup:
-#if defined(MBEDTLS_THREADING_C)
-    if (mbedtls_mutex_unlock(&ctx->mutex) != 0) {
-        return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
-    }
-#endif
 
     mbedtls_mpi_free(&T);
 
@@ -1445,12 +1427,6 @@ int mbedtls_rsa_private(mbedtls_rsa_context *ctx,
         return MBEDTLS_ERR_RSA_BAD_INPUT_DATA;
     }
 
-#if defined(MBEDTLS_THREADING_C)
-    if ((ret = mbedtls_mutex_lock(&ctx->mutex)) != 0) {
-        return ret;
-    }
-#endif
-
     /* MPI Initialization */
     mbedtls_mpi_init(&T);
 
@@ -1570,11 +1546,6 @@ int mbedtls_rsa_private(mbedtls_rsa_context *ctx,
     MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(&T, output, olen));
 
 cleanup:
-#if defined(MBEDTLS_THREADING_C)
-    if (mbedtls_mutex_unlock(&ctx->mutex) != 0) {
-        return MBEDTLS_ERR_THREADING_MUTEX_ERROR;
-    }
-#endif
 
     mbedtls_mpi_free(&P1);
     mbedtls_mpi_free(&Q1);
@@ -2830,14 +2801,6 @@ void mbedtls_rsa_free(mbedtls_rsa_context *ctx)
     mbedtls_mpi_free(&ctx->DQ);
     mbedtls_mpi_free(&ctx->DP);
 #endif /* MBEDTLS_RSA_NO_CRT */
-
-#if defined(MBEDTLS_THREADING_C)
-    /* Free the mutex, but only if it hasn't been freed already. */
-    if (ctx->ver != 0) {
-        mbedtls_mutex_free(&ctx->mutex);
-        ctx->ver = 0;
-    }
-#endif
 }
 
 #if defined(MBEDTLS_SELF_TEST)


### PR DESCRIPTION
## Description

Resolves https://github.com/Mbed-TLS/mbedtls/issues/4124

## PR checklist

- [x] **changelog** not required because: RSA module was internal and already mutexed by the PSA interface so nothing changes from user point of view.
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **mbedtls 3.6 PR** not required because: no backport
- **tests**  not required