### PR TITLE
Fix path in test after removing ecdh.c

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -24,7 +24,7 @@ component_test_accel_ecdh() {
     make
 
     # Make sure built-in ECDH was not re-enabled by accident (additive config)
-    not grep mbedtls_ecdh_ ${CMAKE_BUILTIN_BUILD_DIR}/ecdh.c.o
+    not grep mbedtls_psa_key_agreement_ecdh ${CMAKE_BUILTIN_BUILD_DIR}/psa_crypto_ecp.c.o
 
     # Run the tests
     # -------------


### PR DESCRIPTION
## Description

Preliminary to https://github.com/Mbed-TLS/mbedtls-framework/pull/268 which revealed this issue.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#268
- [x] **mbedtls development PR**  not required
- [x] **mbedtls 3.6 PR**  not required
- **tests**  provided
