### PR TITLE
Fix module-import-in-extern-c compiler error

### DIFF
--- a/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
+++ b/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
@@ -1,0 +1,5 @@
+Changes
+   * Fixes a compiler error when building C++ projects that use the 'modules'
+     C++ language feature, and consume Mbed TLS. The specific error is
+     module-import-in-extern-c, which occurs when an #include occurs within
+     'extern C' blocks.

--- a/drivers/builtin/include/mbedtls/private/chachapoly.h
+++ b/drivers/builtin/include/mbedtls/private/chachapoly.h
@@ -31,10 +31,6 @@
 /** Authenticated decryption failed: data was not authentic. */
 #define MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED          PSA_ERROR_INVALID_SIGNATURE
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
     MBEDTLS_CHACHAPOLY_ENCRYPT,     /**< The mode value for performing encryption. */
     MBEDTLS_CHACHAPOLY_DECRYPT      /**< The mode value for performing decryption. */
@@ -42,6 +38,10 @@ typedef enum {
 mbedtls_chachapoly_mode_t;
 
 #include "mbedtls/private/chacha20.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct mbedtls_chachapoly_context {
     mbedtls_chacha20_context MBEDTLS_PRIVATE(chacha20_ctx);  /**< The ChaCha20 context. */

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -35,10 +35,6 @@
 
 #include <psa/crypto_driver_random.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * \name SECTION: Module settings
  *
@@ -130,6 +126,10 @@ extern "C" {
 #define MBEDTLS_PLATFORM_STD_FREE
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \} name SECTION: Module settings */
 
 /*
@@ -145,8 +145,15 @@ extern "C" {
 #define mbedtls_free       MBEDTLS_PLATFORM_FREE_MACRO
 #define mbedtls_calloc     MBEDTLS_PLATFORM_CALLOC_MACRO
 #else
+#ifdef __cplusplus
+}
+#endif
 /* For size_t */
 #include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void *mbedtls_calloc(size_t n, size_t size);
 extern void mbedtls_free(void *ptr);
 
@@ -173,8 +180,14 @@ int mbedtls_platform_set_calloc_free(void *(*calloc_func)(size_t, size_t),
  * The function pointers for fprintf
  */
 #if defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
+#ifdef __cplusplus
+}
+#endif
 /* We need FILE * */
 #include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int (*mbedtls_fprintf)(FILE *stream, const char *format, ...);
 
 /**
@@ -268,13 +281,25 @@ int mbedtls_platform_set_snprintf(int (*snprintf_func)(char *s, size_t n,
  *   the destination buffer is too short.
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
+#ifdef __cplusplus
+}
+#endif
 #include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
 int mbedtls_platform_win32_vsnprintf(char *s, size_t n, const char *fmt, va_list arg);
 #endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
+#ifdef __cplusplus
+}
+#endif
 #include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int (*mbedtls_vsnprintf)(char *s, size_t n, const char *format, va_list arg);
 
 /**
@@ -299,7 +324,13 @@ int mbedtls_platform_set_vsnprintf(int (*vsnprintf_func)(char *s, size_t n,
  * The function pointers for setbuf
  */
 #if defined(MBEDTLS_PLATFORM_SETBUF_ALT)
+#ifdef __cplusplus
+}
+#endif
 #include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * \brief                  Function pointer to call for `setbuf()` functionality
  *                         (changing the internal buffering on stdio calls).
@@ -445,7 +476,13 @@ typedef struct mbedtls_platform_context {
 mbedtls_platform_context;
 
 #else
+#ifdef __cplusplus
+}
+#endif
 #include "platform_alt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 #endif /* !MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
 
 /**

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -12,10 +12,6 @@
 
 #include "tf-psa-crypto/build_info.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * The time_t datatype
  */
@@ -34,6 +30,10 @@ typedef MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO mbedtls_ms_time_t;
 #include <inttypes.h>
 typedef int64_t mbedtls_ms_time_t;
 #endif /* MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief   Get time in milliseconds.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -19,10 +19,6 @@
 #include <time.h>
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Internal helper macros for deprecating API constants. */
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -56,6 +52,10 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
 #else
 #define MBEDTLS_CHECK_RETURN
 #endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /** Critical-failure function

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -16,8 +16,13 @@
 
 #include <stdlib.h>
 
-#ifdef __cplusplus
-extern "C" {
+#if defined(MBEDTLS_THREADING_PTHREAD)
+#include <pthread.h>
+#endif
+
+#if defined(MBEDTLS_THREADING_ALT)
+/* You should define the mbedtls_threading_mutex_t type in your header */
+#include "threading_alt.h"
 #endif
 
 /** Detected error in mutex or condition variable usage.
@@ -32,19 +37,18 @@ extern "C" {
 /** A historical alias for #MBEDTLS_ERR_THREADING_USAGE_ERROR. */
 #define MBEDTLS_ERR_THREADING_MUTEX_ERROR MBEDTLS_ERR_THREADING_USAGE_ERROR
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(MBEDTLS_THREADING_C)
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
-#include <pthread.h>
 typedef pthread_mutex_t mbedtls_platform_mutex_t;
 typedef pthread_cond_t mbedtls_platform_condition_variable_t;
 #endif
 
 #if defined(MBEDTLS_THREADING_ALT)
-/* You should define the types mbedtls_platform_mutex_t and
- * mbedtls_platform_condition_variable_t in your header. */
-#include "threading_alt.h"
-
 /**
  * \brief           Set your alternate threading implementation function
  *                  pointers and initialize global mutexes. If used, this

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -31,10 +31,6 @@
 /**@}*/
 #endif /* __DOXYGEN_ONLY__ */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* The file "crypto_types.h" declares types that encode errors,
  * algorithms, key types, policies, etc. */
 #include "crypto_types.h"
@@ -69,6 +65,10 @@ extern "C" {
 #include MBEDTLS_PSA_CRYPTO_STRUCT_FILE
 #else
 #include "crypto_struct.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /** \defgroup initialization Library initialization

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -50,15 +50,15 @@
 #define PSA_CRYPTO_STRUCT_H
 #include "mbedtls/private_access.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "tf-psa-crypto/build_info.h"
 
 /* Include the context definition for the compiled-in drivers for the primitive
  * algorithms. */
 #include "psa/crypto_driver_contexts_primitives.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_hash_operation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
@@ -117,9 +117,15 @@ static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
     return v;
 }
 
+#ifdef __cplusplus
+}
+#endif
 /* Include the context definition for the compiled-in drivers for the composite
  * algorithms. */
 #include "psa/crypto_driver_contexts_composites.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_mac_operation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
@@ -188,9 +194,15 @@ static inline struct psa_aead_operation_s psa_aead_operation_init(void)
     return v;
 }
 
+#ifdef __cplusplus
+}
+#endif
 /* Include the context definition for the compiled-in drivers for the key
  * derivation algorithms. */
 #include "psa/crypto_driver_contexts_key_derivation.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_key_derivation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)


### PR DESCRIPTION
## Description
This fixes https://github.com/Mbed-TLS/mbedtls/issues/10490.

This fixes a compiler error when building C++ projects that use the 'modules' C++ language feature consume Mbed TLS. The specific error is module-import-in-extern-c, which occurs when `#include`s occur within `extern C` blocks.

Example:
```
$ clang-17 -std=c++20 -fmodules -Itf-psa-crypto/include -Itf-psa-crypto/drivers/builtin/include -o sample sample.cpp
In file included from sample.cpp:8:
In file included from tf-psa-crypto/drivers/builtin/include/mbedtls/private/chachapoly.h:44:
tf-psa-crypto/drivers/builtin/include/mbedtls/private/chacha20.h:26:1: error: import of C++ module '_Builtin_stdint' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   26 | #include <stdint.h>
      | ^
tf-psa-crypto/drivers/builtin/include/mbedtls/private/chachapoly.h:35:1: note: extern "C" language linkage specification begins here
   35 | extern "C" {
      | ^
1 error generated.
```

This seems to primarily be an issue with clang. See https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fmodules


## PR checklist
- [X] **changelog** entry added
- [ ] **framework PR** not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10488
- [X] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10489
- [X] **tests** Sample C++ file that includes all affected headers compiles