### PR TITLE
PK: fix config dependencies and simplify guards

### DIFF
--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -261,8 +261,12 @@
 #endif
 
 #if defined(MBEDTLS_PK_C) && \
-    !defined(MBEDTLS_RSA_C) && !defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
-#error "MBEDTLS_PK_C defined, but not all prerequisites"
+    !defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) && !defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+#error "MBEDTLS_PK_C defined, but neither PSA_WANT_KEY_TYPE_[ECC|RSA]_PUBLIC_KEY are"
+#endif
+
+#if defined(MBEDTLS_PK_C) && !defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+#error "MBEDTLS_PK_C defined, but not MBEDTLS_PSA_CRYPTO_CLIENT"
 #endif
 
 #if defined(MBEDTLS_PK_PARSE_C) && \

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -32,10 +32,8 @@
 #include "mbedtls/private/ecdsa.h"
 #endif
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include "psa_util_internal.h"
 #include "mbedtls/psa_util.h"
-#endif
 
 #include <limits.h>
 #include <stdint.h>
@@ -52,11 +50,9 @@ void mbedtls_pk_init(mbedtls_pk_context *ctx)
     ctx->pk_info = NULL;
     ctx->pk_ctx = NULL;
     ctx->priv_id = MBEDTLS_SVC_KEY_ID_INIT;
-#if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     memset(ctx->pub_raw, 0, sizeof(ctx->pub_raw));
     ctx->pub_raw_len = 0;
     ctx->bits = 0;
-#endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY || PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     ctx->ec_family = 0;
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
@@ -538,7 +534,6 @@ int mbedtls_pk_can_do_psa(const mbedtls_pk_context *pk, psa_algorithm_t alg,
     return 0;
 }
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 int mbedtls_pk_get_psa_attributes(const mbedtls_pk_context *pk,
                                   psa_key_usage_t usage,
                                   psa_key_attributes_t *attributes)
@@ -1010,7 +1005,6 @@ int mbedtls_pk_copy_public_from_psa(mbedtls_svc_key_id_t key_id,
 {
     return copy_from_psa(key_id, pk, 1);
 }
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 /*
  * Helper for mbedtls_pk_sign and mbedtls_pk_verify

--- a/drivers/builtin/src/pk_internal.h
+++ b/drivers/builtin/src/pk_internal.h
@@ -20,7 +20,6 @@
 #include "mbedtls/private/ecp.h"
 #endif
 
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include "psa/crypto.h"
 
 #include "psa_util_internal.h"
@@ -31,7 +30,6 @@
 #define PSA_PK_ECDSA_TO_MBEDTLS_ERR(status) PSA_TO_MBEDTLS_ERR_LIST(status,   \
                                                                     psa_to_pk_ecdsa_errors,        \
                                                                     psa_pk_status_to_mbedtls)
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 /* Headers/footers for PEM files */
 #define PEM_BEGIN_PUBLIC_KEY    "-----BEGIN PUBLIC KEY-----"

--- a/drivers/builtin/src/pkwrite.c
+++ b/drivers/builtin/src/pkwrite.c
@@ -29,9 +29,7 @@
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include "pk_internal.h"
 #endif
-#if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
 #include "pkwrite.h"
-#endif
 #if defined(MBEDTLS_PEM_WRITE_C)
 #include "mbedtls/pem.h"
 #endif

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -156,7 +156,6 @@ typedef struct mbedtls_pk_context {
      * Other keys still use the pk_ctx to store their own context. */
     mbedtls_svc_key_id_t MBEDTLS_PRIVATE(priv_id);
 
-#if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     /* Public EC or RSA key in raw format, where raw here means the format returned
      * by psa_export_public_key(). */
     uint8_t MBEDTLS_PRIVATE(pub_raw)[MBEDTLS_PK_MAX_PUBKEY_RAW_LEN];
@@ -166,7 +165,6 @@ typedef struct mbedtls_pk_context {
 
     /* Bits of the private/public key. */
     size_t MBEDTLS_PRIVATE(bits);
-#endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY || PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     /* EC family. Only applies to EC keys. */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -16,12 +16,8 @@
 
 #include "tf-psa-crypto/build_info.h"
 #include "mbedtls/compat-3-crypto.h"
-
 #include "mbedtls/md.h"
-
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 #include "psa/crypto.h"
-#endif
 
 /** Type mismatch, eg attempt to do ECDSA with an RSA key */
 #define MBEDTLS_ERR_PK_TYPE_MISMATCH       -0x3F00
@@ -339,8 +335,6 @@ size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context *ctx);
  */
 int mbedtls_pk_can_do_psa(const mbedtls_pk_context *pk, psa_algorithm_t alg,
                           psa_key_usage_t usage);
-
-#if defined(MBEDTLS_PSA_CRYPTO_CLIENT)
 /**
  * \brief           Determine valid PSA attributes that can be used to
  *                  import a key into PSA.
@@ -535,7 +529,6 @@ int mbedtls_pk_copy_from_psa(mbedtls_svc_key_id_t key_id, mbedtls_pk_context *pk
  *                  parameters are not correct.
  */
 int mbedtls_pk_copy_public_from_psa(mbedtls_svc_key_id_t key_id, mbedtls_pk_context *pk);
-#endif /* MBEDTLS_PSA_CRYPTO_CLIENT */
 
 /**
  * \brief           Verify signature.

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -794,7 +794,9 @@
  * Module:  drivers/builtin/src/pk.c
  * Caller:  drivers/builtin/src/psa_crypto_rsa.c
  *
- * Requires: MBEDTLS_MD_C, the built-in RSA or ECP implementation
+ * Requires: #MBEDTLS_PSA_CRYPTO_CLIENT and at least one between
+ *           #PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY and
+ *           #PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY.
  *
  * Uncomment to enable generic public key wrappers.
  */


### PR DESCRIPTION
## Description

Resolves #490.

## PR checklist

- [x] **changelog** not required because: I don't think it's required. With this PR we basically making explicit some dependencies that were already in place also before, so nothing new is happening for which the end user should be warned.
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **mbedtls 3.6 PR** not required because: no backport
- **tests** not required because: no code change to be tested