### PR TITLE
Replace references of mbedtls_ecp_set_max_ops

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -4396,7 +4396,7 @@ typedef struct psa_verify_hash_interruptible_operation_s psa_verify_hash_interru
  *
  * \note                        For keys in local storage when no accelerator
  *                              driver applies, please see also the
- *                              documentation for \c mbedtls_ecp_set_max_ops(),
+ *                              documentation for \c psa_interruptible_set_max_ops(),
  *                              which is the internal implementation in these
  *                              cases.
  *

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -1613,9 +1613,9 @@
  * This allows various functions to pause by returning
  * #PSA_OPERATION_INCOMPLETE and then be called later again in
  * order to further progress and eventually complete their operation. This is
- * controlled through mbedtls_ecp_set_max_ops() which limits the maximum
+ * controlled through psa_interruptible_set_max_ops() which limits the maximum
  * number of ECC operations a function may perform before pausing; see
- * mbedtls_ecp_set_max_ops() for more information.
+ * psa_interruptible_set_max_ops() for more information.
  *
  * This is useful in non-threaded environments if you want to avoid blocking
  * for too long on ECC (and, hence, X.509 or SSL/TLS) operations.


### PR DESCRIPTION
## Description

Replace references of mbedtls_ecp_set_max_ops with psa_interruptible_set_max_ops as it is now internal. resolves https://github.com/Mbed-TLS/mbedtls/issues/10545

## PR checklist

- [x] **changelog** not required because: No publlic changes
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#https://github.com/Mbed-TLS/mbedtls/pull/10549
- [x] **mbedtls 3.6 PR**not required because: No backports
- **tests**  not required because: No increase in test matrix
