### PR TITLE
Adopt crypto part of Mbed TLS makefiles

### DIFF
--- a/core/crypto-library.make
+++ b/core/crypto-library.make
@@ -1,0 +1,42 @@
+# Helper code for library/Makefile in Mbed TLS.
+# This file is only meant to be included by library/Makefile in Mbed TLS and
+# is unlikely to work in another context.
+
+# List the generated files from crypto that are needed in the build,
+# because we don't have the list in a consumable form.
+TF_PSA_CRYPTO_LIBRARY_GENERATED_FILES := \
+	$(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers.h \
+	$(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers_no_static.c \
+	$(TF_PSA_CRYPTO_CORE_PATH)/tf_psa_crypto_config_check_before.h \
+	$(TF_PSA_CRYPTO_CORE_PATH)/tf_psa_crypto_config_check_final.h \
+	$(TF_PSA_CRYPTO_CORE_PATH)/tf_psa_crypto_config_check_user.h
+
+GENERATED_WRAPPER_FILES = \
+                    $(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers.h \
+                    $(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers_no_static.c
+$(GENERATED_WRAPPER_FILES): ../tf-psa-crypto/scripts/generate_driver_wrappers.py
+$(GENERATED_WRAPPER_FILES): ../tf-psa-crypto/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+$(GENERATED_WRAPPER_FILES): ../tf-psa-crypto/scripts/data_files/driver_templates/psa_crypto_driver_wrappers_no_static.c.jinja
+$(GENERATED_WRAPPER_FILES):
+	echo "  Gen   $(GENERATED_WRAPPER_FILES)"
+	$(PYTHON) ../tf-psa-crypto/scripts/generate_driver_wrappers.py $(TF_PSA_CRYPTO_CORE_PATH)
+
+$(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto.o:$(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers.h
+
+TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES = $(shell $(PYTHON) \
+	$(TF_PSA_CRYPTO_CORE_PATH)/../scripts/generate_config_checks.py \
+	--list $(TF_PSA_CRYPTO_CORE_PATH))
+$(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES): $(gen_file_dep) \
+	$(TF_PSA_CRYPTO_CORE_PATH)/../scripts/generate_config_checks.py \
+	../framework/scripts/mbedtls_framework/config_checks_generator.py
+$(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES):
+	echo "  Gen   $(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES)"
+	$(PYTHON) $(TF_PSA_CRYPTO_CORE_PATH)/../scripts/generate_config_checks.py
+
+$(TF_PSA_CRYPTO_CORE_PATH)/tf_psa_crypto_config.o: $(TF_PSA_CRYPTO_GENERATED_CONFIG_CHECK_FILES)
+
+TF_PSA_CRYPTO_LIBRARY_OBJS := $(patsubst %.c, %.o,$(wildcard $(TF_PSA_CRYPTO_CORE_PATH)/*.c $(TF_PSA_CRYPTO_DRIVERS_BUILTIN_SRC_PATH)/*.c))
+TF_PSA_CRYPTO_LIBRARY_GENERATED_OBJS = $(TF_PSA_CRYPTO_CORE_PATH)/psa_crypto_driver_wrappers_no_static.o
+TF_PSA_CRYPTO_LIBRARY_OBJS := $(filter-out $(TF_PSA_CRYPTO_LIBRARY_GENERATED_OBJS),$(TF_PSA_CRYPTO_LIBRARY_OBJS))
+TF_PSA_CRYPTO_LIBRARY_OBJS += $(TF_PSA_CRYPTO_LIBRARY_GENERATED_OBJS)
+TF_PSA_CRYPTO_LIBRARY_OBJS+=$(THIRDPARTY_CRYPTO_OBJECTS)

--- a/programs/crypto-programs.make
+++ b/programs/crypto-programs.make
@@ -1,0 +1,52 @@
+# Helper code for programs/Makefile in Mbed TLS.
+# This file is only meant to be included by programs/Makefile in Mbed TLS and
+# is unlikely to work in another context.
+
+TF_PSA_CRYPTO_PROGRAMS_GENERATED_FILES := \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/psa_constant_names_generated.c
+
+../tf-psa-crypto/programs/psa/psa_constant_names_generated.c: $(gen_file_dep) ../tf-psa-crypto/scripts/generate_psa_constants.py
+../tf-psa-crypto/programs/psa/psa_constant_names_generated.c: $(gen_file_dep) ../tf-psa-crypto/include/psa/crypto_values.h
+../tf-psa-crypto/programs/psa/psa_constant_names_generated.c: $(gen_file_dep) ../tf-psa-crypto/include/psa/crypto_extra.h
+../tf-psa-crypto/programs/psa/psa_constant_names_generated.c: $(gen_file_dep) ../tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data
+../tf-psa-crypto/programs/psa/psa_constant_names_generated.c:
+	echo "  Gen   $@"
+	cd ../tf-psa-crypto; $(PYTHON) ./scripts/generate_psa_constants.py
+
+TF_PSA_CRYPTO_APPS := \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/aead_demo \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/crypto_examples \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/hmac_demo \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/key_ladder_demo \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/psa_constant_names \
+	$(TF_PSA_CRYPTO_PATH)/programs/psa/psa_hash \
+	$(TF_PSA_CRYPTO_PATH)/programs/test/which_aes \
+# End of APPS
+
+../tf-psa-crypto/programs/psa/aead_demo$(EXEXT): ../tf-psa-crypto/programs/psa/aead_demo.c $(DEP)
+	echo "  CC    psa/aead_demo.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/aead_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/psa/crypto_examples$(EXEXT): ../tf-psa-crypto/programs/psa/crypto_examples.c $(DEP)
+	echo "  CC    psa/crypto_examples.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/crypto_examples.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/psa/hmac_demo$(EXEXT): ../tf-psa-crypto/programs/psa/hmac_demo.c $(DEP)
+	echo "  CC    psa/hmac_demo.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/hmac_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/psa/key_ladder_demo$(EXEXT): ../tf-psa-crypto/programs/psa/key_ladder_demo.c $(DEP)
+	echo "  CC    psa/key_ladder_demo.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/key_ladder_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/psa/psa_constant_names$(EXEXT): ../tf-psa-crypto/programs/psa/psa_constant_names.c ../tf-psa-crypto/programs/psa/psa_constant_names_generated.c $(DEP)
+	echo "  CC    psa/psa_constant_names.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/psa_constant_names.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/psa/psa_hash$(EXEXT): ../tf-psa-crypto/programs/psa/psa_hash.c $(DEP)
+	echo "  CC    psa/psa_hash.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/psa/psa_hash.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+
+../tf-psa-crypto/programs/test/which_aes$(EXEXT): ../tf-psa-crypto/programs/test/which_aes.c $(DEP)
+	echo "  CC    test/which_aes.c"
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ../tf-psa-crypto/programs/test/which_aes.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@

--- a/scripts/crypto-common.make
+++ b/scripts/crypto-common.make
@@ -1,0 +1,99 @@
+# Helper code for the make build system in Mbed TLS: define some variables
+# providing information such as file paths.
+# This file is only meant to exist for a short transition period.
+# It may change or be removed without notice.
+# Do not use it if you are not Mbed TLS!
+
+# Assume that this makefile is located in a first-level subdirectory of the
+# Mbed TLS root, and is accessed directly (not via VPATH or such).
+# If this is not the case, TF_PSA_CRYPTO_PATH or MBEDTLS_PATH must be defined
+# before including this file.
+ifneq ($(origin TF_PSA_CRYPTO_PATH), undefined)
+  # TF_PSA_CRYPTO_PATH was defined before including this file, good.
+else ifneq ($(origin MBEDTLS_PATH), undefined)
+  TF_PSA_CRYPTO_PATH := $(MBEDTLS_PATH)/tf-psa-crypto
+else
+  # $(dir $(lastword $(MAKEFILE_LIST))) is the path to this file, possibly
+  # a relative path, with a trailing slash. Strip off another directory
+  # from that.
+  TF_PSA_CRYPTO_PATH := $(patsubst %/,%,$(dir $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))))/tf-psa-crypto
+endif
+
+ifeq (,$(wildcard $(TF_PSA_CRYPTO_PATH)/core/psa_crypto.c))
+  $(error $$(TF_PSA_CRYPTO_PATH)/core/psa_crypto.c not found)
+endif
+
+TF_PSA_CRYPTO_CORE_PATH = $(TF_PSA_CRYPTO_PATH)/core
+TF_PSA_CRYPTO_DRIVERS_BUILTIN_SRC_PATH = $(TF_PSA_CRYPTO_PATH)/drivers/builtin/src
+
+# Gather information about crypto drivers that are separate from the main
+# "builtin" driver (historically located in /3rdparty in Mbed TLS 2.x/3.x).
+THIRDPARTY_DIR := $(TF_PSA_CRYPTO_PATH)/drivers
+THIRDPARTY_INCLUDES =
+include $(TF_PSA_CRYPTO_PATH)/drivers/everest/Makefile.inc
+include $(TF_PSA_CRYPTO_PATH)/drivers/p256-m/Makefile.inc
+
+# Directories with headers of public interfaces of TF-PSA-Crypto
+TF_PSA_CRYPTO_LIBRARY_PUBLIC_INCLUDE = \
+	-I$(TF_PSA_CRYPTO_PATH)/include \
+	-I$(TF_PSA_CRYPTO_PATH)/drivers/builtin/include \
+	$(THIRDPARTY_INCLUDES)
+
+# Directories with headers of internal interfaces of TF-PSA-Crypto
+# (currently consumed by Mbed TLS, eventually not so when we've finished
+# cleaning up)
+TF_PSA_CRYPTO_LIBRARY_PRIVATE_INCLUDE = \
+	-I$(TF_PSA_CRYPTO_CORE_PATH) \
+	-I$(TF_PSA_CRYPTO_DRIVERS_BUILTIN_SRC_PATH)
+
+# Extra linker flags required by the crypto library or the platform
+TF_PSA_CRYPTO_EXTRA_LDFLAGS =
+
+## Usage: $(call remove_enabled_options_crypto,PREPROCESSOR_INPUT)
+## Remove the preprocessor symbols that are set in the current configuration
+## from PREPROCESSOR_INPUT. Also normalize whitespace.
+## Example:
+##   $(call remove_enabled_options_crypto,MBEDTLS_FOO MBEDTLS_BAR)
+## This expands to an empty string "" if MBEDTLS_FOO and MBEDTLS_BAR are both
+## enabled in the TF-PSA-Crypto configuration, to "MBEDTLS_FOO" if
+## MBEDTLS_BAR is enabled but MBEDTLS_FOO is disabled, etc.
+##
+## This only works with a Unix-like shell environment (Bourne/POSIX-style shell
+## and standard commands) and a Unix-like compiler (supporting -E). In
+## other environments, the output is likely to be empty.
+define remove_enabled_options_crypto
+$(strip $(shell
+  exec 2>/dev/null;
+  { echo '#include <tf-psa-crypto/build_info.h>'; echo $(1); } |
+  $(CC) $(TF_PSA_CRYPTO_LIBRARY_PUBLIC_INCLUDE) $(CFLAGS) -E - |
+  tail -n 1
+))
+endef
+
+# Ensure that `THREADING` is always defined. This lets us get a clean run
+# with `make --warn-undefined-variables` without making the conditionals
+# below more complex than they already are. At this stage, if `$(THREADING)`
+# is empty, it means we don't know yet whether the threading implementation
+# requires extra `LDFLAGS`. Once we've done the analysis, if `$(THREADING)`
+# is empty, it will mean that no extra `LDFLAGS` are required, either
+# because threading is disabled or because the threading implementation
+# doesn't require any extra `LDFLAGS`.
+THREADING ?=
+
+ifndef WINDOWS_BUILD
+  ifeq ($(THREADING),)
+    # Auto-detect configurations with pthread.
+    # If the call to remove_enabled_options returns "control", the symbols
+    # are confirmed set and we link with pthread.
+    # If the auto-detection fails, the result of the call is empty and
+    # we keep THREADING undefined.
+    ifeq (control,$(call remove_enabled_options_crypto,control MBEDTLS_THREADING_C MBEDTLS_THREADING_PTHREAD))
+      THREADING := pthread
+    endif
+  endif
+  #$(info THREADING = $(THREADING))
+
+  ifeq ($(THREADING),pthread)
+    TF_PSA_CRYPTO_EXTRA_LDFLAGS += -lpthread
+  endif
+endif

--- a/tests/crypto-tests.make
+++ b/tests/crypto-tests.make
@@ -1,0 +1,121 @@
+# Helper code for tests/Makefile in Mbed TLS.
+# This file is only meant to be included by tests/Makefile in Mbed TLS and
+# is unlikely to work in another context.
+
+GENERATED_BIGNUM_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+	$(PYTHON) ../framework/scripts/generate_bignum_tests.py --list || \
+	echo FAILED \
+))
+ifeq ($(GENERATED_BIGNUM_DATA_FILES),FAILED)
+$(error "$(PYTHON) ../framework/scripts/generate_bignum_tests.py --list" failed)
+endif
+TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES += $(GENERATED_BIGNUM_DATA_FILES)
+
+# generate_bignum_tests.py and generate_psa_tests.py spend more time analyzing
+# inputs than generating outputs. Its inputs are the same no matter which files
+# are being generated.
+# It's rare not to want all the outputs. So always generate all of its outputs.
+# Use an intermediate phony dependency so that parallel builds don't run
+# a separate instance of the recipe for each output file.
+$(GENERATED_BIGNUM_DATA_FILES): $(gen_file_dep) generated_bignum_test_data
+generated_bignum_test_data: ../framework/scripts/generate_bignum_tests.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/bignum_common.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/bignum_core.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/bignum_mod_raw.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/bignum_mod.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/test_case.py
+generated_bignum_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
+generated_bignum_test_data:
+	echo "  Gen   $(GENERATED_BIGNUM_DATA_FILES)"
+	$(PYTHON) ../framework/scripts/generate_bignum_tests.py --directory ../tf-psa-crypto/tests/suites
+.SECONDARY: generated_bignum_test_data
+
+GENERATED_CRYPTO_CONFIG_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+	$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_config_tests.py --list || \
+	echo FAILED \
+))
+ifeq ($(GENERATED_CRYPTO_CONFIG_DATA_FILES),FAILED)
+$(error "$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_config_tests.py --list" failed)
+endif
+TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES += $(GENERATED_CRYPTO_CONFIG_DATA_FILES)
+
+# We deliberately omit the configuration files (mbedtls_config.h,
+# crypto_config.h) from the depenency list because during development
+# and on the CI, we often edit those in a way that doesn't change the
+# output, to comment out certain options, or even to remove certain
+# lines which do affect the output negatively (it will miss the
+# corresponding test cases).
+$(GENERATED_CRYPTO_CONFIG_DATA_FILES): $(gen_file_dep) generated_crypto_config_test_data
+generated_crypto_config_test_data: ../framework/scripts/generate_config_tests.py
+generated_crypto_config_test_data: ../scripts/config.py
+generated_crypto_config_test_data: ../framework/scripts/mbedtls_framework/test_case.py
+generated_crypto_config_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
+generated_crypto_config_test_data:
+	echo "  Gen   $(GENERATED_CRYPTO_CONFIG_DATA_FILES)"
+	cd ../tf-psa-crypto && $(PYTHON) ./framework/scripts/generate_config_tests.py
+.SECONDARY: generated_crypto_config_test_data
+
+GENERATED_ECP_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+	$(PYTHON) ../framework/scripts/generate_ecp_tests.py --list || \
+	echo FAILED \
+))
+ifeq ($(GENERATED_ECP_DATA_FILES),FAILED)
+$(error "$(PYTHON) ../framework/scripts/generate_ecp_tests.py --list" failed)
+endif
+TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES += $(GENERATED_ECP_DATA_FILES)
+
+$(GENERATED_ECP_DATA_FILES): $(gen_file_dep) generated_ecp_test_data
+generated_ecp_test_data: ../framework/scripts/generate_ecp_tests.py
+generated_ecp_test_data: ../framework/scripts/mbedtls_framework/bignum_common.py
+generated_ecp_test_data: ../framework/scripts/mbedtls_framework/ecp.py
+generated_ecp_test_data: ../framework/scripts/mbedtls_framework/test_case.py
+generated_ecp_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
+generated_ecp_test_data:
+	echo "  Gen   $(GENERATED_ECP_DATA_FILES)"
+	$(PYTHON) ../framework/scripts/generate_ecp_tests.py --directory ../tf-psa-crypto/tests/suites
+.SECONDARY: generated_ecp_test_data
+
+GENERATED_PSA_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+	$(PYTHON) ../framework/scripts/generate_psa_tests.py --list || \
+	echo FAILED \
+))
+ifeq ($(GENERATED_PSA_DATA_FILES),FAILED)
+$(error "$(PYTHON) ../framework/scripts/generate_psa_tests.py --list" failed)
+endif
+TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES += $(GENERATED_PSA_DATA_FILES)
+
+$(GENERATED_PSA_DATA_FILES): $(gen_file_dep) generated_psa_test_data
+generated_psa_test_data: ../framework/scripts/generate_psa_tests.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/crypto_data_tests.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/crypto_knowledge.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/macro_collector.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_information.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_storage.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/psa_test_case.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/test_case.py
+generated_psa_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
+## The generated file only depends on the options that are present in
+## crypto_config.h, not on which options are set. To avoid regenerating this
+## file all the time when switching between configurations, don't declare
+## crypto_config.h as a dependency. Remove this file from your working tree
+## if you've just added or removed an option in crypto_config.h.
+#generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_config.h
+generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_values.h
+generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_extra.h
+generated_psa_test_data: ../tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data
+generated_psa_test_data:
+	echo "  Gen   $(GENERATED_PSA_DATA_FILES) ..."
+	$(PYTHON) ../framework/scripts/generate_psa_tests.py --directory ../tf-psa-crypto/tests/suites
+.SECONDARY: generated_psa_test_data
+
+TF_PSA_CRYPTO_TESTS_DATA_FILES = $(filter-out $(TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES), $(wildcard $(TF_PSA_CRYPTO_PATH)/tests/suites/test_suite_*.data))
+# Make sure that generated data files are included even if they don't
+# exist yet when the makefile is parsed.
+TF_PSA_CRYPTO_TESTS_DATA_FILES += $(TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES)
+
+../tf-psa-crypto/tests/include/test/test_keys.h: ../tf-psa-crypto/framework/scripts/generate_test_keys.py
+	echo "  Gen   $@"
+	$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_test_keys.py --output $@
+
+TF_PSA_CRYPTO_TESTS_GENERATED_C_FILES = \
+	../tf-psa-crypto/tests/include/test/test_keys.h


### PR DESCRIPTION
Adopt the files from https://github.com/Mbed-TLS/mbedtls/pull/10543.

Note to reviewers: this should be reviewed together with https://github.com/Mbed-TLS/mbedtls/pull/10544. This pull request is correct if the files that get removed from Mbed TLS are identical to the files that get added to TF-PSA-Crypto.

Needs preceding PR:

* https://github.com/Mbed-TLS/mbedtls/pull/10543 for content. strictly speaking it doesn't need to be merged, but we need to make sure we have the final versions of the file.
* https://github.com/Mbed-TLS/mbedtls/pull/10544 for CI. Obviously we need to merge the crypto PR before we can finalize 10544, but we need to ensure that the CI passes on 10544 in order to validate 616.

## PR checklist

- [x] **changelog** provided | not required because: only internal build schenanigans
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/258
- [x] **mbedtls development PR** requires https://github.com/Mbed-TLS/mbedtls/pull/10543; allows https://github.com/Mbed-TLS/mbedtls/pull/10544
- [x] **mbedtls 3.6 PR** not required because: not applicable to 3.6
- **tests**  provided
