### PR TITLE
Bugfix/fix intrinsic header for arm architecture

### DIFF
--- a/drivers/builtin/src/sha256.c
+++ b/drivers/builtin/src/sha256.c
@@ -15,10 +15,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA224_C)
-
 #if defined(__clang__) &&  (__clang_major__ >= 4)
 
 /* Ideally, we would simply use MBEDTLS_ARCH_IS_ARMV8_A in the following #if,
@@ -30,15 +26,18 @@
 #endif
 
 #if defined(MBEDTLS_SHA256_ARCH_IS_ARMV8_A) && !defined(__ARM_FEATURE_CRYPTO)
-/* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
- *
+/*
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:
  * these are normally only enabled by the -march option on the command line.
  * By defining the macros ourselves we gain access to those declarations without
  * requiring -march on the command line.
  *
  * `arm_neon.h` is included by tf_psa_crypto_common.h, so we put these defines
- * at the top of this file, before any includes.
+ * at the top of this file, before any includes but after the intrinsic
+ * declaration. This is necessary with
+ * Clang <=15.x. With Clang 16.0 and above, these macro definitions are
+ * no longer required, but they're harmless. See
+ * https://reviews.llvm.org/D131064
  */
 #define __ARM_FEATURE_CRYPTO 1
 /* See: https://arm-software.github.io/acle/main/acle.html#cryptographic-extensions
@@ -51,6 +50,10 @@
 #endif
 
 #endif /* defined(__clang__) &&  (__clang_major__ >= 4) */
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_SHA256_C) || defined(MBEDTLS_SHA224_C)
 
 #include "mbedtls/private/sha256.h"
 #include "mbedtls/platform_util.h"

--- a/drivers/builtin/src/sha512.c
+++ b/drivers/builtin/src/sha512.c
@@ -10,25 +10,28 @@
  *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
  */
 
-#include "tf_psa_crypto_common.h"
-
-#if defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_SHA384_C)
-
 #if defined(__aarch64__) && !defined(__ARM_FEATURE_SHA512) && \
     defined(__clang__) && __clang_major__ >= 7
-/* TODO: Re-consider above after https://reviews.llvm.org/D131064 merged.
- *
+/*
  * The intrinsic declaration are guarded by predefined ACLE macros in clang:
  * these are normally only enabled by the -march option on the command line.
  * By defining the macros ourselves we gain access to those declarations without
  * requiring -march on the command line.
  *
  * `arm_neon.h` is included by tf_psa_crypto_common.h, so we put these defines
- * at the top of this file, before any includes.
+ * at the top of this file, before any includes but after the intrinsic
+ * declaration. This is necessary with
+ * Clang <=15.x. With Clang 16.0 and above, these macro definitions are
+ * no longer required, but they're harmless. See
+ * https://reviews.llvm.org/D131064
  */
 #define __ARM_FEATURE_SHA512 1
 #define MBEDTLS_ENABLE_ARM_SHA3_EXTENSIONS_COMPILER_FLAG
 #endif
+
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_SHA512_C) || defined(MBEDTLS_SHA384_C)
 
 #include "mbedtls/private/sha512.h"
 #include "mbedtls/platform_util.h"


### PR DESCRIPTION
## Description

Currently the development branch fails to compile in arm silicone because of how the arm intrisics macros are not properly defined. This pr changes the inclusion order of `tf_psa_crypto_common.h` after they have been defined, in affected source files.

It also updates to the head of framework to bring in other related bugfixes in the tf-psa-crypto branch. 

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: the bug that is fixed by this PR has not been released
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: The crypto files have been moved to TF-PSA-Crypto
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10542
- **tests**  provided | not required because: 
