### PR TITLE
Fix non-determinism when generating tf_psa_crypto_config_check_user.h

### DIFF
--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -34,7 +34,7 @@ def checkers_for_removed_options() -> Iterator[Checker]:
         if option in ALWAYS_ENABLED_SINCE_1_0:
             continue
         yield Removed(option, 'TF-PSA_Crypto 1.0')
-    for option in current.internal() - new_public - old_public:
+    for option in sorted(current.internal() - new_public - old_public):
         # Macros describing accelerator drivers are not in the config
         # file, but it's ok if integrators put them there.
         if option.startswith('MBEDTLS_PSA_ACCEL_'):


### PR DESCRIPTION
Not caught in the CI because of https://github.com/Mbed-TLS/mbedtls-framework/issues/244

## PR checklist

- [x] **changelog** provided | not required because: only maintainers care
- [x] **framework PR** not required
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10555
- [x] **mbedtls 3.6 PR** not required because: added in 1.0/4.0
- **tests**  no message about an out-of-date file in `tests/scripts/all.sh -k tf_psa_crypto_check_generated_files`; will be enforced on the CI once https://github.com/Mbed-TLS/mbedtls-framework/pull/245 is merged
