### PR TITLE
PK: remove pk_debug() and related stuff

### DIFF
--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -1370,23 +1370,6 @@ size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context *ctx)
 }
 
 /*
- * Export debug information
- */
-int mbedtls_pk_debug(const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items)
-{
-    if (ctx->pk_info == NULL) {
-        return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
-    }
-
-    if (ctx->pk_info->debug_func == NULL) {
-        return MBEDTLS_ERR_PK_TYPE_MISMATCH;
-    }
-
-    ctx->pk_info->debug_func((mbedtls_pk_context *) ctx, items);
-    return 0;
-}
-
-/*
  * Access the PK type name
  */
 const char *mbedtls_pk_get_name(const mbedtls_pk_context *ctx)

--- a/drivers/builtin/src/pk_wrap.c
+++ b/drivers/builtin/src/pk_wrap.c
@@ -152,13 +152,6 @@ static int rsa_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv)
     return 0;
 }
 
-static void rsa_debug(mbedtls_pk_context *pk, mbedtls_pk_debug_item *items)
-{
-    items->type = MBEDTLS_PK_DEBUG_PSA_RSA;
-    items->name = "rsa";
-    items->value = pk;
-}
-
 const mbedtls_pk_info_t mbedtls_rsa_info = {
     .type = MBEDTLS_PK_RSA,
     .name = "RSA",
@@ -173,7 +166,6 @@ const mbedtls_pk_info_t mbedtls_rsa_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = rsa_check_pair_wrap,
-    .debug_func = rsa_debug,
 };
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
 
@@ -554,13 +546,6 @@ static int eckey_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *pr
 
 #define ecdsa_opaque_check_pair_wrap    eckey_check_pair_wrap
 
-static void eckey_debug(mbedtls_pk_context *pk, mbedtls_pk_debug_item *items)
-{
-    items->type = MBEDTLS_PK_DEBUG_PSA_EC;
-    items->name = "eckey.Q";
-    items->value = pk;
-}
-
 const mbedtls_pk_info_t mbedtls_eckey_info = {
     .type = MBEDTLS_PK_ECKEY,
     .name = "EC",
@@ -596,7 +581,6 @@ const mbedtls_pk_info_t mbedtls_eckey_info = {
 #endif /* PSA_HAVE_ALG_ECDSA_SIGN || PSA_HAVE_ALG_ECDSA_VERIFY */
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,
-    .debug_func = eckey_debug,
 };
 
 /*
@@ -620,7 +604,6 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
     .sign_rs_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,
-    .debug_func = eckey_debug,            /* Same underlying key structure */
 };
 
 #if defined(PSA_HAVE_ALG_SOME_ECDSA)
@@ -661,7 +644,6 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
 #endif /* PSA_HAVE_ALG_ECDSA_VERIFY || PSA_HAVE_ALG_ECDSA_SIGN */
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = eckey_check_pair_wrap,   /* Compatible key structures */
-    .debug_func = eckey_debug,        /* Compatible key structures */
 };
 #endif /* PSA_HAVE_ALG_SOME_ECDSA */
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
@@ -709,7 +691,6 @@ const mbedtls_pk_info_t mbedtls_ecdsa_opaque_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = ecdsa_opaque_check_pair_wrap,
-    .debug_func = NULL,
 };
 #endif /* PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY */
 
@@ -782,7 +763,6 @@ const mbedtls_pk_info_t mbedtls_rsa_opaque_info = {
     .rs_free_func = NULL,
 #endif /* MBEDTLS_ECP_RESTARTABLE */
     .check_pair_func = NULL,
-    .debug_func = NULL,
 };
 
 #endif /* MBEDTLS_PK_C */

--- a/drivers/builtin/src/pk_wrap.h
+++ b/drivers/builtin/src/pk_wrap.h
@@ -79,9 +79,6 @@ struct mbedtls_pk_info_t {
     void (*rs_free_func)(void *rs_ctx);
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
-    /** Interface with the debug module */
-    void (*debug_func)(mbedtls_pk_context *pk, mbedtls_pk_debug_item *items);
-
 };
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
 extern const mbedtls_pk_info_t mbedtls_rsa_info;

--- a/include/mbedtls/private/pk_private.h
+++ b/include/mbedtls/private/pk_private.h
@@ -41,29 +41,6 @@ typedef enum {
 } mbedtls_pk_type_t;
 
 /**
- * \brief           Types for interfacing with the debug module
- */
-typedef enum {
-    MBEDTLS_PK_DEBUG_NONE = 0,
-    MBEDTLS_PK_DEBUG_MPI,
-    MBEDTLS_PK_DEBUG_ECP,
-    MBEDTLS_PK_DEBUG_PSA_EC,
-    MBEDTLS_PK_DEBUG_PSA_RSA,
-} mbedtls_pk_debug_type;
-
-/**
- * \brief           Item to send to the debug module
- */
-typedef struct mbedtls_pk_debug_item {
-    mbedtls_pk_debug_type MBEDTLS_PRIVATE(type);
-    const char *MBEDTLS_PRIVATE(name);
-    void *MBEDTLS_PRIVATE(value);
-} mbedtls_pk_debug_item;
-
-/** Maximum number of item send for debugging, plus 1 */
-#define MBEDTLS_PK_DEBUG_MAX_ITEMS 3
-
-/**
  * \brief           Return information associated with the given PK type
  *
  * \param pk_type   PK type to search for.
@@ -141,16 +118,6 @@ int mbedtls_pk_can_do(const mbedtls_pk_context *ctx, mbedtls_pk_type_t type);
  */
 int mbedtls_pk_can_do_ext(const mbedtls_pk_context *ctx, psa_algorithm_t alg,
                           psa_key_usage_t usage);
-
-/**
- * \brief           Export debug information
- *
- * \param ctx       The PK context to use. It must have been initialized.
- * \param items     Place to write debug items
- *
- * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
- */
-int mbedtls_pk_debug(const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items);
 
 /**
  * \brief           Access the type name

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -631,7 +631,6 @@ void pk_psa_utils(int key_is_rsa)
 
     mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
     unsigned char b1[1], b2[1];
-    mbedtls_pk_debug_item dbg;
 
     mbedtls_pk_init(&pk);
     mbedtls_pk_init(&pk2);
@@ -692,8 +691,6 @@ void pk_psa_utils(int key_is_rsa)
                                      mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0);
     }
     TEST_ASSERT(mbedtls_pk_check_pair(&pk, &pk2)
-                == MBEDTLS_ERR_PK_TYPE_MISMATCH);
-    TEST_ASSERT(mbedtls_pk_debug(&pk, &dbg)
                 == MBEDTLS_ERR_PK_TYPE_MISMATCH);
 
     /* test that freeing the context does not destroy the key */


### PR DESCRIPTION
## Description

Resolves #530
Depends on https://github.com/Mbed-TLS/mbedtls/pull/10517

## PR checklist

- [ ] **changelog** not required because: `mbedtls_pk_debug` was an internal function so its removal does not need any notification
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10517
- [ ] **mbedtls 3.6 PR** not required because: not backported
- **tests**  provided: unnecessary tests have been removed.