### PR TITLE
Update the argument of mbedtls_pk_get_key_type to const

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -706,7 +706,7 @@ int mbedtls_pk_get_psa_attributes(const mbedtls_pk_context *pk,
     return 0;
 }
 
-psa_key_type_t mbedtls_pk_get_key_type(mbedtls_pk_context *pk)
+psa_key_type_t mbedtls_pk_get_key_type(const mbedtls_pk_context *pk)
 {
     return pk->psa_type;
 }

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -421,7 +421,7 @@ int mbedtls_pk_get_psa_attributes(const mbedtls_pk_context *pk,
  *                      - PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve)
  * \return          PSA_KEY_TYPE_NONE, if the context has not been populated.
  */
-psa_key_type_t mbedtls_pk_get_key_type(mbedtls_pk_context *pk);
+psa_key_type_t mbedtls_pk_get_key_type(const mbedtls_pk_context *pk);
 
 
 /**


### PR DESCRIPTION
## Description

[Update the argument of mbedtls_pk_get_key_type to const, contributes to https://github.com/Mbed-TLS/mbedtls/issues/10456.

## PR checklist

- [x] **changelog** not required because: the function changed was never in a release yet
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# https://github.com/Mbed-TLS/mbedtls/pull/10533
- [x] **mbedtls 3.6 PR** not required because: No backports
- **tests**  provided: TBC
