### PR TITLE
include: fix guard in asn1write.h

### DIFF
--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -388,10 +388,10 @@ int mbedtls_asn1_write_integer(unsigned char **p,
                                const unsigned char *integer,
                                size_t integer_length);
 
+#endif /* MBEDTLS_ASN1_WRITE_C */
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MBEDTLS_ASN1_WRITE_C */
 
 #endif /* MBEDTLS_ASN1WRITE_H */


### PR DESCRIPTION
## Description

Fix the location of the ending braket of "extern C" block in order to have it balanced between C guards.

## PR checklist

- [ ] **changelog** not required because: very minor fix
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: no change there
- [ ] **mbedtls 3.6 PR** not required because: https://github.com/Mbed-TLS/mbedtls/pull/10599
- **tests** not required because: no code change