### PR TITLE
Stop defining inline in our headers

### DIFF
--- a/ChangeLog.d/issue662.txt
+++ b/ChangeLog.d/issue662.txt
@@ -1,0 +1,5 @@
+Removals
+   * Definition of macro 'inline' is removed from 'build_info.h'. This was
+     used on some old non-C99-compliant compilers (ArmCC 5 and old MSVC) for
+     which support for building the library has already been dropped in the
+     past.

--- a/ChangeLog.d/issue662.txt
+++ b/ChangeLog.d/issue662.txt
@@ -1,5 +1,4 @@
 Removals
-   * Definition of macro 'inline' is removed from 'build_info.h'. This was
-     used on some old non-C99-compliant compilers (ArmCC 5 and old MSVC) for
-     which support for building the library has already been dropped in the
-     past.
+   * The headers no longer define 'inline' as a macro. This was done on Arm
+     Compiler 5 and MSVC. The compiler versions that needed this definition are
+     no longer supported since TF-PSA-Crypto 1.0.

--- a/include/tf-psa-crypto/build_info.h
+++ b/include/tf-psa-crypto/build_info.h
@@ -100,12 +100,6 @@
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
 
-/* Define `inline` on some non-C99-compliant compilers. */
-#if (defined(__ARMCC_VERSION) || defined(_MSC_VER)) && \
-    !defined(inline) && !defined(__cplusplus)
-#define inline __inline
-#endif
-
 #if defined(TF_PSA_CRYPTO_CONFIG_FILES_READ)
 #error \
     "Something went wrong: TF_PSA_CRYPTO_CONFIG_FILES_READ defined before reading the config files!"


### PR DESCRIPTION
## Description

Resolves #662

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: no change there
- [ ] **mbedtls 3.6 PR** not required because: no backport
- **tests**  not required because: no code change