### PR TITLE
Fix AESCE regression with Clang due to inclusion order changes

### DIFF
--- a/drivers/builtin/src/aesce.c
+++ b/drivers/builtin/src/aesce.c
@@ -16,15 +16,16 @@
 #endif
 
 #if defined(MBEDTLS_AESCE_ARCH_IS_ARMV8_A) && !defined(__ARM_FEATURE_CRYPTO)
-/* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
- *
- * The intrinsic declaration are guarded by predefined ACLE macros in clang:
+/* The intrinsic declaration are guarded by predefined ACLE macros in clang:
  * these are normally only enabled by the -march option on the command line.
  * By defining the macros ourselves we gain access to those declarations without
  * requiring -march on the command line.
  *
  * `arm_neon.h` is included by tf_psa_crypto_common.h, so we put these defines
- * at the top of this file, before any includes.
+ * at the top of this file, before any includes. This is necessary with
+ * Clang <=15.x. With Clang 16.0 and above, these macro definitions are
+ * no longer required, but they're harmless. See
+ * https://reviews.llvm.org/D131064
  */
 #define __ARM_FEATURE_CRYPTO 1
 /* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions

--- a/drivers/builtin/src/aesce.c
+++ b/drivers/builtin/src/aesce.c
@@ -5,10 +5,6 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_AESCE_C)
-
 #if defined(__clang__) &&  (__clang_major__ >= 4)
 
 /* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8_A in the following #if,
@@ -41,6 +37,10 @@
 #endif
 
 #endif /* defined(__clang__) &&  (__clang_major__ >= 4) */
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_AESCE_C)
 
 #include <string.h>
 


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/601, a regression introduced by https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/550 which just got merged.

## PR checklist

- [x] **changelog** not required because: bug introduced after the last release
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10538
- **tests**
    - Locally: `clang-15 -target aarch64-linux-gnu --sysroot /usr/aarch64-linux-gnu -I include -I core -I drivers/builtin/include -c drivers/builtin/src/aesce.c` (see the [issue description](https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/601) for more details). I tested locally as far back as clang 7. Clang 6 and earlier have a different problem: https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/604
    - On the CI: too much hassle, filed as https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/602
    - Check visually that it doesn't regress https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/548
