### PR TITLE
Add dco.txt mentioned in CONTRIBUTING.md

### DIFF
--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
[`CONTRIBUTING.md`](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md#license-and-copyright) links to [`dco.txt`](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/dco.txt) but the file is missing in TF-PSA-Crypto. Add it (same content as in mbedtls and mbedtls-framework).

- [x] **changelog** provided | not required because: nobody cared
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: only missing in TF-PSA-Crypto
- [x] **mbedtls 3.6 PR** not required because: only missing in TF-PSA-Crypto
- **tests**  not required because: doc only
