### PR TITLE
Fixed clang arm intrinsics for older compiler versions

### DIFF
--- a/drivers/builtin/src/aesce.c
+++ b/drivers/builtin/src/aesce.c
@@ -88,7 +88,11 @@
 #           define MBEDTLS_POP_TARGET_PRAGMA
 #       endif
 #   elif defined(__clang__)
-#       pragma clang attribute push (__attribute__((target("aes"))), apply_to=function)
+#       if __clang_major__ < 7
+#           pragma clang attribute push (__attribute__((target("crypto"))), apply_to=function)
+#       else
+#           pragma clang attribute push (__attribute__((target("aes"))), apply_to=function)
+#       endif
 #       define MBEDTLS_POP_TARGET_PRAGMA
 #   elif defined(__GNUC__)
 #       pragma GCC push_options


### PR DESCRIPTION
## Description

Resolves #660

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: The file only resides on this repository
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10565
- **tests**  not required because: TODO

