### PR TITLE
Include common header first

### DIFF
--- a/ChangeLog.d/aesce-include.txt
+++ b/ChangeLog.d/aesce-include.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compilation errors in `aesce.c` in some Visual Studio builds.
+     Fixes #548.

--- a/drivers/builtin/src/aesce.c
+++ b/drivers/builtin/src/aesce.c
@@ -5,6 +5,10 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_AESCE_C)
+
 #if defined(__clang__) &&  (__clang_major__ >= 4)
 
 /* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8_A in the following #if,
@@ -39,9 +43,6 @@
 #endif /* defined(__clang__) &&  (__clang_major__ >= 4) */
 
 #include <string.h>
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_AESCE_C)
 
 #include "aesce.h"
 

--- a/drivers/builtin/src/base64.c
+++ b/drivers/builtin/src/base64.c
@@ -5,8 +5,6 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-#include <limits.h>
-
 #include "tf_psa_crypto_common.h"
 
 #if defined(MBEDTLS_BASE64_C)
@@ -16,6 +14,7 @@
 #include "constant_time_internal.h"
 #include "mbedtls/private/error_common.h"
 
+#include <limits.h>
 #include <stdint.h>
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/drivers/builtin/src/constant_time.c
+++ b/drivers/builtin/src/constant_time.c
@@ -10,16 +10,15 @@
  * might be translated to branches by some compilers on some platforms.
  */
 
-#include <stdint.h>
-#include <limits.h>
-
 #include "tf_psa_crypto_common.h"
 #include "constant_time_internal.h"
 #include "mbedtls/constant_time.h"
 #include "mbedtls/private/error_common.h"
 #include "mbedtls/platform_util.h"
 
+#include <limits.h>
 #include <string.h>
+#include <stdint.h>
 
 #if !defined(MBEDTLS_CT_ASM)
 /*

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -5,12 +5,6 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-/*
- * This file is private and for internal
- * use only.
- */
-#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
-
 #include "tf_psa_crypto_common.h"
 
 #if defined(MBEDTLS_PK_C)

--- a/drivers/builtin/src/sha256.c
+++ b/drivers/builtin/src/sha256.c
@@ -10,6 +10,15 @@
  *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
  */
 
+/* Ensure that SIG_SETMASK is defined when -std=c99 is used. */
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA224_C)
+
 #if defined(__clang__) &&  (__clang_major__ >= 4)
 
 /* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8_A in the following #if,
@@ -42,15 +51,6 @@
 #endif
 
 #endif /* defined(__clang__) &&  (__clang_major__ >= 4) */
-
-/* Ensure that SIG_SETMASK is defined when -std=c99 is used. */
-#if !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA224_C)
 
 #include "mbedtls/private/sha256.h"
 #include "mbedtls/platform_util.h"

--- a/drivers/builtin/src/sha512.c
+++ b/drivers/builtin/src/sha512.c
@@ -10,6 +10,10 @@
  *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
  */
 
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_SHA384_C)
+
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512) && \
     defined(__clang__) && __clang_major__ >= 7
 /* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
@@ -25,10 +29,6 @@
 #define __ARM_FEATURE_SHA512 1
 #define MBEDTLS_ENABLE_ARM_SHA3_EXTENSIONS_COMPILER_FLAG
 #endif
-
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_SHA384_C)
 
 #include "mbedtls/private/sha512.h"
 #include "mbedtls/platform_util.h"


### PR DESCRIPTION
Fix the order of things at the top of a few library files: `#include "tf_psa_crypto_common.h"` should come before everything else except directives that affect system headers such as `#define _POSIX_C_SOURCE`. (Except in `*_config.c` which is special.) Fixes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/548.

Quick way of locating potentially problematic files:
```
grep -m1 '^#' core/*.c drivers/builtin/src/*.c | grep -v tf_psa_crypto_common
```

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no problem in 4.0 (`grep -m1 '^#' library/*.c | grep -v -e x509_internal -e ssl_misc`)
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10526
- **tests**  ask reporter
