### PR TITLE
all.sh: fix path in "not grep" check

### DIFF
--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -130,7 +130,7 @@ component_tf_psa_crypto_build_custom_config_file () {
     make
     # Verify that MBEDTLS_NIST_KW_C was really disabled, i.e. crypto_config_user.h was included
     # correctly in the build.
-    not grep -q mbedtls_nist_kw_wrap drivers/builtin/libtfpsacrypto.a
+    not grep -q mbedtls_nist_kw_wrap core/libtfpsacrypto.a
 
     # Restore default crypto config file and remove generated ones
     mv include/psa/crypto_config_default.h "$CRYPTO_CONFIG_H"


### PR DESCRIPTION
## Description

Revealed by https://github.com/Mbed-TLS/mbedtls-framework/pull/268 for which this is a prerequisite.

## PR checklist

- [x] **changelog** not required because: tests
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10562
- [x] **TF-PSA-Crypto PR** provided HERE
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#268
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10563
- **tests**  this is about fixing existing tests - and f268 will ensure we've fixed everything.
