### PR TITLE
Add code size target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ else()
     option(GEN_FILES "Generate the auto-generated files as needed" ON)
 endif()
 
+if(NOT CMAKE_SIZE_UTIL)
+    set(CMAKE_SIZE_UTIL size)
+endif()
+
 # Support for package config and install to be added later.
 option(DISABLE_PACKAGE_CONFIG_AND_INSTALL "Disable package configuration, target export and installation" ${TF_PSA_CRYPTO_AS_SUBPROJECT})
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -165,6 +165,14 @@ if(USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
     endif()
 endif(USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
 
+# Add code size target for libtfpsacrypto
+add_custom_target(size
+    COMMAND ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+    ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_code_size_report.py
+    --output-file ${CMAKE_CURRENT_BINARY_DIR}/code_size.json
+    --library-file $<TARGET_FILE_NAME:${tfpsacrypto_target}>
+    --size-cmd ${CMAKE_SIZE_UTIL})
+
 foreach(target IN LISTS target_libraries)
     add_library(TF-PSA-Crypto::${target} ALIAS ${target})  # add_subdirectory support
     target_include_directories(${target}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -171,7 +171,10 @@ add_custom_target(size
     ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/generate_code_size_report.py
     --output-file ${CMAKE_CURRENT_BINARY_DIR}/code_size.json
     --library-file $<TARGET_FILE_NAME:${tfpsacrypto_target}>
-    --size-cmd ${CMAKE_SIZE_UTIL})
+    --size-cmd ${CMAKE_SIZE_UTIL}
+    COMMAND ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+    ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/scripts/show_code_size.py
+    ${CMAKE_CURRENT_BINARY_DIR}/code_size.json)
 
 foreach(target IN LISTS target_libraries)
     add_library(TF-PSA-Crypto::${target} ALIAS ${target})  # add_subdirectory support


### PR DESCRIPTION
Use the scripts from Mbed-TLS/mbedtls-framework#246 to implement a new target in CMake called `size` which displays the code sizes of modules and generates a JSON code size report.

To use it, simply do the following:
```
cd build
cmake ..
make -j8
make size
```
When cross compiling with a toolchain file, this relies on the variable `CMAKE_SIZE_UTIL` being set to the `size` command for the relevant architecture (e.g. `arm-none-eabi-size`).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 