### PR TITLE
Fix "Simplify interruptible ECDH dispatch"

### DIFF
--- a/drivers/builtin/src/psa_crypto_ecp.c
+++ b/drivers/builtin/src/psa_crypto_ecp.c
@@ -852,9 +852,11 @@ psa_status_t mbedtls_psa_key_agreement_iop_abort(
 {
     mbedtls_ecp_keypair_free(operation->our_key);
     mbedtls_free(operation->our_key);
+    operation->our_key = NULL;
 
     mbedtls_ecp_keypair_free(operation->their_key);
     mbedtls_free(operation->their_key);
+    operation->their_key = NULL;
 
     mbedtls_ecp_restart_free(&operation->rs);
     operation->num_ops = 0;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -9807,6 +9807,7 @@ void key_agreement(int alg_arg,
     psa_algorithm_t alg = alg_arg;
     psa_key_type_t our_key_type = our_key_type_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    unsigned char *bad_peer_key = NULL;
     unsigned char *output = NULL;
     size_t output_length = ~0;
     size_t key_bits;
@@ -9869,7 +9870,28 @@ void key_agreement(int alg_arg,
     psa_destroy_key(shared_secret_id);
     shared_secret_id = MBEDTLS_SVC_KEY_ID_INIT;
 
-    /* Larger buffer */
+    /* Input buffer (peer key) too small */
+    size_t bad_peer_key_len = peer_key_data->len - 1;
+    TEST_CALLOC(bad_peer_key, bad_peer_key_len);
+    memcpy(bad_peer_key, peer_key_data->x, bad_peer_key_len);
+    TEST_CALLOC(output, expected_output->len);
+    TEST_EQUAL(PSA_ERROR_INVALID_ARGUMENT,
+               psa_raw_key_agreement(alg, our_key,
+                                     bad_peer_key, bad_peer_key_len,
+                                     output, expected_output->len,
+                                     &output_length));
+    mbedtls_free(output);
+    output = NULL;
+    output_length = ~0;
+    TEST_EQUAL(PSA_ERROR_INVALID_ARGUMENT,
+               psa_key_agreement(our_key, bad_peer_key, bad_peer_key_len,
+                                 alg, &shared_secret_attributes, &shared_secret_id));
+    mbedtls_free(bad_peer_key);
+    bad_peer_key = NULL;
+    psa_destroy_key(shared_secret_id);
+    shared_secret_id = MBEDTLS_SVC_KEY_ID_INIT;
+
+    /* Larger output buffer */
     TEST_CALLOC(output, expected_output->len + 1);
     PSA_ASSERT(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
@@ -9884,7 +9906,7 @@ void key_agreement(int alg_arg,
     psa_destroy_key(shared_secret_id);
     shared_secret_id = MBEDTLS_SVC_KEY_ID_INIT;
 
-    /* Buffer too small */
+    /* Output buffer too small */
     TEST_CALLOC(output, expected_output->len - 1);
     TEST_EQUAL(psa_raw_key_agreement(alg, our_key,
                                      peer_key_data->x, peer_key_data->len,
@@ -9898,6 +9920,7 @@ void key_agreement(int alg_arg,
     output = NULL;
 
 exit:
+    mbedtls_free(bad_peer_key);
     mbedtls_free(output);
     psa_destroy_key(shared_secret_id);
     psa_destroy_key(our_key);

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -9917,6 +9917,7 @@ void key_agreement_interruptible(int alg_arg,
     psa_key_type_t our_key_type = our_key_type_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t shared_secret_attributes = PSA_KEY_ATTRIBUTES_INIT;
+    unsigned char *bad_peer_key = NULL;
     unsigned char *output = NULL;
     size_t output_length = ~0;
     size_t key_bits;
@@ -10038,6 +10039,17 @@ void key_agreement_interruptible(int alg_arg,
 
     PSA_ASSERT(psa_key_agreement_iop_abort(&operation));
 
+    /* Setup with invalid input (peer_key) */
+    size_t bad_peer_key_len = peer_key_data->len - 1;
+    TEST_CALLOC(bad_peer_key, bad_peer_key_len);
+    memcpy(bad_peer_key, peer_key_data->x, bad_peer_key_len);
+    TEST_EQUAL(PSA_ERROR_INVALID_ARGUMENT,
+               psa_key_agreement_iop_setup(&operation, our_key,
+                                           bad_peer_key, bad_peer_key_len,
+                                           alg, &shared_secret_attributes));
+    mbedtls_free(bad_peer_key);
+    bad_peer_key = NULL;
+
 exit:
 
     psa_key_agreement_iop_abort(&operation);
@@ -10045,6 +10057,7 @@ exit:
     psa_destroy_key(our_key);
     psa_destroy_key(output_key);
     mbedtls_free(output);
+    mbedtls_free(bad_peer_key);
     PSA_DONE();
 }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/578 - fixing a bug that was introduced there, and closing a pre-existing test gap.

## PR checklist

- [x] **changelog** not required because: bug was never released
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: development only (interruptible ECDH not in 3.6)
- **tests**  provided