### PR TITLE
Remove residual uses of MBEDTLS_ECDSA_DETERMINISTIC

### DIFF
--- a/drivers/builtin/src/pk_wrap.c
+++ b/drivers/builtin/src/pk_wrap.c
@@ -362,17 +362,6 @@ static int ecdsa_opaque_sign_wrap(mbedtls_pk_context *pk,
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 
-/*
- * Restart context for ECDSA operations with ECKEY context
- *
- * We need to store an actual ECDSA context, as we need to pass the same to
- * the underlying ecdsa function, so we can't create it on the fly every time.
- */
-typedef struct {
-    mbedtls_ecdsa_restart_ctx ecdsa_rs;
-    mbedtls_ecdsa_context ecdsa_ctx;
-} eckey_restart_ctx;
-
 #if defined(PSA_HAVE_ALG_ECDSA_SIGN) || defined(PSA_HAVE_ALG_ECDSA_VERIFY)
 static void *eckey_rs_alloc(mbedtls_pk_rs_op_t op_type)
 {

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -1160,7 +1160,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:MBEDTLS_ECDSA_DETERMINISTIC */
+/* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:PSA_WANT_ALG_DETERMINISTIC_ECDSA */
 void pk_sign_verify_restart(int pk_type, int grp_id, data_t *d_str,
                             char *QX_str, char *QY_str,
                             int md_alg, data_t *hash, data_t *sig_check,
@@ -1664,7 +1664,7 @@ void pk_get_psa_attributes(int pk_type, int from_pair,
     psa_set_key_enrollment_algorithm(&attributes, 42);
     psa_key_usage_t expected_usage = pk_get_psa_attributes_implied_usage(usage);
 
-#if defined(MBEDTLS_ECDSA_DETERMINISTIC)
+#if defined(PSA_WANT_ALG_DETERMINISTIC_ECDSA)
     /* When the resulting algorithm is ECDSA, the compile-time configuration
      * can cause it to be either deterministic or randomized ECDSA.
      * Rather than have two near-identical sets of test data depending on


### PR DESCRIPTION
## Description

Remove remaining occurrences of `MBEDTLS_ECDSA_DETERMINISTIC` that could be replaced with `PSA_WANT_ALG_DETERMINISTIC_ECDSA`. After this PR the remaining occurrences of `MBEDTLS_ECDSA_DETERMINISTIC` in tf-psa-crypto are only associated to the internal `ecdsa.c` module, for which this internal build symbol still make sense.

Resolve https://github.com/Mbed-TLS/mbedtls/issues/10380

## PR checklist

- [ ] **changelog** not required because: only test changes
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: no change there
- [ ] **mbedtls 3.6 PR** not required because: no backport
- **tests** not required because: no code change
