### PR TITLE
Remove uses of mbedtls_pk_verify_new

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1196,22 +1196,6 @@ int mbedtls_pk_verify_ext(mbedtls_pk_sigalg_t type,
 }
 
 /*
- * Verify a signature
- */
-int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
-                          mbedtls_md_type_t md_alg, const unsigned char *hash,
-                          size_t hash_len, const unsigned char *sig, size_t sig_len)
-{
-    return mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) type,
-                                 ctx,
-                                 md_alg,
-                                 hash,
-                                 hash_len,
-                                 sig,
-                                 sig_len);
-}
-
-/*
  * Make a signature (restartable)
  */
 int mbedtls_pk_sign_restartable(mbedtls_pk_context *ctx,

--- a/include/mbedtls/private/pk_private.h
+++ b/include/mbedtls/private/pk_private.h
@@ -247,36 +247,5 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
 int mbedtls_pk_write_pubkey(unsigned char **p, unsigned char *start,
                             const mbedtls_pk_context *key);
 #endif /* MBEDTLS_PK_WRITE_C */
-
-/**
- * \brief           Verify signature, with explicit selection of the signature algorithm.
- *                  (Includes verification of the padding depending on type.)
- *
- * \param type      Signature type (inc. possible padding type) to verify
- * \param ctx       The PK context to use. It must have been set up.
- * \param md_alg    Hash algorithm used (see notes)
- * \param hash      Hash of the message to sign
- * \param hash_len  Hash length or 0 (see notes)
- * \param sig       Signature to verify
- * \param sig_len   Signature length
- *
- * \return          0 on success (signature is valid),
- *                  #MBEDTLS_ERR_PK_TYPE_MISMATCH if the PK context can't be
- *                  used for this type of signatures,
- *                  #PSA_ERROR_INVALID_SIGNATURE if there is a valid
- *                  signature in \p sig but its length is less than \p sig_len,
- *                  or a specific error code.
- *
- * \note            If hash_len is 0, then the length associated with md_alg
- *                  is used instead, or an error returned if it is invalid.
- *
- * \note            \p options parameter is kept for backward compatibility.
- *                  If key type is different from MBEDTLS_PK_RSASSA_PSS it must
- *                  be NULL, otherwise it's just ignored.
- */
-int mbedtls_pk_verify_new(mbedtls_pk_type_t type, mbedtls_pk_context *ctx,
-                          mbedtls_md_type_t md_alg, const unsigned char *hash,
-                          size_t hash_len, const unsigned char *sig, size_t sig_len);
-
 #endif /* MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS */
 #endif /* MBEDTLS_PRIVATE_PK_PRIVATE_H */


### PR DESCRIPTION
## Description

Remove uses of mbedtls_pk_verify_new depends on https://github.com/Mbed-TLS/mbedtls/pull/10449 resolves https://github.com/Mbed-TLS/mbedtls/issues/10445


This PR is part of a multistage PR to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10449
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/517

## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10449
- [x] **mbedtls 3.6 PR** not required because: No backports
- **tests**  not required because: No changes 
