### PR TITLE
Update lcov.sh paths in make files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,9 +431,9 @@ if(ENABLE_TESTING)
         # 2. Run the relevant tests for the part of the code you're interested in.
         #    For the reference coverage measurement, see
         #    tests/scripts/basic-build-test.sh
-        # 3. Run scripts/lcov.sh to generate an HTML report.
+        # 3. Run framework/scripts/lcov.sh to generate an HTML report.
         ADD_CUSTOM_TARGET(lcov
-            COMMAND ${MBEDTLS_DIR}/scripts/lcov.sh
+            COMMAND framework/scripts/lcov.sh
         )
 
         ADD_CUSTOM_TARGET(memcheck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ endif()
 
 # Set the project, Mbed TLS and framework root directory.
 set(TF_PSA_CRYPTO_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(TF_PSA_CRYPTO_FRAMEWORK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/framework)
 
 # Put the version numbers into relevant files


### PR DESCRIPTION
## Description

Update lcov.sh paths in make files, to reflect the move to framework. contributes https://github.com/Mbed-TLS/mbedtls-framework/issues/93

This PR is part of a multistage PR, however the code changes involved appear to not effect the CI so it can be merged in any order. However it is suggested it is merged in the following order. 
1. https://github.com/Mbed-TLS/mbedtls-framework/pull/224 
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/536  
3. https://github.com/Mbed-TLS/mbedtls/pull/10452 
4. https://github.com/Mbed-TLS/mbedtls/pull/10450

## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework https://github.com/Mbed-TLS/mbedtls-framework/pull/224
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10452
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls https://github.com/Mbed-TLS/mbedtls/pull/10452
- **tests**  not required because:  No public changes.
