### PR TITLE
Turn on warnings about undefined preprocessor macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ function(tf_psa_crypto_set_gnu_base_compile_options target)
     # note: starting with CMake 2.8 we could use CMAKE_C_COMPILER_VERSION
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GCC_VERSION)
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Wwrite-strings -Wmissing-prototypes)
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wwrite-strings -Wmissing-prototypes -Wundef)
     if (GCC_VERSION VERSION_GREATER 3.0 OR GCC_VERSION VERSION_EQUAL 3.0)
         target_compile_options(${target} PRIVATE -Wformat=2 -Wno-format-nonliteral)
     endif()
@@ -296,7 +296,7 @@ function(tf_psa_crypto_set_gnu_base_compile_options target)
 endfunction(tf_psa_crypto_set_gnu_base_compile_options)
 
 function(tf_psa_crypto_set_clang_base_compile_options target)
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Wwrite-strings -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral)
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wwrite-strings -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wundef)
     target_compile_options(${target} PRIVATE $<$<CONFIG:Release>:-O2>)
     target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-O0 -g3>)
     target_compile_options(${target} PRIVATE $<$<CONFIG:Coverage>:-O0 -g3 --coverage>)
@@ -332,7 +332,7 @@ endfunction(tf_psa_crypto_set_iar_base_compile_options)
 
 function(tf_psa_crypto_set_msvc_base_compile_options target)
     # Strictest warnings, UTF-8 source and execution charset
-    target_compile_options(${target} PRIVATE /W3 /utf-8)
+    target_compile_options(${target} PRIVATE /W3 /w34668 /utf-8)
 
     if(TF_PSA_CRYPTO_FATAL_WARNINGS)
         target_compile_options(${target} PRIVATE /WX)

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -396,7 +396,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
  */
 #define MBEDTLS_STATIC_ASSERT_SUPPORT
 #elif !defined(__cplusplus) && \
-    ((defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4)) || \
+    ((defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4)) || \
     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L))
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    _Static_assert(expr, msg)
 #define MBEDTLS_STATIC_ASSERT_SUPPORT

--- a/core/tf_psa_crypto_config.c
+++ b/core/tf_psa_crypto_config.c
@@ -14,12 +14,12 @@
  *
  * In the libtestdriver1 build, the next two code lines are
  * `#define LIBTESTDRIVER_FOO 1` and
- * `#if LIBTESTDRIVER_FOO == LIBTESTDRIVER_FOO` so the conditional is true.
+ * `#if defined(LIBTESTDRIVER_FOO)` so the conditional is true.
  * In a normal build, `LIBTESTDRIVER1_TF_PSA_CRYPTO_MARKER` remains
  * undefined so the conditional is false.
  */
 #define TF_PSA_CRYPTO_MARKER 1
-#if LIBTESTDRIVER1_TF_PSA_CRYPTO_MARKER == TF_PSA_CRYPTO_MARKER
+#if defined(LIBTESTDRIVER1_TF_PSA_CRYPTO_MARKER)
 #define TF_PSA_CRYPTO_WE_ARE_IN_LIBTESTDRIVER1
 #endif
 #undef TF_PSA_CRYPTO_MARKER

--- a/drivers/builtin/src/bignum_core.c
+++ b/drivers/builtin/src/bignum_core.c
@@ -9,6 +9,7 @@
 
 #if defined(MBEDTLS_BIGNUM_C)
 
+#include <limits.h>
 #include <string.h>
 
 #include "mbedtls/private/error_common.h"

--- a/drivers/builtin/src/pkcs5.c
+++ b/drivers/builtin/src/pkcs5.c
@@ -30,6 +30,7 @@
 #include "crypto_oid.h"
 #endif /* MBEDTLS_ASN1_PARSE_C */
 
+#include <limits.h>
 #include <string.h>
 
 #include "mbedtls/platform.h"

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -40,6 +40,7 @@
  * standard C headers for functions we'll use here. */
 #include "tf-psa-crypto/build_info.h"
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
## Description

Turn on warnings about undefined preprocessor macros

Fixes #682

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 