### PR TITLE
Hide spurious error message if uncrustify is not present

### DIFF
--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -15,7 +15,7 @@ component_tf_psa_crypto_check_code_style () {
 }
 
 support_tf_psa_crypto_check_code_style () {
-    case $(uncrustify --version) in
+    case $(uncrustify --version 2>/dev/null) in
         *0.75.1*) true;;
         *) false;;
     esac


### PR DESCRIPTION
Partial side port of https://github.com/Mbed-TLS/mbedtls/pull/10493: only the uncrustify warning is present in crypto.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10493
- [x] **TF-PSA-Crypto PR** here
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10586
- **tests**  provided (if the CI keeps passing, it's not wrong)
