### PR TITLE
Use instruction-level parallelism with AES-NI to speed up AES-CTR

### DIFF
--- a/ChangeLog.d/speedup-aesni-ctr.txt
+++ b/ChangeLog.d/speedup-aesni-ctr.txt
@@ -1,0 +1,3 @@
+Features:
+   * Speed up AES-CTR when using AES-NI by using instruction-level
+     parallelism.

--- a/ChangeLog.d/speedup-aesni-ctr.txt
+++ b/ChangeLog.d/speedup-aesni-ctr.txt
@@ -1,3 +1,3 @@
-Features:
+Features
    * Speed up AES-CTR when using AES-NI by using instruction-level
      parallelism.

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -873,7 +873,7 @@ int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context *ctx,
 /* In test_aesni, it is checked whether the software AES implementation is built
  * by checking if mbedtls_internal_aes_encrypt exists in aes.o. Therefore, avoid
  * inlining. */
-#define INTERNAL_AES_ENC_ATTRS __attribute__ ((noinline))
+#define INTERNAL_AES_ENC_ATTRS __attribute__((noinline))
 #else
 #define INTERNAL_AES_ENC_ATTRS
 #endif

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -1058,7 +1058,7 @@ static int mbedtls_aes_crypt_ecb_multiblock(mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
         for (size_t pos = 0; pos < length; pos += 16) {
-            ret = mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
+            ret = mbedtls_aesce_crypt_ecb(ctx, mode, &input[pos], &output[pos]);
             if (ret != 0) {
                 goto exit;
             }
@@ -1070,7 +1070,7 @@ static int mbedtls_aes_crypt_ecb_multiblock(mbedtls_aes_context *ctx,
 #if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
     if (mode == MBEDTLS_AES_DECRYPT) {
         for (size_t pos = 0; pos < length; pos += 16) {
-            ret = mbedtls_internal_aes_decrypt(ctx, input, output);
+            ret = mbedtls_internal_aes_decrypt(ctx, &input[pos], &output[pos]);
             if (ret != 0) {
                 goto exit;
             }
@@ -1079,7 +1079,7 @@ static int mbedtls_aes_crypt_ecb_multiblock(mbedtls_aes_context *ctx,
 #endif
     {
         for (size_t pos = 0; pos < length; pos += 16) {
-            ret = mbedtls_internal_aes_encrypt(ctx, input, output);
+            ret = mbedtls_internal_aes_encrypt(ctx, &input[pos], &output[pos]);
             if (ret != 0) {
                 goto exit;
             }

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -1013,14 +1013,21 @@ MBEDTLS_MAYBE_UNUSED static void aes_maybe_realign(mbedtls_aes_context *ctx)
 /*
  * AES-ECB block encryption/decryption
  */
-int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
-                          int mode,
-                          const unsigned char input[16],
-                          unsigned char output[16])
+static int mbedtls_aes_crypt_ecb_multiblock(mbedtls_aes_context *ctx,
+                                            int mode,
+                                            const unsigned char *input,
+                                            unsigned char *output,
+                                            size_t length)
 {
-    if (mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) {
+    if ((mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) || length % 16 != 0) {
         return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
     }
+
+    if (length == 0) {
+        return 0;
+    }
+
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
 #if defined(MAY_NEED_TO_ALIGN)
     aes_maybe_realign(ctx);
@@ -1028,26 +1035,68 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_AESNI_HAVE_CODE)
     if (mbedtls_aesni_has_support(MBEDTLS_AESNI_AES)) {
-        return mbedtls_aesni_crypt_ecb(ctx, mode, input, output);
+        size_t pos = 0;
+        while (length - pos >= 4 * 16) {
+            ret = mbedtls_aesni_crypt_ecb_4blocks(ctx, mode, &input[pos], &output[pos]);
+            if (ret != 0) {
+                goto exit;
+            }
+            pos += 4 * 16;
+        }
+        size_t remaining_blocks = (length - pos) / 16;
+        if (remaining_blocks == 3) {
+            ret = mbedtls_aesni_crypt_ecb_3blocks(ctx, mode, &input[pos], &output[pos]);
+        } else if (remaining_blocks == 2) {
+            ret = mbedtls_aesni_crypt_ecb_2blocks(ctx, mode, &input[pos], &output[pos]);
+        } else if (remaining_blocks == 1) {
+            ret = mbedtls_aesni_crypt_ecb(ctx, mode, &input[pos], &output[pos]);
+        }
+        goto exit;
     }
 #endif
 
 #if defined(MBEDTLS_AESCE_HAVE_CODE)
     if (MBEDTLS_AESCE_HAS_SUPPORT()) {
-        return mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
+        for (size_t pos = 0; pos < length; pos += 16) {
+            ret = mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
+            if (ret != 0) {
+                goto exit;
+            }
+        }
     }
 #endif
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
     if (mode == MBEDTLS_AES_DECRYPT) {
-        return mbedtls_internal_aes_decrypt(ctx, input, output);
+        for (size_t pos = 0; pos < length; pos += 16) {
+            ret = mbedtls_internal_aes_decrypt(ctx, input, output);
+            if (ret != 0) {
+                goto exit;
+            }
+        }
     } else
 #endif
     {
-        return mbedtls_internal_aes_encrypt(ctx, input, output);
+        for (size_t pos = 0; pos < length; pos += 16) {
+            ret = mbedtls_internal_aes_encrypt(ctx, input, output);
+            if (ret != 0) {
+                goto exit;
+            }
+        }
     }
 #endif /* !MBEDTLS_AES_USE_HARDWARE_ONLY */
+
+exit:
+    return ret;
+}
+
+int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
+                          int mode,
+                          const unsigned char input[16],
+                          unsigned char output[16])
+{
+    return mbedtls_aes_crypt_ecb_multiblock(ctx, mode, input, output, 16);
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
@@ -1405,6 +1454,22 @@ exit:
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+static inline int aes_ctr_generate_keystream(mbedtls_aes_context *ctx,
+                                             unsigned char nonce_counter[16],
+                                             unsigned char *keystream,
+                                             size_t num_blocks)
+{
+    for (size_t i = 0; i < num_blocks; i++) {
+        memcpy(&keystream[i * 16], nonce_counter, 16);
+        mbedtls_ctr_increment_counter(nonce_counter);
+    }
+    return mbedtls_aes_crypt_ecb_multiblock(ctx,
+                                            MBEDTLS_AES_ENCRYPT,
+                                            keystream,
+                                            keystream,
+                                            num_blocks * 16);
+}
+
 /*
  * AES-CTR buffer encryption/decryption
  */
@@ -1424,29 +1489,39 @@ int mbedtls_aes_crypt_ctr(mbedtls_aes_context *ctx,
         return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
     }
 
-    for (size_t i = 0; i < length;) {
-        size_t n = 16;
-        if (offset == 0) {
-            ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, nonce_counter, stream_block);
-            if (ret != 0) {
-                goto exit;
-            }
-            mbedtls_ctr_increment_counter(nonce_counter);
-        } else {
-            n -= offset;
-        }
+    size_t pos = 0;
 
-        if (n > (length - i)) {
-            n = (length - i);
+    if (offset > 0) {
+        size_t n = 16 - offset;
+        if (n > length) {
+            n = length;
         }
-        mbedtls_xor(&output[i], &input[i], &stream_block[offset], n);
-        // offset might be non-zero for the last block, but in that case, we don't use it again
-        offset = 0;
-        i += n;
+        mbedtls_xor(output, input, &stream_block[offset], n);
+        pos += n;
     }
 
-    // capture offset for future resumption
+    unsigned char keystream[4 * 16];
+    unsigned char *last_keystream_block = NULL;
+    while (pos < length) {
+        size_t n = 4 * 16;
+        if (n > length - pos) {
+            n = length - pos;
+        }
+        size_t keystream_blocks_needed = (n + 15) / 16;
+        ret = aes_ctr_generate_keystream(ctx, nonce_counter, keystream, keystream_blocks_needed);
+        if (ret != 0) {
+            goto exit;
+        }
+        mbedtls_xor(&output[pos], &input[pos], keystream, n);
+        last_keystream_block = &keystream[(keystream_blocks_needed - 1) * 16];
+        pos += n;
+    }
+
+    // Capture the offset and last keystream block for resumption.
     *nc_off = (*nc_off + length) % 16;
+    if (last_keystream_block != NULL) {
+        memcpy(stream_block, last_keystream_block, 16);
+    }
 
     ret = 0;
 

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -869,10 +869,18 @@ int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context *ctx,
 /*
  * AES-ECB block encryption
  */
+#if defined(MBEDTLS_COMPILER_IS_GCC)
+/* In test_aesni, it is checked whether the software AES implementation is built
+ * by checking if mbedtls_internal_aes_encrypt exists in aes.o. Therefore, avoid
+ * inlining. */
+#define INTERNAL_AES_ENC_ATTRS __attribute__ ((noinline))
+#else
+#define INTERNAL_AES_ENC_ATTRS
+#endif
 MBEDTLS_CHECK_RETURN_TYPICAL
-static int mbedtls_internal_aes_encrypt(mbedtls_aes_context *ctx,
-                                        const unsigned char input[16],
-                                        unsigned char output[16])
+static int INTERNAL_AES_ENC_ATTRS mbedtls_internal_aes_encrypt(mbedtls_aes_context *ctx,
+                                                               const unsigned char input[16],
+                                                               unsigned char output[16])
 {
     int i;
     uint32_t *RK = ctx->buf + ctx->rk_offset;

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -1063,6 +1063,7 @@ static int mbedtls_aes_crypt_ecb_multiblock(mbedtls_aes_context *ctx,
                 goto exit;
             }
         }
+        goto exit;
     }
 #endif
 

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -1526,6 +1526,7 @@ int mbedtls_aes_crypt_ctr(mbedtls_aes_context *ctx,
     ret = 0;
 
 exit:
+    mbedtls_platform_zeroize(keystream, sizeof(keystream));
     return ret;
 }
 #endif /* MBEDTLS_CIPHER_MODE_CTR */

--- a/drivers/builtin/src/aesni.c
+++ b/drivers/builtin/src/aesni.c
@@ -88,6 +88,62 @@ int mbedtls_aesni_has_support(unsigned int what)
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 
 /*
+ * Encrypt or decrypt multiple blocks using AES-NI. This allows making use of
+ * instruction-level parallelism to speed up AES operations when processing
+ * multiple blocks. The input and output buffers need to have a size of
+ * num_blocks * 16 bytes, while state must have num_blocks items.
+ */
+static inline void aesni_crypt_ecb_multiple_blocks(mbedtls_aes_context *ctx,
+                                                   int mode,
+                                                   const unsigned char *input,
+                                                   unsigned char *output,
+                                                   __m128i *state,
+                                                   size_t num_blocks)
+{
+    const __m128i *rk = (const __m128i *) (ctx->buf + ctx->rk_offset);
+    unsigned nr = ctx->nr; // Number of remaining rounds
+
+    // Load round key 0
+    memcpy(state, input, num_blocks * 16);
+    for (size_t i = 0; i < num_blocks; i++) {
+        state[i] = _mm_xor_si128(state[i], rk[0]);  // state ^= *rk;
+    }
+    ++rk;
+    --nr;
+
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+    if (mode == MBEDTLS_AES_DECRYPT) {
+        while (nr != 0) {
+            for (size_t i = 0; i < num_blocks; i++) {
+                state[i] = _mm_aesdec_si128(state[i], *rk);
+            }
+            ++rk;
+            --nr;
+        }
+        for (size_t i = 0; i < num_blocks; i++) {
+            state[i] = _mm_aesdeclast_si128(state[i], *rk);
+        }
+    } else
+#else
+    (void) mode;
+#endif
+    {
+        while (nr != 0) {
+            for (size_t i = 0; i < num_blocks; i++) {
+                state[i] = _mm_aesenc_si128(state[i], *rk);
+            }
+            ++rk;
+            --nr;
+        }
+        for (size_t i = 0; i < num_blocks; i++) {
+            state[i] = _mm_aesenclast_si128(state[i], *rk);
+        }
+    }
+
+    memcpy(output, state, num_blocks * 16);
+}
+
+/*
  * AES-NI AES-ECB block en(de)cryption
  */
 int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
@@ -95,38 +151,38 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
                             const unsigned char input[16],
                             unsigned char output[16])
 {
-    const __m128i *rk = (const __m128i *) (ctx->buf + ctx->rk_offset);
-    unsigned nr = ctx->nr; // Number of remaining rounds
-
-    // Load round key 0
     __m128i state;
-    memcpy(&state, input, 16);
-    state = _mm_xor_si128(state, rk[0]);  // state ^= *rk;
-    ++rk;
-    --nr;
+    aesni_crypt_ecb_multiple_blocks(ctx, mode, input, output, &state, 1);
+    return 0;
+}
 
-#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
-    if (mode == MBEDTLS_AES_DECRYPT) {
-        while (nr != 0) {
-            state = _mm_aesdec_si128(state, *rk);
-            ++rk;
-            --nr;
-        }
-        state = _mm_aesdeclast_si128(state, *rk);
-    } else
-#else
-    (void) mode;
-#endif
-    {
-        while (nr != 0) {
-            state = _mm_aesenc_si128(state, *rk);
-            ++rk;
-            --nr;
-        }
-        state = _mm_aesenclast_si128(state, *rk);
-    }
+int mbedtls_aesni_crypt_ecb_2blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[2 * 16],
+                                    unsigned char output[2 * 16])
+{
+    __m128i state[2];
+    aesni_crypt_ecb_multiple_blocks(ctx, mode, input, output, state, 2);
+    return 0;
+}
 
-    memcpy(output, &state, 16);
+int mbedtls_aesni_crypt_ecb_3blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[3 * 16],
+                                    unsigned char output[3 * 16])
+{
+    __m128i state[3];
+    aesni_crypt_ecb_multiple_blocks(ctx, mode, input, output, state, 3);
+    return 0;
+}
+
+int mbedtls_aesni_crypt_ecb_4blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[4 * 16],
+                                    unsigned char output[4 * 16])
+{
+    __m128i state[4];
+    aesni_crypt_ecb_multiple_blocks(ctx, mode, input, output, state, 4);
     return 0;
 }
 
@@ -443,10 +499,6 @@ static void aesni_setkey_enc_256(unsigned char *rk_bytes,
  * Operand macros are in gas order (src, dst) as opposed to Intel order
  * (dst, src) in order to blend better into the surrounding assembly code.
  */
-#define AESDEC(regs)      ".byte 0x66,0x0F,0x38,0xDE," regs "\n\t"
-#define AESDECLAST(regs)  ".byte 0x66,0x0F,0x38,0xDF," regs "\n\t"
-#define AESENC(regs)      ".byte 0x66,0x0F,0x38,0xDC," regs "\n\t"
-#define AESENCLAST(regs)  ".byte 0x66,0x0F,0x38,0xDD," regs "\n\t"
 #define AESIMC(regs)      ".byte 0x66,0x0F,0x38,0xDB," regs "\n\t"
 #define AESKEYGENA(regs, imm)  ".byte 0x66,0x0F,0x3A,0xDF," regs "," imm "\n\t"
 #define PCLMULQDQ(regs, imm)   ".byte 0x66,0x0F,0x3A,0x44," regs "," imm "\n\t"
@@ -467,33 +519,33 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
                             const unsigned char input[16],
                             unsigned char output[16])
 {
-    asm ("movdqu    (%3), %%xmm0    \n\t" // load input
-         "movdqu    (%1), %%xmm1    \n\t" // load round key 0
-         "pxor      %%xmm1, %%xmm0  \n\t" // round 0
-         "add       $16, %1         \n\t" // point to next round key
-         "subl      $1, %0          \n\t" // normal rounds = nr - 1
-         "test      %2, %2          \n\t" // mode?
-         "jz        2f              \n\t" // 0 = decrypt
+    asm ("movdqu      (%3), %%xmm0    \n\t" // load input
+         "movdqu      (%1), %%xmm1    \n\t" // load round key 0
+         "pxor        %%xmm1, %%xmm0  \n\t" // round 0
+         "add         $16, %1         \n\t" // point to next round key
+         "subl        $1, %0          \n\t" // normal rounds = nr - 1
+         "test        %2, %2          \n\t" // mode?
+         "jz          2f              \n\t" // 0 = decrypt
 
-         "1:                        \n\t" // encryption loop
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESENC(xmm1_xmm0)                // do round
-         "add       $16, %1         \n\t" // point to next round key
-         "subl      $1, %0          \n\t" // loop
-         "jnz       1b              \n\t"
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESENCLAST(xmm1_xmm0)            // last round
+         "1:                          \n\t" // encryption loop
+         "movdqu      (%1), %%xmm1    \n\t" // load round key
+         "aesenc      %%xmm1, %%xmm0  \n\t" // do round
+         "add         $16, %1         \n\t" // point to next round key
+         "subl        $1, %0          \n\t" // loop
+         "jnz         1b              \n\t"
+         "movdqu      (%1), %%xmm1    \n\t" // load round key
+         "aesenclast  %%xmm1, %%xmm0  \n\t" // last round
 #if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
-         "jmp       3f              \n\t"
+         "jmp         3f              \n\t"
 
-         "2:                        \n\t" // decryption loop
-         "movdqu    (%1), %%xmm1    \n\t"
-         AESDEC(xmm1_xmm0)                // do round
-         "add       $16, %1         \n\t"
-         "subl      $1, %0          \n\t"
-         "jnz       2b              \n\t"
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESDECLAST(xmm1_xmm0)            // last round
+         "2:                          \n\t" // decryption loop
+         "movdqu      (%1), %%xmm1    \n\t"
+         "aesdec      %%xmm1, %%xmm0  \n\t" // do round
+         "add         $16, %1         \n\t"
+         "subl        $1, %0          \n\t"
+         "jnz         2b              \n\t"
+         "movdqu      (%1), %%xmm1    \n\t" // load round key
+         "aesdeclast  %%xmm1, %%xmm0  \n\t" // last round
 #endif
 
          "3:                        \n\t"
@@ -501,6 +553,189 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
          :
          : "r" (ctx->nr), "r" (ctx->buf + ctx->rk_offset), "r" (mode), "r" (input), "r" (output)
          : "memory", "cc", "xmm0", "xmm1", "0", "1");
+
+
+    return 0;
+}
+
+/*
+ * AES-NI AES-ECB block en(de)cryption, two at a time.
+ */
+int mbedtls_aesni_crypt_ecb_2blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[2 * 16],
+                                    unsigned char output[2 * 16])
+{
+    asm ("movdqu     (%3), %%xmm0      \n\t" // load input
+         "movdqu     16(%3), %%xmm1    \n\t"
+         "movdqu     (%1), %%xmm2      \n\t" // load round key 0
+         "pxor       %%xmm2, %%xmm0    \n\t" // round 0
+         "pxor       %%xmm2, %%xmm1    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // normal rounds = nr - 1
+         "test       %2, %2            \n\t" // mode?
+         "jz         2f                \n\t" // 0 = decrypt
+
+         "1:                           \n\t" // encryption loop
+         "movdqu     (%1), %%xmm2      \n\t" // load round key
+         "aesenc     %%xmm2, %%xmm0    \n\t" // do round
+         "aesenc     %%xmm2, %%xmm1    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // loop
+         "jnz        1b                \n\t"
+         "movdqu     (%1), %%xmm2      \n\t" // load round key
+         "aesenclast %%xmm2, %%xmm0    \n\t" // last round
+         "aesenclast %%xmm2, %%xmm1    \n\t"
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+         "jmp        3f                 \n\t"
+
+         "2:                            \n\t" // decryption loop
+         "movdqu     (%1), %%xmm2       \n\t"
+         "aesdec     %%xmm2, %%xmm0     \n\t" // do round
+         "aesdec     %%xmm2, %%xmm1     \n\t"
+         "add        $16, %1            \n\t"
+         "subl       $1, %0             \n\t"
+         "jnz        2b                 \n\t"
+         "movdqu     (%1), %%xmm2       \n\t" // load round key
+         "aesdeclast %%xmm2, %%xmm0     \n\t" // last round
+         "aesdeclast %%xmm2, %%xmm1     \n\t"
+#endif
+
+         "3:                            \n\t"
+         "movdqu     %%xmm0, (%4)       \n\t" // export output
+         "movdqu     %%xmm1, 16(%4)     \n\t"
+         :
+         : "r" (ctx->nr), "r" (ctx->buf + ctx->rk_offset), "r" (mode), "r" (input), "r" (output)
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "0", "1");
+
+
+    return 0;
+}
+
+/*
+ * AES-NI AES-ECB block en(de)cryption, three at a time.
+ */
+int mbedtls_aesni_crypt_ecb_3blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[3 * 16],
+                                    unsigned char output[3 * 16])
+{
+    asm ("movdqu     (%3), %%xmm0      \n\t" // load input
+         "movdqu     16(%3), %%xmm1    \n\t"
+         "movdqu     32(%3), %%xmm2    \n\t"
+         "movdqu     (%1), %%xmm3      \n\t" // load round key 0
+         "pxor       %%xmm3, %%xmm0    \n\t" // round 0
+         "pxor       %%xmm3, %%xmm1    \n\t"
+         "pxor       %%xmm3, %%xmm2    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // normal rounds = nr - 1
+         "test       %2, %2            \n\t" // mode?
+         "jz         2f                \n\t" // 0 = decrypt
+
+         "1:                           \n\t" // encryption loop
+         "movdqu     (%1), %%xmm3      \n\t" // load round key
+         "aesenc     %%xmm3, %%xmm0    \n\t" // do round
+         "aesenc     %%xmm3, %%xmm1    \n\t"
+         "aesenc     %%xmm3, %%xmm2    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // loop
+         "jnz        1b                \n\t"
+         "movdqu     (%1), %%xmm3      \n\t" // load round key
+         "aesenclast %%xmm3, %%xmm0    \n\t" // last round
+         "aesenclast %%xmm3, %%xmm1    \n\t"
+         "aesenclast %%xmm3, %%xmm2    \n\t"
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+         "jmp        3f                 \n\t"
+
+         "2:                            \n\t" // decryption loop
+         "movdqu     (%1), %%xmm3       \n\t"
+         "aesdec     %%xmm3, %%xmm0     \n\t" // do round
+         "aesdec     %%xmm3, %%xmm1     \n\t"
+         "aesdec     %%xmm3, %%xmm2     \n\t"
+         "add        $16, %1            \n\t"
+         "subl       $1, %0             \n\t"
+         "jnz        2b                 \n\t"
+         "movdqu     (%1), %%xmm3       \n\t" // load round key
+         "aesdeclast %%xmm3, %%xmm0     \n\t" // last round
+         "aesdeclast %%xmm3, %%xmm1     \n\t"
+         "aesdeclast %%xmm3, %%xmm2     \n\t"
+#endif
+
+         "3:                            \n\t"
+         "movdqu     %%xmm0, (%4)       \n\t" // export output
+         "movdqu     %%xmm1, 16(%4)     \n\t"
+         "movdqu     %%xmm2, 32(%4)     \n\t"
+         :
+         : "r" (ctx->nr), "r" (ctx->buf + ctx->rk_offset), "r" (mode), "r" (input), "r" (output)
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "xmm3", "0", "1");
+
+
+    return 0;
+}
+
+/*
+ * AES-NI AES-ECB block en(de)cryption, four at a time.
+ */
+int mbedtls_aesni_crypt_ecb_4blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[4 * 16],
+                                    unsigned char output[4 * 16])
+{
+    asm ("movdqu     (%3), %%xmm0      \n\t" // load input
+         "movdqu     16(%3), %%xmm1    \n\t"
+         "movdqu     32(%3), %%xmm2    \n\t"
+         "movdqu     48(%3), %%xmm3    \n\t"
+         "movdqu     (%1), %%xmm4      \n\t" // load round key 0
+         "pxor       %%xmm4, %%xmm0    \n\t" // round 0
+         "pxor       %%xmm4, %%xmm1    \n\t"
+         "pxor       %%xmm4, %%xmm2    \n\t"
+         "pxor       %%xmm4, %%xmm3    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // normal rounds = nr - 1
+         "test       %2, %2            \n\t" // mode?
+         "jz         2f                \n\t" // 0 = decrypt
+
+         "1:                           \n\t" // encryption loop
+         "movdqu     (%1), %%xmm4      \n\t" // load round key
+         "aesenc     %%xmm4, %%xmm0    \n\t" // do round
+         "aesenc     %%xmm4, %%xmm1    \n\t"
+         "aesenc     %%xmm4, %%xmm2    \n\t"
+         "aesenc     %%xmm4, %%xmm3    \n\t"
+         "add        $16, %1           \n\t" // point to next round key
+         "subl       $1, %0            \n\t" // loop
+         "jnz        1b                \n\t"
+         "movdqu     (%1), %%xmm4      \n\t" // load round key
+         "aesenclast %%xmm4, %%xmm0    \n\t" // last round
+         "aesenclast %%xmm4, %%xmm1    \n\t"
+         "aesenclast %%xmm4, %%xmm2    \n\t"
+         "aesenclast %%xmm4, %%xmm3    \n\t"
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+         "jmp        3f                 \n\t"
+
+         "2:                            \n\t" // decryption loop
+         "movdqu     (%1), %%xmm4       \n\t"
+         "aesdec     %%xmm4, %%xmm0     \n\t" // do round
+         "aesdec     %%xmm4, %%xmm1     \n\t"
+         "aesdec     %%xmm4, %%xmm2     \n\t"
+         "aesdec     %%xmm4, %%xmm3     \n\t"
+         "add        $16, %1            \n\t"
+         "subl       $1, %0             \n\t"
+         "jnz        2b                 \n\t"
+         "movdqu     (%1), %%xmm4       \n\t" // load round key
+         "aesdeclast %%xmm4, %%xmm0     \n\t" // last round
+         "aesdeclast %%xmm4, %%xmm1     \n\t"
+         "aesdeclast %%xmm4, %%xmm2     \n\t"
+         "aesdeclast %%xmm4, %%xmm3     \n\t"
+#endif
+
+         "3:                            \n\t"
+         "movdqu     %%xmm0, (%4)       \n\t" // export output
+         "movdqu     %%xmm1, 16(%4)     \n\t"
+         "movdqu     %%xmm2, 32(%4)     \n\t"
+         "movdqu     %%xmm3, 48(%4)     \n\t"
+         :
+         : "r" (ctx->nr), "r" (ctx->buf + ctx->rk_offset), "r" (mode), "r" (input), "r" (output)
+         : "memory", "cc", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "0", "1");
 
 
     return 0;

--- a/drivers/builtin/src/aesni.c
+++ b/drivers/builtin/src/aesni.c
@@ -101,9 +101,9 @@ static inline void aesni_crypt_ecb_multiple_blocks(mbedtls_aes_context *ctx,
                                                    size_t num_blocks)
 {
     const __m128i *rk = (const __m128i *) (ctx->buf + ctx->rk_offset);
+    // Load round key 0
     unsigned nr = ctx->nr; // Number of remaining rounds
 
-    // Load round key 0
     memcpy(state, input, num_blocks * 16);
     for (size_t i = 0; i < num_blocks; i++) {
         state[i] = _mm_xor_si128(state[i], rk[0]);  // state ^= *rk;
@@ -176,13 +176,63 @@ int mbedtls_aesni_crypt_ecb_3blocks(mbedtls_aes_context *ctx,
     return 0;
 }
 
+/*
+ * "Hand-written" version for four blocks, because GCC does not unroll the
+ * loops in aesni_crypt_ecb_multiple_blocks() when num_rounds is 4.
+ */
 int mbedtls_aesni_crypt_ecb_4blocks(mbedtls_aes_context *ctx,
                                     int mode,
                                     const unsigned char input[4 * 16],
                                     unsigned char output[4 * 16])
 {
     __m128i state[4];
-    aesni_crypt_ecb_multiple_blocks(ctx, mode, input, output, state, 4);
+
+    // Load round key 0
+    const __m128i *rk = (const __m128i *) (ctx->buf + ctx->rk_offset);
+    unsigned nr = ctx->nr; // Number of remaining rounds
+
+    memcpy(state, input, 4 * 16);
+    state[0] = _mm_xor_si128(state[0], rk[0]);  // state XOR first round key.
+    state[1] = _mm_xor_si128(state[1], rk[0]);
+    state[2] = _mm_xor_si128(state[2], rk[0]);
+    state[3] = _mm_xor_si128(state[3], rk[0]);
+    ++rk;
+    --nr;
+
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+    if (mode == MBEDTLS_AES_DECRYPT) {
+        while (nr != 0) {
+            state[0] = _mm_aesdec_si128(state[0], *rk);
+            state[1] = _mm_aesdec_si128(state[1], *rk);
+            state[2] = _mm_aesdec_si128(state[2], *rk);
+            state[3] = _mm_aesdec_si128(state[3], *rk);
+            ++rk;
+            --nr;
+        }
+        state[0] = _mm_aesdeclast_si128(state[0], *rk);
+        state[1] = _mm_aesdeclast_si128(state[1], *rk);
+        state[2] = _mm_aesdeclast_si128(state[2], *rk);
+        state[3] = _mm_aesdeclast_si128(state[3], *rk);
+    } else
+#else
+    (void) mode;
+#endif
+    {
+        while (nr != 0) {
+            state[0] = _mm_aesenc_si128(state[0], *rk);
+            state[1] = _mm_aesenc_si128(state[1], *rk);
+            state[2] = _mm_aesenc_si128(state[2], *rk);
+            state[3] = _mm_aesenc_si128(state[3], *rk);
+            ++rk;
+            --nr;
+        }
+        state[0] = _mm_aesenclast_si128(state[0], *rk);
+        state[1] = _mm_aesenclast_si128(state[1], *rk);
+        state[2] = _mm_aesenclast_si128(state[2], *rk);
+        state[3] = _mm_aesenclast_si128(state[3], *rk);
+    }
+
+    memcpy(output, state, 4 * 16);
     return 0;
 }
 

--- a/drivers/builtin/src/aesni.h
+++ b/drivers/builtin/src/aesni.h
@@ -103,6 +103,66 @@ int mbedtls_aesni_crypt_ecb(mbedtls_aes_context *ctx,
                             unsigned char output[16]);
 
 /**
+ * \brief          Internal AES-NI block encryption and decryption
+ *                 This function processes two blocks at once to benefit from
+ *                 instruction-level parallelism.
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    Buffer containing two 16-byte input blocks
+ * \param output   Buffer with room for two 16-byte output blocks
+ *
+ * \return         0 on success (cannot fail)
+ */
+int mbedtls_aesni_crypt_ecb_2blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[2 * 16],
+                                    unsigned char output[2 * 16]);
+
+/**
+ * \brief          Internal AES-NI block encryption and decryption
+ *                 This function processes three blocks at once to benefit from
+ *                 instruction-level parallelism.
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    Buffer containing three 16-byte input blocks
+ * \param output   Buffer with room for three 16-byte output blocks
+ *
+ * \return         0 on success (cannot fail)
+ */
+int mbedtls_aesni_crypt_ecb_3blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[3 * 16],
+                                    unsigned char output[3 * 16]);
+
+/**
+ * \brief          Internal AES-NI block encryption and decryption
+ *                 This function processes four blocks at once to benefit from
+ *                 instruction-level parallelism.
+ *
+ * \note           This function is only for internal use by other library
+ *                 functions; you must not call it directly.
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    Buffer containing four 16-byte input blocks
+ * \param output   Buffer with room for four 16-byte output blocks
+ *
+ * \return         0 on success (cannot fail)
+ */
+int mbedtls_aesni_crypt_ecb_4blocks(mbedtls_aes_context *ctx,
+                                    int mode,
+                                    const unsigned char input[4 * 16],
+                                    unsigned char output[4 * 16]);
+
+/**
  * \brief          Internal GCM multiplication: c = a * b in GF(2^128)
  *
  * \note           This function is only for internal use by other library


### PR DESCRIPTION
## Description

One feature of the AES-NI instructions is instruction-level parallelism, which means that, while one round of AES takes multiple clock cycles to complete, another instruction can already start executing on the next clock cycle. Only when the result of the AES round is used do we need to wait for it to finish.

In particular, this makes it possible to encrypt or decrypt multiple AES blocks in parallel which can be used to speed up AES in some modes of operation. In this commit, it is used to speed up AES-CTR. I have chosen to do up to four blocks in parallel. More would be possible, but while testing on my machine, I didn't see meaningful speed-ups when going beyond 4, and I don't want to clutter the source files with even more assembly.

I have removed the `defines` with the `aesenc` etc. opcodes assuming that we don't need to support these older versions of binutils anymore. If that's wrong, I'll put them back (and add my own macros for the registers I need to use).

I would like to go on and also use it in AES-GCM, but there I ran into a problem. GCM runs the underlying block cipher in ECB mode. Due to an inconsistency in the `mbedtls_cipher` API, ECB mode always encrypts exactly one block. As far as I understand, `mbedtls_cipher` is on its way out, so I don't know if you would want to spend time reviewing a fix for this. Please let me know what you think would be the best approach!

An alternative I can see would be to use CTR mode (making sure that the 32-bit counter in GCM doesn't overflow) inside of GCM, if available.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: No changes in mbedtls are needed to make use of this. The speed-up will take effect as soon as the submodule is updated. (Should I make a pull request just to update the submodule?)
- [x] **mbedtls 3.6 PR** not required because: It's a new feature, not a bugfix. It doesn't have to be backported. (As far as I'm concerned.)
- **tests** not required because: No changes in the output are intended, only performance.