### PR TITLE
ppc64le: Adding PowerPC support for AES and GCM functions.

### DIFF
--- a/drivers/builtin/include/mbedtls/private/aes.h
+++ b/drivers/builtin/include/mbedtls/private/aes.h
@@ -89,6 +89,7 @@ typedef struct mbedtls_aes_xts_context {
 typedef enum {
     MBEDTLS_AES_IMP_UNKNOWN = -1,
     MBEDTLS_AES_IMP_SOFTWARE,
+    MBEDTLS_AES_IMP_AESPPC,
     MBEDTLS_AES_IMP_AESCE,
     MBEDTLS_AES_IMP_AESNI_ASM,
     MBEDTLS_AES_IMP_AESNI_INTRINSICS,

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -37,6 +37,13 @@
 #include "aesce.h"
 #endif
 
+#if defined(MBEDTLS_AESPPC_C)
+# if defined(MBEDTLS_GCM_C)
+#include "mbedtls/private/gcm.h"
+# endif
+#include "aesppc.h"
+#endif
+
 #include "mbedtls/platform.h"
 #include "ctr.h"
 
@@ -498,6 +505,12 @@ mbedtls_aes_implementation mbedtls_aes_get_implementation(void)
     }
 #endif
 
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+        return MBEDTLS_AES_IMP_AESPPC;
+    }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
+
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     return MBEDTLS_AES_IMP_SOFTWARE;
 #endif
@@ -528,7 +541,8 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context *ctx)
  * Note that the offset is in units of elements of buf, i.e. 32-bit words,
  * i.e. an offset of 1 means 4 bytes and so on.
  */
-#if defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2
+#if defined(MBEDTLS_AESNI_C) && MBEDTLS_AESNI_HAVE_CODE == 2 || \
+    (defined(MBEDTLS_AESPPC_HAVE_CODE) && (defined(MBEDTLS_AESPPC_C)))
 #define MAY_NEED_TO_ALIGN
 #endif
 
@@ -541,6 +555,10 @@ MBEDTLS_MAYBE_UNUSED static unsigned mbedtls_aes_rk_offset(uint32_t *buf)
     if (mbedtls_aesni_has_support(MBEDTLS_AESNI_AES)) {
         align_16_bytes = 1;
     }
+#endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    align_16_bytes = 1;
 #endif
 
     if (align_16_bytes) {
@@ -598,6 +616,12 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
         return mbedtls_aesce_setkey_enc((unsigned char *) RK, key, keybits);
     }
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+        return mbedtls_aesppc_setkey_enc((unsigned char *) RK, key, keybits);
+    }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     for (unsigned int i = 0; i < (keybits >> 5); i++) {
@@ -713,6 +737,14 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
         goto exit;
     }
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+        mbedtls_aesppc_inverse_key((unsigned char *) RK,
+                                   (const unsigned char *) (cty.buf + cty.rk_offset), ctx->nr);
+        goto exit;
+    }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
     SK = cty.buf + cty.rk_offset + cty.nr * 4;
@@ -1037,6 +1069,12 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
         return mbedtls_aesce_crypt_ecb(ctx, mode, input, output);
     }
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+        return mbedtls_aesppc_crypt_ecb(ctx, mode, input, output);
+    }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
 #if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
 #if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
@@ -1829,6 +1867,9 @@ int mbedtls_aes_self_test(int verbose)
                 break;
             case MBEDTLS_AES_IMP_AESCE:
                 mbedtls_printf("  AES note: using AESCE.\n");
+                break;
+            case MBEDTLS_AES_IMP_AESPPC:
+                mbedtls_printf("  AES note: using AESPPC.\n");
                 break;
             case MBEDTLS_AES_IMP_SOFTWARE:
                 mbedtls_printf("  AES note: built-in implementation.\n");

--- a/drivers/builtin/src/aesppc.c
+++ b/drivers/builtin/src/aesppc.c
@@ -1,0 +1,592 @@
+/*
+ *  AES PPC (ppc64le)  support functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *
+ *  Copyright IBM Corp. 2026
+ *
+ * ===================================================================================
+ * Written by Danny Tsen <dtsen@us.ibm.com>
+ */
+
+#include "tf_psa_crypto_common.h"
+#include <string.h>
+
+#if defined(MBEDTLS_GCM_C)
+#include "mbedtls/private/gcm.h"
+#endif
+
+#if defined(MBEDTLS_AES_C)
+#include "mbedtls/private/aes.h"
+#endif
+
+#include "aesppc.h"
+
+/*
+ * ppc_crypto_capable - PPC capability supports.
+ */
+#ifndef PPC_VEC_CRYPTO
+# define PPC_VEC_CRYPTO   0x02000000
+#endif
+#ifndef PPC_ARCH_3_00
+# define PPC_ARCH_3_00    0x00800000
+#endif
+#ifndef PPC_ARCH_3_10
+# define PPC_ARCH_3_10    0x00040000
+#endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE) && defined(PPC_LITTLE_ENDIAN)
+
+int ppc_crypto_capable()
+{
+#if defined(__GLIBC__) && defined(__GNUC__) && __GNUC__ >= 6
+    int ppc_hwcap2 = 0;
+
+    if (__builtin_cpu_supports("vcrypto")) {
+        ppc_hwcap2 |= PPC_VEC_CRYPTO;
+    }
+
+    if (__builtin_cpu_supports("arch_3_00")) {
+        ppc_hwcap2 |= PPC_ARCH_3_00;
+    }
+    if (__builtin_cpu_supports("arch_3_1")) {
+        ppc_hwcap2 |= PPC_ARCH_3_10;
+    }
+
+    if (ppc_hwcap2 & (PPC_VEC_CRYPTO | PPC_ARCH_3_00)) {
+        return PPC_CRYPTO_SUPPORT;
+    }
+#endif
+    return 0;
+}
+
+/*
+ * AES encrypt
+ */
+static void _aes_encrypt(const unsigned char *in, unsigned char *out,
+                         unsigned char *rk, int rounds)
+{
+    if (out == NULL) {
+        return;
+    }
+
+    asm volatile (
+        "lxvb16x 32+1, 0, %1    \n\t" // load inp
+        "vmr    2, 1            \n\t"
+
+        "lvx    2, 0, %2        \n\t" // load key
+        "vxor   2, 2, 1         \n\t"
+
+        "addi   7, %3, -1       \n\t" // n round - 1
+        "mtctr  7               \n\t"
+        "li     8, 16           \n\t" // round key index
+
+        "1:                     \n\t"
+        "lvx    0, 8, %2        \n\t" // load key
+        "vcipher 2, 2, 0        \n\t"
+        "addi   8, 8, 16        \n\t"
+        "bdnz   1b              \n\t"
+
+        "lvx    0, 8, %2        \n\t" // load key
+        "vcipherlast 2, 2, 0    \n\t"
+        "stxvb16x 32+2, 0, %0   \n\t"
+        : "+r" (out)
+        : "r" (in), "r" (rk), "r" (rounds)
+        : "memory", "v1", "v2", "r7", "r8");
+}
+
+/*
+ * AES decrypt
+ */
+static void _aes_decrypt(const unsigned char *in, unsigned char *out,
+                         unsigned char *rk, int rounds)
+{
+    if (out == NULL) {
+        return;
+    }
+
+    asm volatile (
+        "lxvb16x 32+1, 0, %1    \n\t" // load inp
+        "vmr    2, 1            \n\t"
+
+        "lvx    2, 0, %2        \n\t" // load key
+        "vxor   2, 2, 1         \n\t"
+
+        "addi   7, %3, -1       \n\t" // n round - 1
+        "mtctr  7               \n\t"
+        "li     8, 16           \n\t" // round key index
+
+        "1:                     \n\t"
+        "lvx    0, 8, %2        \n\t" // load key
+        "vncipher 2, 2, 0       \n\t"
+        "addi   8, 8, 16        \n\t"
+        "bdnz   1b              \n\t"
+
+        "lvx    0, 8, %2        \n\t" // load key
+        "vncipherlast 2, 2, 0   \n\t"
+        "stxvb16x 32+2, 0, %0   \n\t"
+        : "+r" (out)
+        : "r" (in), "r" (rk), "r" (rounds)
+        : "memory", "v1", "v2", "r7", "r8");
+}
+
+/*
+ * AES PPC AES-ECB block en(de)cryption
+ */
+int mbedtls_aesppc_crypt_ecb(mbedtls_aes_context *ctx,
+                             int mode,
+                             const unsigned char input[16],
+                             unsigned char output[16])
+{
+    int rounds = ctx->nr;
+    unsigned char *rkey = (unsigned char *) (ctx->buf + ctx->rk_offset);
+
+#if !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+    if (mode == MBEDTLS_AES_DECRYPT) {
+        _aes_decrypt(input, output, rkey, rounds);
+    } else
+#else
+    (void) mode;
+#endif
+    {
+        _aes_encrypt(input, output, rkey, rounds);
+    }
+
+    return 0;
+}
+
+/*
+ * Compute decryption round keys from encryption round keys
+ */
+void mbedtls_aesppc_inverse_key(unsigned char *invkey,
+                                const unsigned char *fwdkey,
+                                int nr)
+{
+    unsigned char *ik = invkey;
+    const unsigned char *fk = fwdkey + 16 * nr;
+
+    memcpy(ik, fk, 16);
+
+    for (fk -= 16, ik += 16; fk > fwdkey; fk -= 16, ik += 16) {
+        memcpy(ik, fk, 16);
+    }
+    memcpy(ik, fk, 16);
+}
+
+/*
+ * _ppc_gcm_mul(Xi, Htable, input, len)
+ *
+ * Refer to:
+ *   1. Karatsuba multiplication method in Optimzed Galois-Counter-Mode
+ *      Implementation On Intel Architecture Processors.
+ *   2. Implementing GCM on ARMv8.
+ */
+static void _ppc_gcm_mul(unsigned char *Xi, unsigned char *Htable,
+                         const unsigned char *input, int len)
+{
+    asm volatile (
+        "li     8, 0xc2          \n\t"
+        "sldi   8, 8, 56         \n\t"
+        "mtvsrdd 32+18, 0, 8     \n\t"
+
+        "li      10, 16          \n\t"
+        "lxvd2x  10+32, 10, %1   \n\t"    // Hl
+        "li      10, 32          \n\t"
+        "lxvd2x  2+32, 10, %1    \n\t"    // H
+        "li      10, 48          \n\t"
+        "lxvd2x  11+32, 10, %1   \n\t"    // Hh
+
+        "vxor    0, 0, 0         \n\t"
+
+        "li    10, 16            \n\t"
+        "divdu 10, %3, 10        \n\t"
+        "mtctr 10                \n\t"
+        "li    9, 0              \n\t"
+
+        "1:                      \n\t"
+        "lxvb16x  32+1, 9, %2    \n\t"     // load input
+        "addi  9, 9, 16          \n\t"
+
+        "vpmsumd         4, 10, 1 \n\t"              // L
+        "vpmsumd         5, 2, 1  \n\t"              // M
+        "vpmsumd         6, 11, 1 \n\t"              // H
+
+        "vpmsumd         7, 4, 18 \n\t"              // reduction
+
+        "vsldoi          8, 5, 0, 8 \n\t"          // mL
+        "vsldoi          9, 0, 5, 8 \n\t"          // mH
+        "vxor            4, 4, 8    \n\t"             // LL + LL
+        "vxor            6, 6, 9    \n\t"             // HH + HH
+
+        "vsldoi          4, 4, 4, 8 \n\t"          // swap
+        "vxor            4, 4, 7    \n\t"
+
+        "vsldoi          10, 4, 4, 8 \n\t"          // swap
+        "vpmsumd         4, 4, 18    \n\t"              // reduction
+        "vxor            10, 10, 6   \n\t"
+        "vxor            0, 4, 10    \n\t"
+        "bdnz    1b                  \n\t"
+
+        "stxvb16x 32+0, 0, %0        \n\t"
+
+        : "+r" (Xi)
+        : "r" (Htable), "r" (input), "r" (len)
+        : "memory", "r8", "r9", "r10", "v0", "v2", "v4", "v5", "v6", "v7", "v8", "v9", \
+		    "v10", "v11", "v18", "v19");
+}
+
+/*
+ * Shift H <<< 1
+ * _ppc_gcm_shift(H, output)
+ */
+static void _ppc_gcm_shift(const unsigned char *H, unsigned char *output)
+{
+    asm volatile (
+        "li     5, 0xc2                 \n\t"
+        "sldi   5, 5, 56                \n\t"
+        "mtvsrd 32+19, 5                \n\t"
+        "vxor    0, 0, 0                \n\t"
+        "lxvd2x 32+1, 0, %1             \n\t"  // load H
+
+        "vspltisb 7, 1                  \n\t"
+        "vspltisb 10, 7                 \n\t"
+        "vsldoi 8, 0, 7, 1              \n\t"   // ...0x1
+        "vor    18, 19, 8               \n\t"   // 0xc2...1
+        "vspltb 9, 1, 0                 \n\t"   // most sig byte
+        "vsl    1, 1, 7                 \n\t"   // Carry = H << 7
+        "vsrab  9, 9, 10                \n\t"
+        "vand   9, 9, 18                \n\t"   // intersted carry
+        "vxor   10, 1, 9                \n\t"   // shift H <<< 1
+
+        "vsldoi 19, 0, 18, 8            \n\t"   // 0...0xc2
+        "vsldoi 11, 10, 10, 8           \n\t"   // swap L, H
+        "vsldoi 2, 0, 11, 8             \n\t"   // H.L
+        "vsldoi 3, 11, 0, 8             \n\t"   // H.H
+
+        "stxvd2x 32+19, 0, %0           \n\t"
+        "li     9, 16                   \n\t"
+        "stxvd2x 32+2, 9, %0            \n\t"
+        "addi   9, 9, 16                \n\t"
+        "stxvd2x 32+11, 9, %0           \n\t"
+        "addi   9, 9, 16                \n\t"
+        "stxvd2x 32+3, 9, %0            \n\t"
+        : "+r" (output)
+        : "r" (H)
+        : "memory", "r5", "r9", "v0", "v1", "v2", "v3", "v7", "v8", "v9", \
+		    "v10", "v11", "v18", "v19");
+
+    return;
+}
+
+/*
+ * GCM multiplication
+ */
+void mbedtls_aesppc_gcm_mult(unsigned char output[16],
+                             const unsigned char x[16],
+                             const unsigned char h[16])
+{
+    unsigned char H[64] = { 0, };
+
+    /* Shift H <<< 1 and arrange hash in (L, M, H) */
+    _ppc_gcm_shift(h, &H[0]);
+
+    _ppc_gcm_mul(&output[0], &H[0], &x[0], 16);
+
+    return;
+}
+
+/*
+ * vr1 is the first key
+ * vr5 is a mask to rotate a word in applied for all four words in our key.
+ * vr5 = 0x0d0e0f0c 0d0e0f0c 0d0e0f0c 0d0e0f0c
+ * vr3 is the key in use destination
+ * vr4 is the first rcon loaded: 01 00 00 00 01 00 00 00 01 00 00 00 01 00 00 00
+ *
+ * key: (w0 - w3) -> (w4 - w7)
+ * rcon : 1, 2, 3, 4, 5, 6, 7, 8, 0x1b, 0x36
+ * Z1(w3): vcipherlast: (RotWord, SubWord) xor rcon(n, 0, 0, 0)
+ *
+ * Operation for 128 bits:
+ *        w0    w1    w2    w3
+ *       0    w0    w1    w2
+ *  xor ------------------------
+ *        w4'   w5'  t-w6'  t-w7'
+ *       0    0     w0    w1
+ *  xor ------------------------
+ *        w4'   w5'   w6'  t-w7'
+ *       0    0     0     w0
+ *  xor ------------------------
+ *        w4'   w5'   w6'    w7'
+ *        Z1    Z1    Z1     Z1
+ *  xor ------------------------
+ *        w4    w5    w6     w7
+ *
+ * Refer to NIST.FIPS.197 appendix A.
+ * -------------------------------------------------------------
+ */
+
+static uint8_t const rcon1[16] = { 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1,
+                                   0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1 };
+static uint8_t const rcon1b[16] = { 0x0, 0x0, 0x0, 0x1b, 0x0, 0x0, 0x0, 0x1b,
+                                    0x0, 0x0, 0x0, 0x1b, 0x0, 0x0, 0x0, 0x1b };
+static uint8_t const mask[16] = { 0xc, 0xf, 0xe, 0xd, 0xc, 0xf, 0xe, 0xd,
+                                  0xc, 0xf, 0xe, 0xd, 0xc, 0xf, 0xe, 0xd };
+
+static void _ppc_setkey128(const unsigned char *key, unsigned char *rk)
+{
+    unsigned char buf[48+16];
+    unsigned char *r1, *m;
+
+    r1 = (unsigned char *) PPC_ALIGN(buf, 16);
+    m = r1 + 32;
+    memcpy(r1, rcon1, 16);
+    memcpy(r1+16, rcon1b, 16);
+    memcpy(m, mask, 16);
+
+    asm volatile (
+        "lvx    4, 0, %2        \n\t"   // 01 00 00 00
+        "lvx    5, 0, %3        \n\t"   // mask
+
+        "vxor   0, 0, 0         \n\t"
+        "lxvb16x 32+1, 0, %1    \n\t"   // key
+        "li     6, 8            \n\t"
+        "mtctr  6               \n\t"
+        "mr     7, %0           \n\t"   // out
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        "1:                     \n\t"
+        "vperm  3,1,1,5         \n\t"   // Z1 (v3) = RotWord(w3)
+        "vsldoi 6,0,1,12        \n\t"   // v6 = key >> 32
+        "vcipherlast 3,3,4      \n\t"   // v3 = (SubBytes, ShiftRows) ^ rcon
+        "vxor   1,1,6           \n\t"   // w4' w5' t-w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' w7'
+        "vadduwm 4,4,4          \n\t"   // next rcon
+        "vxor   1,1,3           \n\t"   // w4 w5 w6 w7
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+        "bdnz   1b              \n\t"
+
+        "li     6, 16           \n\t"
+        "lvx    4, 6, %2        \n\t" // 0x1b
+
+        "vperm  3,1,1,5         \n\t"
+        "vsldoi 6,0,1,12        \n\t"
+        "vcipherlast 3,3,4      \n\t"
+        "vxor   1,1,6           \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   1,1,6           \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   1,1,6           \n\t"
+        "vadduwm 4,4,4          \n\t"
+        "vxor   1,1,3           \n\t"
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        "vperm  3,1,1,5         \n\t"
+        "vsldoi 6,0,1,12        \n\t"
+        "vcipherlast 3,3,4      \n\t"
+        "vxor   1,1,6           \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   1,1,6           \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   1,1,6           \n\t"
+        "vxor   1,1,3           \n\t"
+        "stvx   1, 0, 7         \n\t"
+        : "+r" (rk)
+        : "r" (key), "r" (r1), "r" (m)
+        : "memory", "r6", "r7", "v0", "v1", "v3", "v4", "v5", "v6");
+}
+
+static void _ppc_setkey192(const unsigned char *key, unsigned char *rk)
+{
+    unsigned char buf[48+16];
+    unsigned char *r1, *m;
+    r1 = (unsigned char *) PPC_ALIGN(buf, 16);
+    m = r1 + 16;
+    memcpy(r1, rcon1, 16);
+    memcpy(m, mask, 16);
+
+    asm volatile (
+        "lvx    4, 0, %2        \n\t" // 01 00 00 00
+        "lvx    5, 0, %3        \n\t" // mask
+
+        "vxor   0, 0, 0         \n\t"
+        "lxvb16x 32+1, 0, %1    \n\t" // load first 16-byte key
+        "li     6, 16           \n\t"
+        "lxvb16x 32+11, 6, %1   \n\t"   // load second 8-byte key
+        "vsldoi 11, 0, 11, 8    \n\t"   // >> 8 bytes (0, 0, w4, w5)
+        "li     6, 4            \n\t"
+        "mtctr  6               \n\t"
+        "mr     7, %0           \n\t"   // out
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        "1:                     \n\t"
+        // frst 4 words
+        "vperm  3,11,11,5       \n\t"   // Z1 (v3) = RotWord(w5)
+        "vsldoi 6,0,1,12        \n\t"   // v6 = key >> 32
+        "vcipherlast 3,3,4      \n\t"   // v3 = (SubBytes, ShiftRows) ^ rcon
+        "vxor   1,1,6           \n\t"   // w4' w5' t-w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   2,1,6           \n\t"   // w4' w5' w6' w7'
+        "vxor   1,2,3           \n\t"   // w4 w5 w6 w7
+        "vsldoi 7, 11, 1, 8     \n\t"   // w4" w5" w0 w1
+        "stvx   7, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        // handle remaining 2 words
+        "vspltw 3, 1, 3         \n\t"
+        "vsldoi 6,0,11,12       \n\t"   // v6 = key >> 32
+        "vxor   11,11,6         \n\t"   // w4' w5'
+        "vxor   11,11,3         \n\t"   // w4 w5
+        "vsldoi 11, 11, 0, 8    \n\t"
+        "vsldoi 7, 1, 11, 8     \n\t"   // (w6, w7, w4, w5)
+        "vadduwm 4,4,4          \n\t"
+        "stvx   7, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        // previous 6 words, v2 (w4", w5", w0, w1) and v11 (w4 w5, 0, 0)
+        // handle new 4 words
+        "vsldoi 11, 0, 11, 8    \n\t"
+        "vperm  3,11,11,5       \n\t"   // Z1 (v3) = RotWord(last word)
+        "vsldoi 6,0,1,12        \n\t"   // v6 = key >> 32
+        "vcipherlast 3,3,4      \n\t"   // v3 = (SubBytes, ShiftRows) ^ rcon
+        "vxor   1,1,6           \n\t"   // w4' w5' t-w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   2,1,6           \n\t"   // w4' w5' w6' w7'
+        "vxor   1,2,3           \n\t"   // w4 w5 w6 w7
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+        "vadduwm 4,4,4          \n\t"
+
+        // handle remaining 2 words
+        "vspltw 3, 1, 3         \n\t"
+        "vsldoi 6,0,11,12       \n\t"   // v6 = key >> 32
+        "vxor   11,11,6         \n\t"   // w4' w5'
+        "vxor   11,11,3         \n\t"   // w4 w5
+        "vsldoi 11, 11, 11, 8   \n\t"
+        "vsldoi 11, 0, 11, 8    \n\t"
+
+        "bdnz   1b              \n\t"
+        : "+r" (rk)
+        : "r" (key), "r" (r1), "r" (m)
+        : "memory", "r6", "r7", "v0", "v1", "v3", "v4", "v5", "v6", "v7", "v11");
+}
+
+static void _ppc_setkey256(const unsigned char *key, unsigned char *rk)
+{
+    unsigned char buf[48+16];
+    unsigned char *r1, *m;
+    r1 = (unsigned char *) PPC_ALIGN(buf, 16);
+    m = r1 + 16;
+    memcpy(r1, rcon1, 16);
+    memcpy(m, mask, 16);
+
+    asm volatile (
+        "lvx    4, 0, %2        \n\t" // 01 00 00 00
+        "lvx    5, 0, %3        \n\t" // mask
+
+        "vxor   0, 0, 0         \n\t"
+        "lxvb16x 32+1, 0, %1    \n\t"   // load first 16-byte key
+        "li     6, 16           \n\t"
+        "lxvb16x 32+11, 6, %1   \n\t"   // load second 16-byte key
+        "li     6, 6            \n\t"   // 7 - 1
+        "mtctr  6               \n\t"
+        "mr     7, %0           \n\t"   // out
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+        "stvx   11, 0, 7        \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        "1:                     \n\t"
+        "vperm  3,11,11,5       \n\t"   // Z1 (v3) = RotWord(w7)
+        "vsldoi 6,0,1,12        \n\t"   // v6 = key >> 32
+        "vcipherlast 3,3,4      \n\t"   // v3 = (SubBytes, ShiftRows) ^ rcon
+        "vxor   1,1,6           \n\t"   // w4' w5' t-w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' w7'
+        "vxor   1,1,3           \n\t"   // w4 w5 w6 w7
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+
+        "vspltw 3,1,3           \n\t"   // splat last word
+        "vsldoi 6,0,11,12       \n\t"
+        "vsbox  3,3             \n\t"   // SubWord
+        "vxor   11,11,6         \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   11,11,6         \n\t"
+        "vsldoi 6,0,6,12        \n\t"
+        "vxor   11,11,6         \n\t"
+        "vadduwm 4,4,4          \n\t"
+        "vxor   11,11,3         \n\t"
+        "stvx   11, 0, 7        \n\t"
+        "addi   7, 7, 16        \n\t"
+        "bdnz   1b              \n\t"
+
+        // need one more
+        "vperm  3,11,11,5       \n\t"   // Splat and rotate last key
+        "vsldoi 6,0,1,12        \n\t"   // v6 = key >> 32
+        "vcipherlast 3,3,4      \n\t"   // v3 = (SubBytes, ShiftRows) ^ rcon
+        "vxor   1,1,6           \n\t"   // w4' w5' t-w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' t-w7'
+        "vsldoi 6,0,6,12        \n\t"   //
+        "vxor   1,1,6           \n\t"   // w4' w5' w6' w7'
+        "vxor   1,1,3           \n\t"   // w4 w5 w6 w7
+        "stvx   1, 0, 7         \n\t"
+        "addi   7, 7, 16        \n\t"
+        : "+r" (rk)
+        : "r" (key), "r" (r1), "r" (m)
+        : "memory", "r6", "r7", "v0", "v1", "v3", "v4", "v5", "v6", "v11");
+}
+
+int mbedtls_aesppc_setkey_enc(unsigned char *rk, const unsigned char *key,
+                              unsigned int keybits)
+{
+    unsigned char Rkey[256+16];
+    unsigned char *t1;
+    uint32_t *t2 = (uint32_t *) rk;
+    int i = 0, nr = 10;
+
+    t1 = (unsigned char *) PPC_ALIGN(Rkey, 16);
+    memset(t2, 0, 256);
+
+    switch (keybits) {
+        case 128:
+            _ppc_setkey128(key, t1);
+            nr = 10;
+            break;
+        case 192:
+            _ppc_setkey192(key, t1);
+            nr = 12;
+            break;
+        case 256:
+            _ppc_setkey256(key, t1);
+            nr = 14;
+            break;
+    }
+
+    /* Reverse word order */
+    for (i = 0; i < (nr+1); i++) {
+        t2[0] = MBEDTLS_GET_UINT32_LE(t1, 0);
+        t2[1] = MBEDTLS_GET_UINT32_LE(t1, 4);
+        t2[2] = MBEDTLS_GET_UINT32_LE(t1, 8);
+        t2[3] = MBEDTLS_GET_UINT32_LE(t1, 12);
+        t1 += 16;
+        t2 += 4;
+    }
+    return 0;
+}
+
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */

--- a/drivers/builtin/src/aesppc.h
+++ b/drivers/builtin/src/aesppc.h
@@ -1,0 +1,48 @@
+/*
+ * aesppc.h - AES PPC (ppc64le) support definitions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *
+ *  Copyright IBM Corp. 2026
+ *
+ * ===================================================================================
+ * Written by Danny Tsen <dtsen@us.ibm.com>
+ */
+
+#ifndef TF_PSA_CRYPTO_AESPPC_H
+#define TF_PSA_CRYPTO_AESPPC_H
+
+#if defined(__powerpc__) || defined(__powerpc64__)
+
+#if !defined(PPC_LITTLE_ENDIAN) && defined(__LITTLE_ENDIAN__)
+# define PPC_LITTLE_ENDIAN 1
+#endif
+
+#define MBEDTLS_AESPPC_HAVE_CODE 1
+
+#ifdef PPC_LITTLE_ENDIAN
+#define PPC_CRYPTO_SUPPORT 1
+
+#define PPC_ALIGN(p, mask) (((unsigned long) (p) + (mask-1)) & ~(mask-1))
+
+int ppc_crypto_capable(void);
+
+int mbedtls_aesppc_crypt_ecb(mbedtls_aes_context *ctx, int mode,
+                             const unsigned char input[16],
+                             unsigned char output[16]);
+
+void mbedtls_aesppc_inverse_key(unsigned char *invkey,
+                                const unsigned char *fwdkey,
+                                int nr);
+
+int mbedtls_aesppc_setkey_enc(unsigned char *rk, const unsigned char *key,
+                              unsigned int keybits);
+
+void mbedtls_aesppc_gcm_mult(unsigned char output[16],
+                             const unsigned char x[16],
+                             const unsigned char h[16]);
+#endif /* PPC_LITTLE_ENDIAN */
+
+#endif /* powerpc64 */
+#endif /* TF_PSA_CRYPTO_AESPPC_H */

--- a/drivers/builtin/src/gcm.c
+++ b/drivers/builtin/src/gcm.c
@@ -39,11 +39,16 @@
 #include "aesce.h"
 #endif
 
+#if defined(MBEDTLS_AESPPC_C)
+#include "aesppc.h"
+#endif
+
 /* Used to select the acceleration mechanism */
 #define MBEDTLS_GCM_ACC_SMALLTABLE  0
 #define MBEDTLS_GCM_ACC_LARGETABLE  1
 #define MBEDTLS_GCM_ACC_AESNI       2
 #define MBEDTLS_GCM_ACC_AESCE       3
+#define MBEDTLS_GCM_ACC_AESPPC      4
 
 /*
  * Initialize a context
@@ -73,6 +78,12 @@ static inline void gcm_set_acceleration(mbedtls_gcm_context *ctx)
         ctx->acceleration = MBEDTLS_GCM_ACC_AESCE;
     }
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+    if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+        ctx->acceleration = MBEDTLS_GCM_ACC_AESPPC;
+    }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 }
 
 static inline void gcm_gen_table_rightshift(uint64_t dst[2], const uint64_t src[2])
@@ -126,6 +137,11 @@ static int gcm_gen_table(mbedtls_gcm_context *ctx)
         case MBEDTLS_GCM_ACC_AESCE:
             return 0;
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+        case MBEDTLS_GCM_ACC_AESPPC:
+            return 0;
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
         default:
             /* 0 corresponds to 0 in GF(2^128) */
@@ -357,6 +373,26 @@ static void gcm_mult(mbedtls_gcm_context *ctx, const unsigned char x[16],
             mbedtls_aesce_gcm_mult(output, x, (uint8_t *) ctx->H[MBEDTLS_GCM_HTABLE_SIZE/2]);
             break;
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+        case MBEDTLS_GCM_ACC_AESPPC:
+            if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+                unsigned char h[16];
+                uint64_t hi, lo;
+
+                hi = ctx->H[MBEDTLS_GCM_HTABLE_SIZE/2][0];
+                lo = ctx->H[MBEDTLS_GCM_HTABLE_SIZE/2][1];
+
+                /* mbedtls_aesppc_gcm_mult needs big-endian input */
+                MBEDTLS_PUT_UINT32_BE(hi >> 32, h,  0);
+                MBEDTLS_PUT_UINT32_BE(hi,       h,  4);
+                MBEDTLS_PUT_UINT32_BE(lo >> 32, h,  8);
+                MBEDTLS_PUT_UINT32_BE(lo,       h, 12);
+
+                mbedtls_aesppc_gcm_mult(output, x, (unsigned char *) &h);
+            }
+            break;
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
 #if defined(MBEDTLS_GCM_LARGE_TABLE)
         case MBEDTLS_GCM_ACC_LARGETABLE:
@@ -1031,6 +1067,12 @@ int mbedtls_gcm_self_test(int verbose)
             mbedtls_printf("  GCM note: using AESCE.\n");
         } else
 #endif
+
+#if defined(MBEDTLS_AESPPC_HAVE_CODE)
+        if (ppc_crypto_capable() == PPC_CRYPTO_SUPPORT) {
+            mbedtls_printf("  GCM note: using AESPPC.\n");
+        }
+#endif /* MBEDTLS_AESPPC_HAVE_CODE */
 
         mbedtls_printf("  GCM note: built-in implementation.\n");
     }

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -1491,6 +1491,27 @@
 #define MBEDTLS_AESCE_C
 
 /**
+ * \def MBEDTLS_AESPPC_C
+ *
+ * Enable AES cryptographic extension support on Power9+ (ppc64le).
+ *
+ * Module:  drivers/builtin/src/aesppc.c
+ * Caller:  drivers/builtin/src/aes.c
+ *
+ * Requires: The AES built-in implementation
+ *
+ * \warning Runtime detection only works on Linux. For non-Linux operating
+ *          system, P9+ (ppc64le) Cryptographic Extensions must be supported by
+ *          the CPU when this option is enabled.
+ *
+ * \note    Minimum compiler versions for this feature when targeting ppc64 with
+ *          ISA 3.0 support.
+ *
+ * This module adds support for the AES ppc64le Cryptographic Extensions on p9+ systems.
+ */
+#define MBEDTLS_AESPPC_C
+
+/**
  * \def MBEDTLS_AES_ROM_TABLES
  *
  * Use precomputed AES tables stored in ROM.


### PR DESCRIPTION
ppc64le: Adding PowerPC support for AES and GCM functions.

The supporting functions are in aesppc.c which is PowerPC inline assembly for ppc64le.
  1. added aes-ecb encrypt and decrypt functions.
  2. added AES key scheduling functions.
  3. added GCM multiplication functions.
  4. Arch supports: p9 and above.

Signed-off-by: Danny Tsen <dtsen@us.ibm.com>

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
