### PR TITLE
fix error in GCC bswap

### DIFF
--- a/core/alignment.h
+++ b/core/alignment.h
@@ -280,15 +280,15 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 /*
  * Detect GCC built-in byteswap routines
  */
-#if defined(__GNUC__) && defined(__GNUC_PREREQ)
-#if __GNUC_PREREQ(4, 8)
+#if defined(__GNUC__)
+#if MBEDTLS_GCC_VERSION >= 40800
 #define MBEDTLS_BSWAP16 __builtin_bswap16
-#endif /* __GNUC_PREREQ(4,8) */
-#if __GNUC_PREREQ(4, 3)
+#endif
+#if MBEDTLS_GCC_VERSION >= 40300
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #define MBEDTLS_BSWAP64 __builtin_bswap64
-#endif /* __GNUC_PREREQ(4,3) */
-#endif /* defined(__GNUC__) && defined(__GNUC_PREREQ) */
+#endif
+#endif /* defined(__GNUC__) */
 
 /*
  * Detect Clang built-in byteswap routines


### PR DESCRIPTION
## Description

The gcc detection for some reason depended on `__GNUC_PREREQ`, which was undefined (AIUI it comes from a header which isn't included here). Replace with `MBEDTLS_GCC_VERSION`.

Presumably size & performance-affecting (I haven't properly measured, but observed eg 17% improvement from this patch in `benchmark ctr_drbg`) but not a functional change. Improves AES-GCM by around 20-25%.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: no functional change
- [x] **framework PR** not affected
- [x] **mbedtls development PR** this PR
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10589
- [x] **tests**  not required because: already tested / no functional change

