### PR TITLE
cmake: Add TF_PSA_CRYPTO_CONFIG_NAME option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ if(NOT DEFINED TF_PSA_CRYPTO_AS_SUBPROJECT)
 endif()
 
 # Set the project, Mbed TLS and framework root directory.
-set(TF_PSA_CRYPTO_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TF_PSA_CRYPTO_FRAMEWORK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/framework)
 
 # Put the version numbers into relevant files
@@ -72,7 +71,7 @@ set(version_number_files
         doxygen/tfpsacrypto.doxyfile)
 foreach(file ${version_number_files})
     configure_file(${file}.in
-                   ${TF_PSA_CRYPTO_DIR}/${file})
+                   ${PROJECT_SOURCE_DIR}/${file})
 endforeach(file)
 
 ADD_CUSTOM_TARGET(${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto-apidoc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,15 @@ endif()
 # Make TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
+set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Name of the configuration to use (see config.py documentation)")
+
+set(TF_PSA_CRYPTO_crypto_config_path ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h)
+if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+    if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "")
+        message(FATAL_ERROR "TF_PSA_CRYPTO_CONFIG_NAME and TF_PSA_CRYPTO_CONFIG_FILE are incompatible.")
+    endif()
+    set(TF_PSA_CRYPTO_crypto_config_path ${PROJECT_BINARY_DIR}/include/psa/crypto_config.h)
+endif(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,12 +157,10 @@ set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (over
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
 set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Name of the configuration to use (see config.py documentation)")
 
-set(TF_PSA_CRYPTO_crypto_config_path ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h)
 if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
     if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "")
         message(FATAL_ERROR "TF_PSA_CRYPTO_CONFIG_NAME and TF_PSA_CRYPTO_CONFIG_FILE are incompatible.")
     endif()
-    set(TF_PSA_CRYPTO_crypto_config_path ${PROJECT_BINARY_DIR}/include/psa/crypto_config.h)
 endif(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
 
 # Create a symbolic link from ${base_name} in the binary directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,9 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
                 ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/tests/include
                 tests/include
                 tests/include/test
+                # Add the build-tree include directory before the source-tree one
+                # so that generated headers in the build tree take precedence.
+                ${CMAKE_CURRENT_BINARY_DIR}/include
                 include
                 core
                 drivers/builtin/src)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -30,7 +30,7 @@ if(GEN_FILES)
             ${PROJECT_SOURCE_DIR}/scripts/generate_config_checks.py
             --list-for-cmake "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${PROJECT_SOURCE_DIR}
         OUTPUT_VARIABLE
             TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,18 +16,18 @@ if(GEN_FILES)
             ${CMAKE_CURRENT_BINARY_DIR}/psa_crypto_driver_wrappers_no_static.c
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
-                ${TF_PSA_CRYPTO_DIR}/scripts/generate_driver_wrappers.py
+                ${PROJECT_SOURCE_DIR}/scripts/generate_driver_wrappers.py
                 ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
-            ${TF_PSA_CRYPTO_DIR}/scripts/generate_driver_wrappers.py
-            ${TF_PSA_CRYPTO_DIR}/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
-            ${TF_PSA_CRYPTO_DIR}/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
+            ${PROJECT_SOURCE_DIR}/scripts/generate_driver_wrappers.py
+            ${PROJECT_SOURCE_DIR}/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+            ${PROJECT_SOURCE_DIR}/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
     )
 
     execute_process(
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
-            ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+            ${PROJECT_SOURCE_DIR}/scripts/generate_config_checks.py
             --list-for-cmake "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY
             ${CMAKE_CURRENT_SOURCE_DIR}/..
@@ -38,10 +38,10 @@ if(GEN_FILES)
         OUTPUT ${TF_PSA_CRYPTO_GENERATED_CONFIG_CHECKS_HEADERS}
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
-                ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+                ${PROJECT_SOURCE_DIR}/scripts/generate_config_checks.py
                 ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
-            ${TF_PSA_CRYPTO_DIR}/scripts/generate_config_checks.py
+            ${PROJECT_SOURCE_DIR}/scripts/generate_config_checks.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/config_checks_generator.py
     )
 
@@ -159,10 +159,10 @@ endif(USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
 foreach(target IN LISTS target_libraries)
     add_library(TF-PSA-Crypto::${target} ALIAS ${target})  # add_subdirectory support
     target_include_directories(${target}
-        PUBLIC $<BUILD_INTERFACE:${TF_PSA_CRYPTO_DIR}/include/>
+        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        PRIVATE ${TF_PSA_CRYPTO_DIR}/core
-                ${TF_PSA_CRYPTO_DIR}/drivers/builtin/src
+        PRIVATE ${PROJECT_SOURCE_DIR}/core
+                ${PROJECT_SOURCE_DIR}/drivers/builtin/src
                 # Needed to include psa_crypto_driver_wrappers.h
                 ${CMAKE_CURRENT_BINARY_DIR})
     foreach(driver_target ${TF_PSA_CRYPTO_DRIVER_TARGETS})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -159,7 +159,10 @@ endif(USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
 foreach(target IN LISTS target_libraries)
     add_library(TF-PSA-Crypto::${target} ALIAS ${target})  # add_subdirectory support
     target_include_directories(${target}
-        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+        # Add the build-tree include directory before the source-tree one
+        # so that generated headers in the build tree take precedence.
+        PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/>
+               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         PRIVATE ${PROJECT_SOURCE_DIR}/core
                 ${PROJECT_SOURCE_DIR}/drivers/builtin/src

--- a/drivers/driver.cmake
+++ b/drivers/driver.cmake
@@ -39,7 +39,10 @@ foreach (target IN LISTS target_libraries)
 
     target_include_directories(${target}
       PUBLIC include
-      PRIVATE ${PROJECT_SOURCE_DIR}/include
+      PRIVATE # Add the build-tree include directory before the source-tree one
+              # so that generated headers in the build tree take precedence.
+              ${PROJECT_BINARY_DIR}/include
+              ${PROJECT_SOURCE_DIR}/include
               ${PROJECT_SOURCE_DIR}/core
               ${TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS})
     tf_psa_crypto_set_config_files_compile_definitions(${target})

--- a/drivers/everest/CMakeLists.txt
+++ b/drivers/everest/CMakeLists.txt
@@ -17,7 +17,10 @@ foreach (target IN LISTS target_libraries)
     tf_psa_crypto_set_base_compile_options(${target})
     target_include_directories(${target}
       PUBLIC include
-      PRIVATE ${PROJECT_SOURCE_DIR}/include
+      PRIVATE # Add the build-tree include directory before the source-tree one
+              # so that generated headers in the build tree take precedence.
+              ${PROJECT_BINARY_DIR}/include
+              ${PROJECT_SOURCE_DIR}/include
               ${TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS}
               include/tf-psa-crypto/private/everest
               include/tf-psa-crypto/private/everest/kremlib

--- a/drivers/everest/CMakeLists.txt
+++ b/drivers/everest/CMakeLists.txt
@@ -17,11 +17,11 @@ foreach (target IN LISTS target_libraries)
     tf_psa_crypto_set_base_compile_options(${target})
     target_include_directories(${target}
       PUBLIC include
-      PRIVATE ${TF_PSA_CRYPTO_DIR}/include
+      PRIVATE ${PROJECT_SOURCE_DIR}/include
               ${TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS}
               include/tf-psa-crypto/private/everest
               include/tf-psa-crypto/private/everest/kremlib
-              ${TF_PSA_CRYPTO_DIR}/core)
+              ${PROJECT_SOURCE_DIR}/core)
     tf_psa_crypto_set_config_files_compile_definitions(${target})
     if(TF_PSA_CRYPTO_TEST_DRIVER)
         add_dependencies(${target} ${TF_PSA_CRYPTO_TEST_DRIVER_GENERATION_TARGETS})

--- a/drivers/p256-m/CMakeLists.txt
+++ b/drivers/p256-m/CMakeLists.txt
@@ -17,7 +17,10 @@ foreach (target IN LISTS target_libraries)
 
     target_include_directories(${target}
       PUBLIC p256-m
-      PRIVATE ${PROJECT_SOURCE_DIR}/include
+              # Add the build-tree include directory before the source-tree one
+              # so that generated headers in the build tree take precedence.
+      PRIVATE ${PROJECT_BINARY_DIR}/include
+              ${PROJECT_SOURCE_DIR}/include
               ${PROJECT_SOURCE_DIR}/core
               ${TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS}
     )

--- a/drivers/p256-m/CMakeLists.txt
+++ b/drivers/p256-m/CMakeLists.txt
@@ -17,8 +17,8 @@ foreach (target IN LISTS target_libraries)
 
     target_include_directories(${target}
       PUBLIC p256-m
-      PRIVATE ${TF_PSA_CRYPTO_DIR}/include
-              ${TF_PSA_CRYPTO_DIR}/core
+      PRIVATE ${PROJECT_SOURCE_DIR}/include
+              ${PROJECT_SOURCE_DIR}/core
               ${TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS}
     )
     tf_psa_crypto_set_config_files_compile_definitions(${target})

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,8 +1,41 @@
 option(INSTALL_TF_PSA_CRYPTO_HEADERS "Install TF PSA Crypto headers." ON)
 
+# The handling of TF_PSA_CRYPTO_CONFIG_NAME assumes that the default
+# configuration file 'include/psa/crypto_config.h' exists in the source tree.
+# That file is copied into the build tree and then modified with 'config.py'
+# according to the configuration name provided via TF_PSA_CRYPTO_CONFIG_NAME.
+
+if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/psa)
+    file(COPY ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h
+         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/psa)
+
+    message(STATUS "Setting ${TF_PSA_CRYPTO_CONFIG_NAME} configuration")
+    execute_process(
+        COMMAND
+            ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/config.py
+            -f ${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h
+            ${TF_PSA_CRYPTO_CONFIG_NAME}
+        RESULT_VARIABLE result
+    )
+    if(result)
+        message(FATAL_ERROR "Setting ${TF_PSA_CRYPTO_CONFIG_NAME} configuration failed")
+    endif()
+endif(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+
 if(INSTALL_TF_PSA_CRYPTO_HEADERS)
     install(DIRECTORY "."
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h"
+        PATTERN "crypto_config.h" EXCLUDE
     )
+
+    if("${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/psa/crypto_config.h"
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa)
+    else()
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h"
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa)
+    endif("${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
 endif(INSTALL_TF_PSA_CRYPTO_HEADERS)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,8 +6,3 @@ if(INSTALL_TF_PSA_CRYPTO_HEADERS)
         FILES_MATCHING PATTERN "*.h"
     )
 endif(INSTALL_TF_PSA_CRYPTO_HEADERS)
-
-# Make includes available in an out-of-source build. ssl-opt.sh requires it.
-if (ENABLE_TESTING AND NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    tf_psa_crypto_link_to_source(psa)
-endif()

--- a/programs/psa/CMakeLists.txt
+++ b/programs/psa/CMakeLists.txt
@@ -14,14 +14,14 @@ if(GEN_FILES)
             ${CMAKE_CURRENT_BINARY_DIR}/psa_constant_names_generated.c
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
-                ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_psa_constants.py
+                ${PROJECT_SOURCE_DIR}/scripts/generate_psa_constants.py
                 ${CMAKE_CURRENT_BINARY_DIR}
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/../..
+            ${PROJECT_SOURCE_DIR}
         DEPENDS
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/generate_psa_constants.py
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../include/psa/crypto_values.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/../../include/psa/crypto_extra.h
+            ${PROJECT_SOURCE_DIR}/scripts/generate_psa_constants.py
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_values.h
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_extra.h
     )
 else()
     tf_psa_crypto_link_to_source(psa_constant_names_generated.c)
@@ -31,7 +31,7 @@ foreach(exe IN LISTS executables)
     add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:tf_psa_crypto_test>)
     tf_psa_crypto_set_base_compile_options(${exe})
     target_link_libraries(${exe} ${tfpsacrypto_target} ${CMAKE_THREAD_LIBS_INIT})
-    target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../framework/tests/include)
+    target_include_directories(${exe} PRIVATE ${PROJECT_SOURCE_DIR}/framework/tests/include)
 endforeach()
 
 target_include_directories(psa_constant_names PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -21,14 +21,14 @@ target_link_libraries(which_aes PRIVATE ${tfpsacrypto_target})
 # dlopen
 if(USE_SHARED_TF_PSA_CRYPTO_LIBRARY AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "[Ww][Ii][Nn]")
     tfpsacrypto_build_program_common(tfpsacrypto_dlopen tfpsacrypto_dlopen.c)
-    target_include_directories(tfpsacrypto_dlopen PRIVATE ${TF_PSA_CRYPTO_DIR}/drivers/builtin/include/)
+    target_include_directories(tfpsacrypto_dlopen PRIVATE ${PROJECT_SOURCE_DIR}/drivers/builtin/include/)
     target_link_libraries(tfpsacrypto_dlopen PRIVATE ${CMAKE_DL_LIBS} ${tfpsacrypto_target})
 endif()
 
 # zeroize
 tfpsacrypto_build_program_common(tf_psa_crypto_zeroize ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/tests/programs/zeroize.c)
 target_link_libraries(tf_psa_crypto_zeroize ${tfpsacrypto_target})
-target_include_directories(tf_psa_crypto_zeroize PRIVATE ${TF_PSA_CRYPTO_DIR}/tests/include/test)
+target_include_directories(tf_psa_crypto_zeroize PRIVATE ${PROJECT_SOURCE_DIR}/tests/include/test)
 
 install(TARGETS ${executable_programs}
         DESTINATION "bin"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -344,9 +344,6 @@ endforeach(test_suite)
 # Make scripts and data files needed for testing available in an
 # out-of-source build.
 if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/seedfile")
-        tf_psa_crypto_link_to_source(seedfile)
-    endif()
     tf_psa_crypto_link_to_source(Descriptions.txt)
     tf_psa_crypto_link_to_source(../framework/data_files)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,7 +153,7 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_data_generation.py
-            ${TF_PSA_CRYPTO_crypto_config_path}
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h
             ${PROJECT_SOURCE_DIR}/include/psa/crypto_values.h
             ${PROJECT_SOURCE_DIR}/include/psa/crypto_extra.h
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,11 +153,10 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_data_generation.py
-            ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h
+            ${TF_PSA_CRYPTO_crypto_config_path}
             ${PROJECT_SOURCE_DIR}/include/psa/crypto_values.h
             ${PROJECT_SOURCE_DIR}/include/psa/crypto_extra.h
     )
-
 else()
     foreach(file ${all_generated_data_files})
         tf_psa_crypto_link_to_source(${file})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ execute_process(
         ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_bignum_tests.py
         --list-for-cmake
     WORKING_DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE
         base_bignum_generated_data_files)
 string(REGEX REPLACE "[^;]*/" ""
@@ -29,7 +29,7 @@ execute_process(
         ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_config_tests.py
         --list-for-cmake
     WORKING_DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE
         base_config_generated_data_files)
 string(REGEX REPLACE "[^;]*/" ""
@@ -42,7 +42,7 @@ execute_process(
         ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_ecp_tests.py
         --list-for-cmake
     WORKING_DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE
         base_ecp_generated_data_files)
 string(REGEX REPLACE "[^;]*/" ""
@@ -54,7 +54,7 @@ execute_process(
         ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_psa_tests.py
         --list-for-cmake
     WORKING_DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE
         base_psa_generated_data_files)
 string(REGEX REPLACE "[^;]*/" ""
@@ -89,7 +89,7 @@ if(GEN_FILES)
         OUTPUT
             ${bignum_generated_data_files}
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${PROJECT_SOURCE_DIR}
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_bignum_tests.py
@@ -107,7 +107,7 @@ if(GEN_FILES)
         OUTPUT
             ${config_generated_data_files}
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${PROJECT_SOURCE_DIR}
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_config_tests.py
@@ -122,7 +122,7 @@ if(GEN_FILES)
         OUTPUT
             ${ecp_generated_data_files}
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${PROJECT_SOURCE_DIR}
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_ecp_tests.py
@@ -138,7 +138,7 @@ if(GEN_FILES)
         OUTPUT
             ${psa_generated_data_files}
         WORKING_DIRECTORY
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${PROJECT_SOURCE_DIR}
         COMMAND
             ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_psa_tests.py
@@ -153,9 +153,9 @@ if(GEN_FILES)
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/psa_test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_case.py
             ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/mbedtls_framework/test_data_generation.py
-            ${CMAKE_CURRENT_SOURCE_DIR}/../include/psa/crypto_config.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/../include/psa/crypto_values.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/../include/psa/crypto_extra.h
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_values.h
+            ${PROJECT_SOURCE_DIR}/include/psa/crypto_extra.h
     )
 
 else()
@@ -301,8 +301,8 @@ function(tf_psa_crypto_add_test_suite suite_name)
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/test
         PRIVATE ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/tests/include
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../core
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../drivers/builtin/src)
+        PRIVATE ${PROJECT_SOURCE_DIR}/core
+        PRIVATE ${PROJECT_SOURCE_DIR}/drivers/builtin/src)
     # Request C11, which is needed for memory poisoning tests
     set_target_properties(test_suite_${data_name} PROPERTIES C_STANDARD 11)
 

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -151,7 +151,7 @@ component_tf_psa_crypto_build_config_name () {
     cmake --build "$OUT_OF_SOURCE_DIR" --target tfpsacrypto
 
     # Restore the default config file in the source tree as we need a sane
-    # one to build the tests.
+    # one to build some PSA test data.
     cp include/psa/crypto_config_default.h "$CRYPTO_CONFIG_H"
     cmake --build "$OUT_OF_SOURCE_DIR"
     cmake --build "$OUT_OF_SOURCE_DIR" --target install


### PR DESCRIPTION
## Description
Add TF_PSA_CRYPTO_CONFIG_NAME CMake option to set one of the named configuration defined in config.py.

## PR checklist
- [x] **changelog** not required (config names are only useful to maintainers)
- [x] **framework PR** not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# TODO but not necessary to merge this PR
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required, not sure if we should add this functionality in 3.6 and how different to do it would be
- **tests**  provided