### PR TITLE
Test release preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ massif-*
 # Generated documentation:
 /apidoc
 
+# Release artifacts from prepare_release.py
+/release-artifacts/
+
 # PSA Crypto compliance test repo, cloned by test_psa_compliance.py
 /psa-arch-tests
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+#
+# Purpose
+#
+# Sets the version numbers in the source code to those given.
+#
+# Usage: bump_version.sh [ --version <version> ] [ --so-crypto <version>]
+#                           [ --so-x509 <version> ] [ --so-tls <version> ]
+#                           [ -v | --verbose ] [ -h | --help ]
+#
+
+set -e
+
+VERSION=""
+SOVERSION=""
+
+# Parse arguments
+#
+until [ -z "$1" ]
+do
+  case "$1" in
+    --version)
+      # Version to use
+      shift
+      VERSION=$1
+      ;;
+    --so-crypto)
+      shift
+      SO_CRYPTO=$1
+      ;;
+    --so-x509)
+      shift
+      SO_X509=$1
+      ;;
+    --so-tls)
+      shift
+      SO_TLS=$1
+      ;;
+    -v|--verbose)
+      # Be verbose
+      VERBOSE="1"
+      ;;
+    -h|--help)
+      # print help
+      echo "Usage: $0"
+      echo -e "  -h|--help\t\tPrint this help."
+      echo -e "  --version <version>\tVersion to bump to."
+      echo -e "  --so-crypto <version>\tSO version to bump libmbedcrypto to."
+      echo -e "  --so-x509 <version>\tSO version to bump libmbedx509 to."
+      echo -e "  --so-tls <version>\tSO version to bump libmbedtls to."
+      echo -e "  -v|--verbose\t\tVerbose."
+      exit 1
+      ;;
+    *)
+      # print error
+      echo "Unknown argument: '$1'"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "X" = "X$VERSION" ];
+then
+  echo "No version specified. Unable to continue."
+  exit 1
+fi
+
+[ $VERBOSE ] && echo "Bumping VERSION in CMakeLists.txt"
+sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < CMakeLists.txt > tmp
+mv tmp CMakeLists.txt
+
+[ $VERBOSE ] && echo "Bumping VERSION in library/CMakeLists.txt"
+sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < library/CMakeLists.txt > tmp
+mv tmp library/CMakeLists.txt
+
+if [ "X" != "X$SO_CRYPTO" ];
+then
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/CMakeLists.txt"
+  sed -e "/mbedcrypto/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_CRYPTO/g" < library/CMakeLists.txt > tmp
+  mv tmp library/CMakeLists.txt
+
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/Makefile"
+  sed -e "s/SOEXT_CRYPTO?=so.[0-9]\{1,\}/SOEXT_CRYPTO?=so.$SO_CRYPTO/g" < library/Makefile > tmp
+  mv tmp library/Makefile
+fi
+
+if [ "X" != "X$SO_X509" ];
+then
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/CMakeLists.txt"
+  sed -e "/mbedx509/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_X509/g" < library/CMakeLists.txt > tmp
+  mv tmp library/CMakeLists.txt
+
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/Makefile"
+  sed -e "s/SOEXT_X509?=so.[0-9]\{1,\}/SOEXT_X509?=so.$SO_X509/g" < library/Makefile > tmp
+  mv tmp library/Makefile
+fi
+
+if [ "X" != "X$SO_TLS" ];
+then
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/CMakeLists.txt"
+  sed -e "/mbedtls/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_TLS/g" < library/CMakeLists.txt > tmp
+  mv tmp library/CMakeLists.txt
+
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/Makefile"
+  sed -e "s/SOEXT_TLS?=so.[0-9]\{1,\}/SOEXT_TLS?=so.$SO_TLS/g" < library/Makefile > tmp
+  mv tmp library/Makefile
+fi
+
+[ $VERBOSE ] && echo "Bumping VERSION in include/mbedtls/build_info.h"
+read MAJOR MINOR PATCH <<<$(IFS="."; echo $VERSION)
+VERSION_NR="$( printf "0x%02X%02X%02X00" $MAJOR $MINOR $PATCH )"
+cat include/mbedtls/build_info.h |                                    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_MAJOR .\{1,\}/\1_MAJOR  $MAJOR/" |    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_MINOR .\{1,\}/\1_MINOR  $MINOR/" |    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_PATCH .\{1,\}/\1_PATCH  $PATCH/" |    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_NUMBER .\{1,\}/\1_NUMBER         $VERSION_NR/" |    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING .\{1,\}/\1_STRING         \"$VERSION\"/" |    \
+    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING_FULL .\{1,\}/\1_STRING_FULL    \"Mbed TLS $VERSION\"/" \
+    > tmp
+mv tmp include/mbedtls/build_info.h
+
+[ $VERBOSE ] && echo "Bumping version in tests/suites/test_suite_version.data"
+sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tf-psa-crypto/tests/suites/test_suite_version.data > tmp
+mv tmp tf-psa-crypto/tests/suites/test_suite_version.data
+
+[ $VERBOSE ] && echo "Bumping PROJECT_NAME in doxygen/mbedtls.doxyfile and doxygen/input/doc_mainpage.h"
+for i in doxygen/mbedtls.doxyfile doxygen/input/doc_mainpage.h;
+do
+  sed -e "s/\\([Mm]bed TLS v\\)[0-9][0-9.]*/\\1$VERSION/g" < $i > tmp
+  mv tmp $i
+done
+
+[ $VERBOSE ] && echo "Re-generating library/error.c"
+scripts/generate_errors.pl
+
+[ $VERBOSE ] && echo "Re-generating programs/test/query_config.c"
+scripts/generate_query_config.pl
+
+[ $VERBOSE ] && echo "Re-generating library/version_features.c"
+scripts/generate_features.pl
+
+[ $VERBOSE ] && echo "Re-generating visualc files"
+scripts/generate_visualc_files.pl
+

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -70,18 +70,14 @@ then
 fi
 
 [ $VERBOSE ] && echo "Bumping VERSION in CMakeLists.txt"
-sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < CMakeLists.txt > tmp
+sed -e "s/(MBEDTLS_VERSION [0-9.]\{1,\})/(MBEDTLS_VERSION $VERSION)/g" < CMakeLists.txt > tmp
 mv tmp CMakeLists.txt
-
-[ $VERBOSE ] && echo "Bumping VERSION in library/CMakeLists.txt"
-sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < library/CMakeLists.txt > tmp
-mv tmp library/CMakeLists.txt
 
 if [ "X" != "X$SO_CRYPTO" ];
 then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/CMakeLists.txt"
-  sed -e "/mbedcrypto/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_CRYPTO/g" < library/CMakeLists.txt > tmp
-  mv tmp library/CMakeLists.txt
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in CMakeLists.txt"
+  sed -e "s/(MBEDTLS_CRYPTO_SOVERSION [0-9]\{1,\})/(MBEDTLS_CRYPTO_SOVERSION $SO_CRYPTO)/g" < CMakeLists.txt > tmp
+  mv tmp CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/Makefile"
   sed -e "s/SOEXT_CRYPTO?=so.[0-9]\{1,\}/SOEXT_CRYPTO?=so.$SO_CRYPTO/g" < library/Makefile > tmp
@@ -90,9 +86,9 @@ fi
 
 if [ "X" != "X$SO_X509" ];
 then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/CMakeLists.txt"
-  sed -e "/mbedx509/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_X509/g" < library/CMakeLists.txt > tmp
-  mv tmp library/CMakeLists.txt
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in CMakeLists.txt"
+  sed -e "s/(MBEDTLS_X509_SOVERSION [0-9]\{1,\})/(MBEDTLS_X509_SOVERSION $SO_X509)/g" < CMakeLists.txt > tmp
+  mv tmp CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/Makefile"
   sed -e "s/SOEXT_X509?=so.[0-9]\{1,\}/SOEXT_X509?=so.$SO_X509/g" < library/Makefile > tmp
@@ -101,9 +97,9 @@ fi
 
 if [ "X" != "X$SO_TLS" ];
 then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/CMakeLists.txt"
-  sed -e "/mbedtls/ s/ SOVERSION [0-9]\{1,\}/ SOVERSION $SO_TLS/g" < library/CMakeLists.txt > tmp
-  mv tmp library/CMakeLists.txt
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in CMakeLists.txt"
+  sed -e "s/(MBEDTLS_TLS_SOVERSION [0-9]\{1,\})/(MBEDTLS_TLS_SOVERSION $SO_TLS)/g" < CMakeLists.txt > tmp
+  mv tmp CMakeLists.txt
 
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/Makefile"
   sed -e "s/SOEXT_TLS?=so.[0-9]\{1,\}/SOEXT_TLS?=so.$SO_TLS/g" < library/Makefile > tmp

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -8,7 +8,6 @@
 # Sets the version numbers in the source code to those given.
 #
 # Usage: bump_version.sh [ --version <version> ] [ --so-crypto <version>]
-#                           [ --so-x509 <version> ] [ --so-tls <version> ]
 #                           [ -v | --verbose ] [ -h | --help ]
 #
 
@@ -31,14 +30,6 @@ do
       shift
       SO_CRYPTO=$1
       ;;
-    --so-x509)
-      shift
-      SO_X509=$1
-      ;;
-    --so-tls)
-      shift
-      SO_TLS=$1
-      ;;
     -v|--verbose)
       # Be verbose
       VERBOSE="1"
@@ -49,8 +40,6 @@ do
       echo -e "  -h|--help\t\tPrint this help."
       echo -e "  --version <version>\tVersion to bump to."
       echo -e "  --so-crypto <version>\tSO version to bump libmbedcrypto to."
-      echo -e "  --so-x509 <version>\tSO version to bump libmbedx509 to."
-      echo -e "  --so-tls <version>\tSO version to bump libmbedtls to."
       echo -e "  -v|--verbose\t\tVerbose."
       exit 1
       ;;
@@ -84,28 +73,6 @@ then
   mv tmp library/Makefile
 fi
 
-if [ "X" != "X$SO_X509" ];
-then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in CMakeLists.txt"
-  sed -e "s/(MBEDTLS_X509_SOVERSION [0-9]\{1,\})/(MBEDTLS_X509_SOVERSION $SO_X509)/g" < CMakeLists.txt > tmp
-  mv tmp CMakeLists.txt
-
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedx509 in library/Makefile"
-  sed -e "s/SOEXT_X509?=so.[0-9]\{1,\}/SOEXT_X509?=so.$SO_X509/g" < library/Makefile > tmp
-  mv tmp library/Makefile
-fi
-
-if [ "X" != "X$SO_TLS" ];
-then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in CMakeLists.txt"
-  sed -e "s/(MBEDTLS_TLS_SOVERSION [0-9]\{1,\})/(MBEDTLS_TLS_SOVERSION $SO_TLS)/g" < CMakeLists.txt > tmp
-  mv tmp CMakeLists.txt
-
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedtls in library/Makefile"
-  sed -e "s/SOEXT_TLS?=so.[0-9]\{1,\}/SOEXT_TLS?=so.$SO_TLS/g" < library/Makefile > tmp
-  mv tmp library/Makefile
-fi
-
 [ $VERBOSE ] && echo "Bumping VERSION in include/mbedtls/build_info.h"
 read MAJOR MINOR PATCH <<<$(IFS="."; echo $VERSION)
 VERSION_NR="$( printf "0x%02X%02X%02X00" $MAJOR $MINOR $PATCH )"
@@ -123,22 +90,4 @@ mv tmp include/mbedtls/build_info.h
 sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tf-psa-crypto/tests/suites/test_suite_version.data > tmp
 mv tmp tf-psa-crypto/tests/suites/test_suite_version.data
 
-[ $VERBOSE ] && echo "Bumping PROJECT_NAME in doxygen/mbedtls.doxyfile and doxygen/input/doc_mainpage.h"
-for i in doxygen/mbedtls.doxyfile doxygen/input/doc_mainpage.h;
-do
-  sed -e "s/\\([Mm]bed TLS v\\)[0-9][0-9.]*/\\1$VERSION/g" < $i > tmp
-  mv tmp $i
-done
-
-[ $VERBOSE ] && echo "Re-generating library/error.c"
-scripts/generate_errors.pl
-
-[ $VERBOSE ] && echo "Re-generating programs/test/query_config.c"
-scripts/generate_query_config.pl
-
-[ $VERBOSE ] && echo "Re-generating library/version_features.c"
-scripts/generate_features.pl
-
-[ $VERBOSE ] && echo "Re-generating visualc files"
-scripts/generate_visualc_files.pl
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -39,7 +39,7 @@ do
       echo "Usage: $0"
       echo -e "  -h|--help\t\tPrint this help."
       echo -e "  --version <version>\tVersion to bump to."
-      echo -e "  --so-crypto <version>\tSO version to bump libmbedcrypto to."
+      echo -e "  --so-crypto <version>\tSO version to bump libtfpsacrypto to."
       echo -e "  -v|--verbose\t\tVerbose."
       exit 1
       ;;
@@ -59,35 +59,29 @@ then
 fi
 
 [ $VERBOSE ] && echo "Bumping VERSION in CMakeLists.txt"
-sed -e "s/(MBEDTLS_VERSION [0-9.]\{1,\})/(MBEDTLS_VERSION $VERSION)/g" < CMakeLists.txt > tmp
+sed -e "s/(TF_PSA_CRYPTO_VERSION [0-9.]\{1,\})/(TF_PSA_CRYPTO_VERSION $VERSION)/g" < CMakeLists.txt > tmp
 mv tmp CMakeLists.txt
 
 if [ "X" != "X$SO_CRYPTO" ];
 then
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in CMakeLists.txt"
-  sed -e "s/(MBEDTLS_CRYPTO_SOVERSION [0-9]\{1,\})/(MBEDTLS_CRYPTO_SOVERSION $SO_CRYPTO)/g" < CMakeLists.txt > tmp
+  [ $VERBOSE ] && echo "Bumping SOVERSION for libtfpsacrypto in CMakeLists.txt"
+  sed -e "s/(TF_PSA_CRYPTO_SOVERSION [0-9]\{1,\})/(TF_PSA_CRYPTO_SOVERSION $SO_CRYPTO)/g" < CMakeLists.txt > tmp
   mv tmp CMakeLists.txt
-
-  [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/Makefile"
-  sed -e "s/SOEXT_CRYPTO?=so.[0-9]\{1,\}/SOEXT_CRYPTO?=so.$SO_CRYPTO/g" < library/Makefile > tmp
-  mv tmp library/Makefile
 fi
 
-[ $VERBOSE ] && echo "Bumping VERSION in include/mbedtls/build_info.h"
+[ $VERBOSE ] && echo "Bumping VERSION in include/tf-psa-crypto/build_info.h"
 read MAJOR MINOR PATCH <<<$(IFS="."; echo $VERSION)
 VERSION_NR="$( printf "0x%02X%02X%02X00" $MAJOR $MINOR $PATCH )"
-cat include/mbedtls/build_info.h |                                    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_MAJOR .\{1,\}/\1_MAJOR  $MAJOR/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_MINOR .\{1,\}/\1_MINOR  $MINOR/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_PATCH .\{1,\}/\1_PATCH  $PATCH/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_NUMBER .\{1,\}/\1_NUMBER         $VERSION_NR/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING .\{1,\}/\1_STRING         \"$VERSION\"/" |    \
-    sed -e "s/\(# *define  *[A-Z]*_VERSION\)_STRING_FULL .\{1,\}/\1_STRING_FULL    \"Mbed TLS $VERSION\"/" \
+cat include/tf-psa-crypto/build_info.h |                                    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_MAJOR .\{1,\}/\1_MAJOR  $MAJOR/" |    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_MINOR .\{1,\}/\1_MINOR  $MINOR/" |    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_PATCH .\{1,\}/\1_PATCH  $PATCH/" |    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_NUMBER .\{1,\}/\1_NUMBER         $VERSION_NR/" |    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_STRING .\{1,\}/\1_STRING         \"$VERSION\"/" |    \
+    sed -e "s/\(# *define  *[A-Z_]*_VERSION\)_STRING_FULL .\{1,\}/\1_STRING_FULL    \"TF-PSA-Crypto $VERSION\"/" \
     > tmp
-mv tmp include/mbedtls/build_info.h
+mv tmp include/tf-psa-crypto/build_info.h
 
-[ $VERBOSE ] && echo "Bumping version in tests/suites/test_suite_version.data"
-sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tf-psa-crypto/tests/suites/test_suite_version.data > tmp
-mv tmp tf-psa-crypto/tests/suites/test_suite_version.data
-
-
+[ $VERBOSE ] && echo "Bumping version in tests/suites/test_suite_tf_psa_crypto_version.data"
+sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tests/suites/test_suite_tf_psa_crypto_version.data > tmp
+mv tmp tests/suites/test_suite_tf_psa_crypto_version.data

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -39,6 +39,12 @@ git_clone_recursively () {
     fi
 }
 
+support_test_prepare_release () {
+    # `prepare_release.py` uses `git archive --mtime` which was added
+    # in Git 2.40.0.
+    git archive --help | grep -q -e --mtime
+}
+
 component_test_prepare_release () {
     msg "Prepare release: Set up testing environment"
 

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -111,6 +111,18 @@ component_test_prepare_release () {
     git fetch --no-write-fetch-head "$preparation_dir" "$preparation_sha"
     echo ">>>> Release candidate sha: $preparation_sha <<<<"
 
+    msg "Prepare release: checking archive reproducibility"
+    mkdir "${preparation_dir}2" "${artifacts_dir}2"
+    cd "${preparation_dir}2"
+    git_clone_recursively "$preparation_dir"
+    # Starting from the release candidate commit, prepare_release.py should
+    # not make any extra commit.
+    # Starting from the same commit, prepare_relase.py should create
+    # identical archives.
+    framework/scripts/prepare_release.py --artifact-directory "${artifacts_dir}2" -r "$new_version"
+    ls -l "${artifacts_dir}2"
+    diff "$shasum_file" "${artifacts_dir}2/${shasum_file##*/}"
+
     msg "Prepare release: Test the release archive"
     shasum_file=$artifacts_dir/tf-psa-crypto-$new_version.txt
     archive_file=$artifacts_dir/tf-psa-crypto-$new_version.tar.bz2

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -60,12 +60,11 @@ component_tf_psa_crypto_test_prepare_release () {
     # So we use clones.
     source_dir=$PWD
     preparation_dir=$OUT_OF_SOURCE_DIR/prep
-    artifacts_dir=$OUT_OF_SOURCE_DIR/artifacts
+    artifacts_dir=$PWD/release-artifacts
     extract_dir=$OUT_OF_SOURCE_DIR/extract
     build_dir=$OUT_OF_SOURCE_DIR/build
     minimal_bin_dir=$OUT_OF_SOURCE_DIR/bin.minimal
-    mkdir "$preparation_dir" "$artifacts_dir"
-    mkdir "$extract_dir" "$build_dir"
+    mkdir "$preparation_dir" "$extract_dir" "$build_dir"
 
     new_version=$(next_product_version)
     echo "Simulating the next minor release: $new_version"
@@ -119,23 +118,26 @@ component_tf_psa_crypto_test_prepare_release () {
     # Make the release candidate sha available in the original git worktree
     # until the next git gc.
     git fetch --no-write-fetch-head "$preparation_dir" "$preparation_sha"
-    echo ">>>> Release candidate sha: $preparation_sha <<<<"
 
     shasum_file=$artifacts_dir/tf-psa-crypto-$new_version.txt
     archive_file=$artifacts_dir/tf-psa-crypto-$new_version.tar.bz2
     archive_top_dir=tf-psa-crypto-$new_version
 
     msg "Prepare release: checking archive reproducibility"
-    mkdir "${preparation_dir}2" "${artifacts_dir}2"
-    cd "${preparation_dir}2"
+    preparation_replay=$OUT_OF_SOURCE_DIR/replay
+    artifacts_replay=$preparation_replay/release-artifacts
+    shasum_replay=$artifacts_replay/${shasum_file##*/}
+    mkdir "$preparation_replay"
+    cd "$preparation_replay"
     git_clone_recursively "$preparation_dir"
+    mkdir -p "$artifacts_replay"
     # Starting from the release candidate commit, prepare_release.py should
     # not make any extra commit.
     # Starting from the same commit, prepare_relase.py should create
     # identical archives.
-    framework/scripts/prepare_release.py --artifact-directory "${artifacts_dir}2" -r "$new_version"
-    ls -l "${artifacts_dir}2"
-    diff "$shasum_file" "${artifacts_dir}2/${shasum_file##*/}"
+    framework/scripts/prepare_release.py --artifact-directory "$artifacts_replay" -r "$new_version"
+    ls -l "$artifacts_replay"
+    diff "$shasum_file" "$shasum_replay"
 
     msg "Prepare release: Test the release archive"
     cd "$artifacts_dir"
@@ -163,4 +165,9 @@ component_tf_psa_crypto_test_prepare_release () {
     unset CC CFLAGS LDFLAGS
     PATH="$minimal_bin_dir" cmake "$extract_dir/$archive_top_dir"
     PATH="$minimal_bin_dir" make tfpsacrypto
+
+    msg "Prepare release: List artifacts"
+    echo ">>>> Artifacts deposited in $artifacts_dir <<<<"
+    ls -l "$artifacts_dir"
+    echo ">>>> Release candidate sha: $preparation_sha <<<<"
 }

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -9,3 +9,101 @@
 #### Release preparation
 ################################################################
 
+next_product_version () {
+    perl -n - CMakeLists.txt <<'EOF'
+        if (/^ *set *\( *[0-9A-Z_a-z]+_VERSION +([0-9]+)\.([0-9]+)[.\)]/) {
+            printf "%d.%d.0\n", $1, $2 + 1;
+            $found = 1;
+            exit 0;
+        }
+        END {
+            if (!$found) {
+                print STDERR "Product version not found in CMakeLists.txt\n";
+                exit 1;
+            }
+        }
+EOF
+}
+
+git_clone_recursively () {
+    git clone --no-checkout "$1" .
+    git -c advice.detachedHead=false checkout "$(git -C "$1" rev-parse HEAD)"
+    git submodule init
+    # Make the framework a clone of the original framework. This gives us
+    # access to local commits that may not have been pushed to the
+    # submodule's URL.
+    git clone --no-checkout "$1/framework" framework
+    git -c advice.detachedHead=false -C framework checkout "$(git -C "$1/framework" rev-parse HEAD)"
+    if ! git diff --quiet framework; then
+        git commit -m 'Update framework submodule' framework
+    fi
+}
+
+component_test_prepare_release () {
+    msg "Prepare release: Set up testing environment"
+
+    # Release preparation needs a clean worktree and can make commits.
+    # To avoid messing up the source directory and the current branch,
+    # do all this work in a separate git clone.
+    # We could use a git worktree, but that would leave traces behind,
+    # and having submodules that are worktrees is not well supported.
+    # So we use clones.
+    source_dir=$PWD
+    preparation_dir=$OUT_OF_SOURCE_DIR/prep
+    artifacts_dir=$OUT_OF_SOURCE_DIR/artifacts
+    mkdir "$preparation_dir" "$artifacts_dir"
+
+    new_version=$(next_product_version)
+    echo "Simulating the next minor release: $new_version"
+
+    # Set up a minimal environment with just a few tools that should
+    # be enough to build the library from a release archive.
+    mkdir "$minimal_bin_dir"
+    # Remove the quiet make/cmake wrappers from the path. They wouldn't
+    # work in the minimal environment.
+    PATH=${PATH#*/quiet:}
+    for x in ar as cc cmake ld ln make; do
+        ln -s "$(command -v $x)" "$minimal_bin_dir/$x"
+    done
+
+    msg "Prepare release: Set up clone"
+    # We'll use the files as they are committed into Git, except that
+    # each submodule is considered separately. On the CI, this shouldn't
+    # be a problem, but locally, the developer running this script may
+    # have changed files. Complain loudly but go on anyway.
+    # Don't complain about changes to all.sh components since they don't
+    # matter. This makes it possible to quickly test changes on the
+    # current script. (On the other hand, you do need to commit any changes
+    # to prepare_release.py.)
+    # Treat each submodule independently, because we'll clone whatever commit
+    # is checked out in the original tree, not the submodule commit referenced
+    # from the parent tree.
+    if ! git diff --quiet --ignore-submodules HEAD ':!tests/scripts/components-*.sh'; then
+        echo
+        echo '**** THE TEST MAY NOT BE CONCLUSIVE! ****'
+        echo 'There are changed files in the main worktree.'
+        echo 'The test will run on what is commited into Git:'
+        echo "  $(git rev-parse HEAD)"
+        echo '*****************************************'
+    fi
+    if ! git -C framework diff --quiet HEAD; then
+        echo
+        echo '**** THE TEST MAY NOT BE CONCLUSIVE! ****'
+        echo 'There are changed files in the framework.'
+        echo 'The test will run on what is commited into Git:'
+        echo "  $(git -C framework rev-parse HEAD)"
+        echo '*****************************************'
+    fi
+    cd "$preparation_dir"
+    git_clone_recursively "$source_dir"
+
+    msg "Prepare release: Prepare release"
+    echo "Prepare $new_version release in $PWD"
+    framework/scripts/prepare_release.py --artifact-directory "$artifacts_dir" -r "$new_version"
+    preparation_sha=$(git rev-parse HEAD)
+    cd "$source_dir"
+    # Make the release candidate sha available in the original git worktree
+    # until the next git gc.
+    git fetch --no-write-fetch-head "$preparation_dir" "$preparation_sha"
+    echo ">>>> Release candidate sha: $preparation_sha <<<<"
+}

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -1,0 +1,11 @@
+# components-release.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This file contains test components that are executed by all.sh
+
+################################################################
+#### Release preparation
+################################################################
+

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -39,7 +39,7 @@ git_clone_recursively () {
     fi
 }
 
-support_test_prepare_release () {
+support_tf_psa_crypto_test_prepare_release () {
     # `prepare_release.py` uses `git archive --mtime` which was added
     # in Git 2.40.0. Check the version, not `git archive --help`, because
     # the help is not available when man pages is installed, which is
@@ -49,7 +49,7 @@ support_test_prepare_release () {
        (${BASH_REMATCH[1]} -eq 2 && ${BASH_REMATCH[2]} -ge 40) ]]
 }
 
-component_test_prepare_release () {
+component_tf_psa_crypto_test_prepare_release () {
     msg "Prepare release: Set up testing environment"
 
     # Release preparation needs a clean worktree and can make commits.

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -121,6 +121,10 @@ component_test_prepare_release () {
     git fetch --no-write-fetch-head "$preparation_dir" "$preparation_sha"
     echo ">>>> Release candidate sha: $preparation_sha <<<<"
 
+    shasum_file=$artifacts_dir/tf-psa-crypto-$new_version.txt
+    archive_file=$artifacts_dir/tf-psa-crypto-$new_version.tar.bz2
+    archive_top_dir=tf-psa-crypto-$new_version
+
     msg "Prepare release: checking archive reproducibility"
     mkdir "${preparation_dir}2" "${artifacts_dir}2"
     cd "${preparation_dir}2"
@@ -134,9 +138,6 @@ component_test_prepare_release () {
     diff "$shasum_file" "${artifacts_dir}2/${shasum_file##*/}"
 
     msg "Prepare release: Test the release archive"
-    shasum_file=$artifacts_dir/tf-psa-crypto-$new_version.txt
-    archive_file=$artifacts_dir/tf-psa-crypto-$new_version.tar.bz2
-    archive_top_dir=tf-psa-crypto-$new_version
     cd "$artifacts_dir"
     echo "Checking checksums in $shasum_file"
     shasum -c "$shasum_file"

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -51,7 +51,11 @@ component_test_prepare_release () {
     source_dir=$PWD
     preparation_dir=$OUT_OF_SOURCE_DIR/prep
     artifacts_dir=$OUT_OF_SOURCE_DIR/artifacts
+    extract_dir=$OUT_OF_SOURCE_DIR/extract
+    build_dir=$OUT_OF_SOURCE_DIR/build
+    minimal_bin_dir=$OUT_OF_SOURCE_DIR/bin.minimal
     mkdir "$preparation_dir" "$artifacts_dir"
+    mkdir "$extract_dir" "$build_dir"
 
     new_version=$(next_product_version)
     echo "Simulating the next minor release: $new_version"
@@ -106,4 +110,34 @@ component_test_prepare_release () {
     # until the next git gc.
     git fetch --no-write-fetch-head "$preparation_dir" "$preparation_sha"
     echo ">>>> Release candidate sha: $preparation_sha <<<<"
+
+    msg "Prepare release: Test the release archive"
+    shasum_file=$artifacts_dir/tf-psa-crypto-$new_version.txt
+    archive_file=$artifacts_dir/tf-psa-crypto-$new_version.tar.bz2
+    archive_top_dir=tf-psa-crypto-$new_version
+    cd "$artifacts_dir"
+    echo "Checking checksums in $shasum_file"
+    shasum -c "$shasum_file"
+    ls -l "$artifacts_dir"
+    cd "$extract_dir"
+    echo "Extracting ${archive_file##*/}"
+    tar -xjf "$archive_file"
+    if ! [ -d "$archive_top_dir" ]; then
+        echo >&2 "$archive_top_dir not found"
+        ls -l
+        # Repeat the failed test so that this is logged as a failure.
+        [ -d "$archive_top_dir" ]
+    fi
+    if ! [ "$(ls)" = "$archive_top_dir" ]; then
+        echo >&2 "There is content in ${archive_file##*/} outside $archive_top_dir"
+        ls -l
+        # Repeat the failed test so that this is logged as a failure.
+        [ "$(ls)" = "$archive_top_dir" ]
+    fi
+    cd "$build_dir"
+    echo
+    echo "Building $extract_dir/$archive_top_dir in minimal environment"
+    unset CC CFLAGS LDFLAGS
+    PATH="$minimal_bin_dir" cmake "$extract_dir/$archive_top_dir"
+    PATH="$minimal_bin_dir" make tfpsacrypto
 }

--- a/tests/scripts/components-release.sh
+++ b/tests/scripts/components-release.sh
@@ -41,8 +41,12 @@ git_clone_recursively () {
 
 support_test_prepare_release () {
     # `prepare_release.py` uses `git archive --mtime` which was added
-    # in Git 2.40.0.
-    git archive --help | grep -q -e --mtime
+    # in Git 2.40.0. Check the version, not `git archive --help`, because
+    # the help is not available when man pages is installed, which is
+    # to be expected in a CI environment.
+    [[ $(git version 2>/dev/null) =~ \ ([0-9]+)\.([0-9]+) ]] &&
+    [[ ${BASH_REMATCH[1]} -ge 3 ||
+       (${BASH_REMATCH[1]} -eq 2 && ${BASH_REMATCH[2]} -ge 40) ]]
 }
 
 component_test_prepare_release () {


### PR DESCRIPTION
Addresses most of https://github.com/Mbed-TLS/mbedtls/issues/3255 . What is left is to arrange for the Groovy code to pick up the release artifacts created by the new `all.sh` component as Jenkins artifacts.

Addresses most of https://github.com/Mbed-TLS/mbedtls-framework/pull/231 by creating `bump_version.sh` in crypto. We might want to put this functionality into `prepare_release.py`, but I'm not fully convinced: there are significant differences between branches with respect to what version bumping does, so I think the code to do that belongs in each branch.

Fixes https://github.com/Mbed-TLS/mbedtls/issues/9521 by testing that builds done in different directories result in identical tarballs.

Needs preceding PR:

* [ ] https://github.com/Mbed-TLS/mbedtls-framework/pull/231
* [x] Not needed to pass the CI, but needed for `bump_version.sh` not to be incomplete: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/554
* [x] The `bump_version.sh` commits are in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/676
* [x]: needs Ubuntu 24.04 on the CI https://github.com/Mbed-TLS/mbedtls-test/pull/230

## PR checklist

- [x] **changelog** not required because: test only
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/231
- [ ] **mbedtls development PR** TODO
- [ ] **mbedtls 4.1 PR** TODO
- [x] **TF-PSA-Crypto development PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/555
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **mbedtls 3.6 PR** No, we'll keep the old process for the remaining life time of 3.6
- **tests**  provided
