### PR TITLE
Fix duplication of product version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,7 +464,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     write_basic_package_version_file(
         "cmake/TF-PSA-CryptoConfigVersion.cmake"
             COMPATIBILITY SameMajorVersion
-            VERSION 0.1.0)
+            VERSION "${TF_PSA_CRYPTO_VERSION}")
 
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/TF-PSA-CryptoConfig.cmake"

--- a/ChangeLog.d/cmake-package-version.txt
+++ b/ChangeLog.d/cmake-package-version.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix CMake package version that was inconsistent with the product version.
+     Fixes #553.


### PR DESCRIPTION
Fix #553

## PR checklist

- [x] **changelog** provided
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10481
- [x] **TF-PSA-Crypto PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: in 3.6, `bump_version.sh` catches all occurrences of the version (although we could backport this if we want more consistency, and we should probably backport this if we move 3.6 to the new release script)
- **tests**  not required because: it's now automatic, so I don't think it's worth testing
