### PR TITLE
Simplify platform requirements before 1.1

### DIFF
--- a/ChangeLog.d/static_assert.txt
+++ b/ChangeLog.d/static_assert.txt
@@ -1,0 +1,4 @@
+Changes
+   * Static assertions in the library (`MBEDTLS_STATIC_ASSERT`) are now
+     always enabled, using indirect methods in pre-C11 compilers. This change
+     also fixes warnings in pedantic mode with GCC or Clang on some platforms.

--- a/ChangeLog.d/unistd.txt
+++ b/ChangeLog.d/unistd.txt
@@ -1,3 +1,7 @@
 Changes
    * Tweak the detection of Unix-like platforms, which makes more system
      interfaces (timing, threading) available on Haiku, QNX and Midipix.
+   * On MinGW, always use a standard-compliant printf function family.
+
+Bugfix
+   * Fix a build failure with dietlibc.

--- a/ChangeLog.d/unistd.txt
+++ b/ChangeLog.d/unistd.txt
@@ -1,0 +1,3 @@
+Changes
+   * Tweak the detection of Unix-like platforms, which makes more system
+     interfaces (timing, threading) available on Haiku, QNX and Midipix.

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -8781,20 +8781,11 @@ static psa_status_t mbedtls_psa_crypto_init_subsystem(mbedtls_psa_crypto_subsyst
 
             /* Initialize and seed the random generator. */
             if (global_data.rng_state == RNG_NOT_INITIALIZED && driver_wrappers_initialized) {
-#if !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG) && !defined(MBEDTLS_STATIC_ASSERT_SUPPORT)
-                if (MBEDTLS_PSA_CRYPTO_RNG_HASH != PSA_ALG_SHA_256 &&
-                    MBEDTLS_PSA_CRYPTO_RNG_HASH != PSA_ALG_SHA_512) {
-                    status = PSA_ERROR_INSUFFICIENT_ENTROPY;
-                } else
-#endif
-                {
-                    mbedtls_psa_random_init(&global_data.rng);
-                    global_data.rng_state = RNG_INITIALIZED;
-
-                    status = mbedtls_psa_random_seed(&global_data.rng);
-                    if (status == PSA_SUCCESS) {
-                        global_data.rng_state = RNG_SEEDED;
-                    }
+                mbedtls_psa_random_init(&global_data.rng);
+                global_data.rng_state = RNG_INITIALIZED;
+                status = mbedtls_psa_random_seed(&global_data.rng);
+                if (status == PSA_SUCCESS) {
+                    global_data.rng_state = RNG_SEEDED;
                 }
             }
 

--- a/core/psa_crypto_random_impl.h
+++ b/core/psa_crypto_random_impl.h
@@ -128,15 +128,6 @@ static inline int mbedtls_psa_drbg_seed(mbedtls_psa_drbg_context_t *drbg_ctx,
                                         mbedtls_entropy_context *entropy,
                                         const unsigned char *custom, size_t len)
 {
-#if !defined(MBEDTLS_STATIC_ASSERT_SUPPORT)
-    if (PSA_BYTES_TO_BITS(PSA_HASH_LENGTH(MBEDTLS_PSA_CRYPTO_RNG_HASH)) <
-        MBEDTLS_PSA_CRYPTO_RNG_STRENGTH) {
-        /* MBEDTLS_PSA_CRYPTO_RNG_HASH size (in bits) must be at least
-         * MBEDTLS_PSA_CRYPTO_RNG_STRENGTH.
-         */
-        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
-    }
-#endif
 #if defined(MBEDTLS_CTR_DRBG_C)
     return mbedtls_ctr_drbg_seed(drbg_ctx, mbedtls_entropy_func, entropy, custom, len);
 #elif defined(MBEDTLS_HMAC_DRBG_C)

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -1,7 +1,18 @@
 /**
  * \file tf_psa_crypto_common.h
  *
- * \brief Utility macros for internal use in the library
+ * \brief Utility macros for internal use in the library.
+ *
+ * This file should be included as the first thing in all library C files.
+ * It must not be included by sample programs, since sample programs
+ * illustrate what you can do without the library sources.
+ * It may be included (often indirectly) by test code that isn't purely
+ * black-box testing.
+ *
+ * This file takes care of setting up requirements for platform headers.
+ * It includes the library configuration and derived macros.
+ * It additionally defines various utility macros and other definitions
+ * (but no function declarations).
  */
 /*
  *  Copyright The Mbed TLS Contributors
@@ -15,7 +26,10 @@
  * headers what we expect of them. */
 #include "tf_psa_crypto_platform_requirements.h"
 
+/* From this point onwards, ensure we have the library configuration and
+ * the configuration-derived macros. */
 #include "tf-psa-crypto/build_info.h"
+
 #include "alignment.h"
 
 #include <assert.h>

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -382,30 +382,121 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #endif
 #endif
 
-/* Always provide a static assert macro, so it can be used unconditionally.
- * It does nothing on systems where we don't know how to define a static assert.
+/** \def MBEDTLS_STATIC_ASSERT
+ *
+ * A static assert macro, equivalent to `static_assert` or `_Static_assert`
+ * in modern C.
+ *
+ * You can use `MBEDTLS_STATIC_ASSERT(expr, msg)` in any position where a
+ * declaration is permitted, both at the toplevel and within a function.
+ * This macro may not be used inside an expression (see #STATIC_ASSERT_EXPR,
+ * available on fewer platforms).
+ *
+ * \param expr  An expression which must be a compile-time constant with
+ *              an integer value. This doesn't have to be a preprocessor
+ *              constant, for example it can use `sizeof`.
+ *              The compilation fails if the value is 0.
+ * \param msg   An error messsage to display if the value of \p expr is 0.
  */
-/* Can't use the C11-style `defined(static_assert)` on FreeBSD, since it
- * defines static_assert even with -std=c99, but then complains about it.
- */
-#if defined(static_assert) && !defined(__FreeBSD__)
+#if __STDC_VERSION__ >= 202311L
+/* static_assert is a keyword since C23 */
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg)
-/* The GCC compiler supports _Static_assert since version 4.6 even with C99 so checking the
- * compiler version should suffice.
- * For non GCC compilers we check that C>=11 is used since C11 introduced _Static_assert.
- */
-#define MBEDTLS_STATIC_ASSERT_SUPPORT
-#elif !defined(__cplusplus) && \
-    ((defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4)) || \
-    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L))
+
+#elif __STDC_VERSION__ >= 201112L
+/* _Static_assert is a keyword since C11 */
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    _Static_assert(expr, msg)
-#define MBEDTLS_STATIC_ASSERT_SUPPORT
+
+#elif defined(static_assert) && !defined(__STRICT_ANSI__)
+/* If static_assert is defined as a macro, presumably from <assert.h>
+ * included above, then trust that it is what we expect.
+ * This is a common extension even before C11.
+ * However, don't use it if it looks like a build with `gcc -c99 -pedantic`
+ * or `clang -c99 -pedantic`, because they would complain about the use of
+ * a feature that doesn't exist in C99.
+ */
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg)
+
+#elif defined(_MSC_VER)
+/* MSVC has `static_assert` as a keyword (not a macro) since
+ * Visual Studio 2010.
+ */
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg)
+
+#elif defined(__GNUC__) && \
+    ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4) && \
+    !defined(__STRICT_ANSI__)
+/* _Static_assert is a keyword since GCC 4.6.
+ * However, don't use it if it looks like a build with `gcc -c99 -pedantic`
+ * or `clang -c99 -pedantic`, because they would complain about the use of
+ * a feature that doesn't exist in C99.
+ */
+#define MBEDTLS_STATIC_ASSERT(expr, msg)    _Static_assert(expr, msg)
+
+#elif defined(__COUNTER__)
+/* Fall back to a hack that works in practice with non-ancient GCC-like
+ * compilers and MSVC, and doesn't trigger `-Wredundant-decls`.
+ *
+ * See the `#else` block below for an explanation. Here, we add another
+ * layer to make the declared name unique using the special preprocessor
+ * token `__COUNTER__`.
+ */
+#define MBEDTLS_STATIC_ASSERT_COUNTER(expr, counter) \
+    extern void mbedtls_static_assert_anchor##counter(char[1 - 2 * !(expr)])
+#define MBEDTLS_STATIC_ASSERT_WRAP(expr, counter) \
+    MBEDTLS_STATIC_ASSERT_COUNTER(expr, counter)
+#define MBEDTLS_STATIC_ASSERT(expr, msg) \
+    MBEDTLS_STATIC_ASSERT_WRAP(expr, __COUNTER__)
+
 #else
-/* Make sure `MBEDTLS_STATIC_ASSERT(expr, msg);` is valid both inside and
- * outside a function. We choose a struct declaration, which can be repeated
- * any number of times and does not need a matching definition. */
+/* Fall back to a hack that works in practice with almost all C compilers.
+ *
+ * Constraints:
+ * - Must be valid C99 when `expr` is a constant expression with a nonzero value.
+ * - Must compile without warnings on known compilers when `expr` is a
+ *   constant expression with a nonzero value.
+ * - Must be valid both at file scope and inside a function.
+ * - Must allow multiple static assertions in the same scope.
+ * - Must not rely on `__LINE__` to create unique identifiers, since this
+ *   could lead to collisions, e.g. if `MBEDTLS_STATIC_ASSERT` is used in
+ *   a header, or if a macro expands to multiple uses of
+ *   `MBEDTLS_STATIC_ASSERT`.
+ * - Should result in an error when `expr` evaluates to 0.
+ *
+ * How it works:
+ * - Ostensibly declare a function. This function will never be used, but
+ *   declaring a function that won't be used is routine.
+ * - The function's name is in our namespace, so we just need to avoid that
+ *   name for any other purpose.
+ * - Declaring the same function with the same prototype multiple times is
+ *   also common (it triggers `gcc -Wredundant-decls`, but we handle
+ *   non-ancient GCC separately above).
+ * - The function takes an argument whose type involves an array.
+ * - The array size is 1 (valid) when the expression is true, and -1
+ *   (invalid, triggers an error in almost all compilers) when the expression
+ *   is false.
+ *
+ * Limitations:
+ * - If you have multiple static assertions in the same scope,
+ *   `gcc -Wredundant-decls` complains.
+ * - Technically, an array of length -1 doesn't have to lead to a compilation
+ *   error in C99. In C89, it does: it's a constraint violation. But in C99,
+ *   it could be a variable-length array.
+ * - When the assertion fails, some compilers complain about a negative
+ *   array length without displaying the problematic line, so the message
+ *   is not visible.
+ *
+ * On Godbolt compiler explorer, the only failures I could find are:
+ * - 6502 cc65 complains if there are multiple assertions in the same scope:
+ *   "Multiple definition for `mbedtls_static_assert_anchor'"
+ * - Chibicc 2020-12-07 ignores the assertion.
+ * - LC3 (trunk) ignores the assertion.
+ * - ppci 0.5.5 dies with a NotImplementedError on the `!` operator.
+ * - SDCC 4.0.0 through 4.5.0 complains if there are multiple assertions in
+ *   the same scope:
+ *   "extern definition for 'mbedtls_static_assert_anchor' mismatches with declaration."
+ */
 #define MBEDTLS_STATIC_ASSERT(expr, msg)                                \
-    struct ISO_C_does_not_allow_extra_semicolon_outside_of_a_function
+    extern void mbedtls_static_assert_anchor(char[(expr) ? 1 : -1])
 #endif
 
 /* Define compiler branch hints */

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -445,7 +445,7 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
 #define MBEDTLS_STATIC_ASSERT(expr, msg)    static_assert(expr, msg)
 
 #elif defined(__GNUC__) && \
-    ((__GNUC__ == 4 && __GNUC_MINOR >= 6) || __GNUC__ > 4) && \
+    ((__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4) && \
     !defined(__STRICT_ANSI__)
 /* _Static_assert is a keyword since GCC 4.6.
  * However, don't use it if it looks like a build with `gcc -c99 -pedantic`

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -33,7 +33,10 @@
 
 /* Decide whether we're built for a Unix-like platform.
  */
-#if defined(_WIN32)
+#if defined(MBEDTLS_TEST_PLATFORM_IS_NOT_UNIXLIKE) //no-check-names
+/* We may be building on a Unix-like platform, but for test purposes,
+ * do not try to use Unix features. */
+#elif defined(_WIN32)
 /* If Windows platform interfaces are available, we use them, even if
  * a Unix-like might also to be available. */
 /* defined(_WIN32) ==> we can include <windows.h> */

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -118,7 +118,7 @@ extern void (*mbedtls_test_hook_test_fail)(const char *test, int line, const cha
 /* A compile-time constant with the value 0. If `const_expr` is not a
  * compile-time constant with a nonzero value, cause a compile-time error. */
 #define STATIC_ASSERT_EXPR(const_expr)                                \
-    (0 && sizeof(char[1 - 2 * !(const_expr)]))
+    (0 && sizeof(struct { unsigned int STATIC_ASSERT : (const_expr) ? 1 : -1; }))
 
 /* Return the scalar value `value` (possibly promoted). This is a compile-time
  * constant if `value` is. `condition` must be a compile-time constant.
@@ -477,7 +477,9 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
  * token `__COUNTER__`.
  */
 #define MBEDTLS_STATIC_ASSERT_COUNTER(expr, counter) \
-    extern void mbedtls_static_assert_anchor##counter(char[1 - 2 * !(expr)])
+    struct mbedtls_static_assert_anchor##counter { \
+        unsigned int STATIC_ASSERT : (expr) ? 1 : -1; \
+    }
 #define MBEDTLS_STATIC_ASSERT_WRAP(expr, counter) \
     MBEDTLS_STATIC_ASSERT_COUNTER(expr, counter)
 #define MBEDTLS_STATIC_ASSERT(expr, msg) \
@@ -506,33 +508,44 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
  * - Declaring the same function with the same prototype multiple times is
  *   also common (it triggers `gcc -Wredundant-decls`, but we handle
  *   non-ancient GCC separately above).
- * - The function takes an argument whose type involves an array.
- * - The array size is 1 (valid) when the expression is true, and -1
- *   (invalid, triggers an error in almost all compilers) when the expression
- *   is false.
+ * - The function returns a pointer to an array.
+ * - The array size involves parsing an anonymous struct declaration.
+ * - The struct declaration contains a bit-field whose width is 1 if the
+ *   assertion is true, and -1 otherwise. This is a constraint violation,
+ *   requiring a diagnostic.
  *
  * Limitations:
  * - If you have multiple static assertions in the same scope,
  *   `gcc -Wredundant-decls` complains.
- * - Technically, an array of length -1 doesn't have to lead to a compilation
- *   error in C99. In C89, it does: it's a constraint violation. But in C99,
- *   it could be a variable-length array.
  * - When the assertion fails, some compilers complain about a negative
- *   array length without displaying the problematic line, so the message
+ *   bit-field width without displaying the problematic line, so the message
  *   is not visible.
  *
  * On Godbolt compiler explorer, the only failures I could find are:
- * - 6502 cc65 complains if there are multiple assertions in the same scope:
- *   "Multiple definition for `mbedtls_static_assert_anchor'"
+ * - CCC (Claude C Compiler) as of 2026-03-02 ignores the assertion.
  * - Chibicc 2020-12-07 ignores the assertion.
  * - LC3 (trunk) ignores the assertion.
- * - ppci 0.5.5 dies with a NotImplementedError on the `!` operator.
- * - SDCC 4.0.0 through 4.5.0 complains if there are multiple assertions in
- *   the same scope:
+ * - MSVC warns about assertions, whether they pass or not:
+ *   "warning C4116: unnamed type definition in parentheses"
+ *   This doesn't matter because non-ancient MSVC supports __COUNTER__,
+ *   which is covered above.
+ * - ppci 0.5.5 complains of a syntax error.
+ * - SDCC 4.5.0 (and earlier) complains if there are multiple assertions in
+ *   the same scope, even if they pass:
  *   "extern definition for 'mbedtls_static_assert_anchor' mismatches with declaration."
+ * - x86 tendra (trunk) complains if there are multiple assertions in
+ *   the same scope, even if they pass:
+ *   " The types 'int ( * ( void ) ) [<exp1>]' and 'int ( * ( void ) ) [<exp2>]' are incompatible."
+ * - vast (trunk) complains about assertions at function scope,
+ *   even if they pass:
+ *   "unexpected error: failed to legalize operation 'll.func' that was explicitly marked illegal"
+ *   This doesn't matter because it supports __COUNTER__,  which is covered
+ *   above.
  */
 #define MBEDTLS_STATIC_ASSERT(expr, msg)                                \
-    extern void mbedtls_static_assert_anchor(char[(expr) ? 1 : -1])
+    extern int (*mbedtls_static_assert_anchor(void))[sizeof(struct {    \
+        int STATIC_ASSERT : (expr) ? 1 : -1;                            \
+    })]
 #endif
 
 /* Define compiler branch hints */

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -11,6 +11,10 @@
 #ifndef TF_PSA_CRYPTO_TF_PSA_CRYPTO_COMMON_H
 #define TF_PSA_CRYPTO_TF_PSA_CRYPTO_COMMON_H
 
+/* Before including any system header, declare some macros to tell system
+ * headers what we expect of them. */
+#include "tf_psa_crypto_platform_requirements.h"
+
 #include "tf-psa-crypto/build_info.h"
 #include "alignment.h"
 

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -27,6 +27,21 @@
 #define MBEDTLS_HAVE_NEON_INTRINSICS
 #endif
 
+/* Decide whether we're built for a Unix-like platform.
+ */
+#if defined(_WIN32)
+/* If Windows platform interfaces are available, we use them, even if
+ * a Unix-like might also to be available. */
+/* defined(_WIN32) ==> we can include <windows.h> */
+#elif defined(unix) || defined(__unix) || defined(__unix__) ||    \
+    (defined(__APPLE__) && defined(__MACH__)) ||                  \
+    defined(__HAIKU__) ||                                         \
+    defined(__midipix__) ||                                       \
+    /* Add other Unix-like platform indicators here ^^^^ */ 0
+/* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) ==> we can include <unistd.h> */
+#define MBEDTLS_PLATFORM_IS_UNIXLIKE
+#endif
+
 /** Helper to define a function as static except when building invasive tests.
  *
  * If a function is only used inside its own source file and should be

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -104,7 +104,7 @@ extern void (*mbedtls_test_hook_test_fail)(const char *test, int line, const cha
 /* A compile-time constant with the value 0. If `const_expr` is not a
  * compile-time constant with a nonzero value, cause a compile-time error. */
 #define STATIC_ASSERT_EXPR(const_expr)                                \
-    (0 && sizeof(struct { unsigned int STATIC_ASSERT : 1 - 2 * !(const_expr); }))
+    (0 && sizeof(char[1 - 2 * !(const_expr)]))
 
 /* Return the scalar value `value` (possibly promoted). This is a compile-time
  * constant if `value` is. `condition` must be a compile-time constant.

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -27,4 +27,9 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
+/* With GNU libc, define all the things, even when compiling with -pedantic. */
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #endif /* TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H */

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -32,6 +32,12 @@
 #define _GNU_SOURCE
 #endif
 
+/* On NetBSD, needed to include <sys/sysctl.h>, which we do in platform_util.c
+ * to get sysctl() and KERN_ARND. */
+#if defined(__NetBSD__) && !defined(_NETBSD_SOURCE)
+#define _NETBSD_SOURCE
+#endif
+
 /* On OpenBSD, needed to make <string.h> declare explicit_bzero()
  * (<strings.h> doesn't declare it). Not used on FreeBSD or NetBSD,
  * but causes Glibc to complain. */

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -45,4 +45,18 @@
 #define _BSD_SOURCE
 #endif
 
+/* On Mingw-w64, force the use of a C99-compliant printf() and friends.
+ * This is necessary on older versions of Mingw and/or Windows runtimes
+ * where snprintf does not always zero-terminate the buffer, and does
+ * not support formats such as "%zu" for size_t and "%lld" for long long.
+ *
+ * Defining __USE_MINGW_ANSI_STDIO=0 may work and provide a small code size
+ * and performance benefit for some combinations of older Mingw and Windows
+ * versions. Do this at your own risk and make sure that least
+ * test_suite_platform_printf passes.
+ */
+#if !defined(__USE_MINGW_ANSI_STDIO)
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #endif /* TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H */

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -32,4 +32,11 @@
 #define _GNU_SOURCE
 #endif
 
+/* On OpenBSD, needed to make <string.h> declare explicit_bzero()
+ * (<strings.h> doesn't declare it). Not used on FreeBSD or NetBSD,
+ * but causes Glibc to complain. */
+#if defined(__OpenBSD__) && !defined(_BSD_SOURCE)
+#define _BSD_SOURCE
+#endif
+
 #endif /* TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H */

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -1,0 +1,18 @@
+/**
+ * \file tf_psa_crypto_platform_requirements.h
+ *
+ * \brief Declare macros that tell system headers what we expect of them.
+ *
+ * This file must be included before any system header, and so in particular
+ * before build_info.h (which includes the user config, which may include
+ * system headers).
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
+#define TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
+
+#endif /* TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H */

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -15,4 +15,16 @@
 #ifndef TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 #define TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 
+#ifndef __STDC_WANT_LIB_EXT1__
+/* Ask for the C11 gmtime_s() and memset_s() if available */
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
+#if !defined(_POSIX_C_SOURCE)
+/* For standards-compliant access to
+ * clock_gettime(), gmtime_r(), ...
+ */
+#define _POSIX_C_SOURCE 200112L
+#endif
+
 #endif /* TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H */

--- a/drivers/builtin/src/platform.c
+++ b/drivers/builtin/src/platform.c
@@ -65,21 +65,6 @@ int mbedtls_platform_set_calloc_free(void *(*calloc_func)(size_t, size_t),
           !( defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&
              defined(MBEDTLS_PLATFORM_FREE_MACRO) ) */
 
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
-#include <stdarg.h>
-int mbedtls_platform_win32_snprintf(char *s, size_t n, const char *fmt, ...)
-{
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    va_list argp;
-
-    va_start(argp, fmt);
-    ret = mbedtls_vsnprintf(s, n, fmt, argp);
-    va_end(argp);
-
-    return ret;
-}
-#endif
-
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
 #if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
 /*
@@ -109,31 +94,6 @@ int mbedtls_platform_set_snprintf(int (*snprintf_func)(char *s, size_t n,
     return 0;
 }
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
-
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
-#include <stdarg.h>
-int mbedtls_platform_win32_vsnprintf(char *s, size_t n, const char *fmt, va_list arg)
-{
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-
-    /* Avoid calling the invalid parameter handler by checking ourselves */
-    if (s == NULL || n == 0 || fmt == NULL) {
-        return -1;
-    }
-
-#if defined(_TRUNCATE)
-    ret = vsnprintf_s(s, n, _TRUNCATE, fmt, arg);
-#else
-    ret = vsnprintf(s, n, fmt, arg);
-    if (ret < 0 || (size_t) ret == n) {
-        s[n-1] = '\0';
-        ret = -1;
-    }
-#endif
-
-    return ret;
-}
-#endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
 #if !defined(MBEDTLS_PLATFORM_STD_VSNPRINTF)

--- a/drivers/builtin/src/platform_util.c
+++ b/drivers/builtin/src/platform_util.c
@@ -22,6 +22,7 @@
 
 // Detect platforms known to support explicit_bzero()
 #if defined(__GLIBC__) && (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 25)
+/* Note: requires _GNU_SOURCE when compiling with -pedantic */
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
 #elif (defined(__FreeBSD__) && (__FreeBSD_version >= 1100037)) || defined(__OpenBSD__)
 #define MBEDTLS_PLATFORM_HAS_EXPLICIT_BZERO 1
@@ -287,16 +288,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
     return 0;
 }
 #else /* _WIN32 && !EFIX64 && !EFI32 */
-
-#if defined(__linux__) || defined(__midipix__)
-/* Ensure that syscall() is available even when compiling with -std=c99 */
-#if !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-#if !defined(__USE_MISC)
-#define __USE_MISC
-#endif
-#endif
 
 /*
  * Test for Linux getrandom() support.

--- a/drivers/builtin/src/platform_util.c
+++ b/drivers/builtin/src/platform_util.c
@@ -6,20 +6,6 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-/*
- * Ensure gmtime_r is available even with -std=c99; must be defined before
- * mbedtls_config.h, which pulls in glibc's features.h. Harmless on other platforms
- * except OpenBSD, where it stops us accessing explicit_bzero.
- */
-#if !defined(_POSIX_C_SOURCE) && !defined(__OpenBSD__)
-#define _POSIX_C_SOURCE 200112L
-#endif
-
-#if !defined(_GNU_SOURCE)
-/* Clang requires this to get support for explicit_bzero */
-#define _GNU_SOURCE
-#endif
-
 #include "tf_psa_crypto_common.h"
 
 #include "mbedtls/platform_util.h"
@@ -28,10 +14,6 @@
 #include "mbedtls/private/error_common.h"
 
 #include <stddef.h>
-
-#ifndef __STDC_WANT_LIB_EXT1__
-#define __STDC_WANT_LIB_EXT1__ 1 /* Ask for the C11 gmtime_s() and memset_s() if available */
-#endif
 #include <string.h>
 
 #if defined(_WIN32)

--- a/drivers/builtin/src/platform_util.c
+++ b/drivers/builtin/src/platform_util.c
@@ -148,12 +148,9 @@ void mbedtls_zeroize_and_free(void *buf, size_t len)
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>
-#if !defined(_WIN32) && (defined(unix) || \
-    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
-    defined(__MACH__)) || defined(__midipix__))
+#if defined(MBEDTLS_PLATFORM_IS_UNIXLIKE)
 #include <unistd.h>
-#endif /* !_WIN32 && (unix || __unix || __unix__ ||
-        * (__APPLE__ && __MACH__) || __midipix__) */
+#endif
 
 #if !((defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L) ||     \
     (defined(_POSIX_THREAD_SAFE_FUNCTIONS) &&                     \
@@ -219,12 +216,10 @@ void (*mbedtls_test_hook_test_fail)(const char *, int, const char *);
 #if defined(MBEDTLS_HAVE_TIME) && !defined(MBEDTLS_PLATFORM_MS_TIME_ALT)
 
 #include <time.h>
-#if !defined(_WIN32) && \
-    (defined(unix) || defined(__unix) || defined(__unix__) || \
-    (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__) || defined(__midipix__))
+#if defined(MBEDTLS_PLATFORM_IS_UNIXLIKE)
 #include <unistd.h>
-#endif \
-    /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__) || __HAIKU__ || __midipix__) */
+#endif
+
 #if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 199309L) || defined(__HAIKU__)
 mbedtls_ms_time_t mbedtls_ms_time(void)
 {
@@ -265,9 +260,9 @@ mbedtls_ms_time_t mbedtls_ms_time(void)
 
 #if defined(MBEDTLS_PSA_BUILTIN_GET_ENTROPY)
 
-#if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
-    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__MVS__)
+#if !defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) && \
+    !defined(__MVS__) /* z/OS */ &&           \
+    !defined(_WIN32)
 #error \
     "The built-in entropy sources only work on Unix and Windows. " \
     "Please enable MBEDTLS_PSA_DRIVER_GET_ENTROPY instead of " \

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -5,14 +5,6 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
-/*
- * Ensure gmtime_r is available even with -std=c99; must be defined before
- * mbedtls_config.h, which pulls in glibc's features.h. Harmless on other platforms.
- */
-#if !defined(_POSIX_C_SOURCE)
-#define _POSIX_C_SOURCE 200112L
-#endif
-
 #include "tf_psa_crypto_common.h"
 
 #if defined(MBEDTLS_THREADING_C)

--- a/drivers/builtin/src/threading.c
+++ b/drivers/builtin/src/threading.c
@@ -23,9 +23,7 @@
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 
-#if !defined(_WIN32) && (defined(unix) || \
-    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
-    defined(__MACH__)))
+#if defined(MBEDTLS_PLATFORM_IS_UNIXLIKE)
 #include <unistd.h>
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -47,15 +47,6 @@ extern "C" {
  * \{
  */
 
-/* The older Microsoft Windows common runtime provides non-conforming
- * implementations of some standard library functions, including snprintf
- * and vsnprintf. This affects MSVC and MinGW builds.
- */
-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER <= 1900)
-#define MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF
-#define MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF
-#endif
-
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,18 +54,10 @@ extern "C" {
 #include <time.h>
 #endif
 #if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
-#define MBEDTLS_PLATFORM_STD_SNPRINTF   mbedtls_platform_win32_snprintf /**< The default \c snprintf function to use.  */
-#else
 #define MBEDTLS_PLATFORM_STD_SNPRINTF   snprintf /**< The default \c snprintf function to use.  */
 #endif
-#endif
 #if !defined(MBEDTLS_PLATFORM_STD_VSNPRINTF)
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
-#define MBEDTLS_PLATFORM_STD_VSNPRINTF   mbedtls_platform_win32_vsnprintf /**< The default \c vsnprintf function to use.  */
-#else
 #define MBEDTLS_PLATFORM_STD_VSNPRINTF   vsnprintf /**< The default \c vsnprintf function to use.  */
-#endif
 #endif
 #if !defined(MBEDTLS_PLATFORM_STD_PRINTF)
 #define MBEDTLS_PLATFORM_STD_PRINTF   printf /**< The default \c printf function to use. */
@@ -208,6 +191,16 @@ extern int (*mbedtls_printf)(const char *format, ...);
  *                      function that is called when the mbedtls_snprintf()
  *                      function is invoked by the library.
  *
+ * \note
+ * The snprintf implementation should conform to C99:
+ * - it *must* always correctly zero-terminate the buffer
+ *   (except when n == 0, then it must leave the buffer untouched)
+ * - however it is acceptable to return -1 instead of the required length when
+ *   the destination buffer is too short.
+ * - It must support common modifiers in formats, including `"%zu"` for a
+ *   `size_t` parameter and `"%lld"` for a `long long` parameter.
+ * - Floating point support is not required.
+ *
  * \param printf_func   The \c printf function implementation.
  *
  * \return              \c 0 on success.
@@ -221,20 +214,6 @@ int mbedtls_platform_set_printf(int (*printf_func)(const char *, ...));
 #define mbedtls_printf     printf
 #endif /* MBEDTLS_PLATFORM_PRINTF_MACRO */
 #endif /* MBEDTLS_PLATFORM_PRINTF_ALT */
-
-/*
- * The function pointers for snprintf
- *
- * The snprintf implementation should conform to C99:
- * - it *must* always correctly zero-terminate the buffer
- *   (except when n == 0, then it must leave the buffer untouched)
- * - however it is acceptable to return -1 instead of the required length when
- *   the destination buffer is too short.
- */
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
-/* For Windows (inc. MSYS2), we provide our own fixed implementation */
-int mbedtls_platform_win32_snprintf(char *s, size_t n, const char *fmt, ...);
-#endif
 
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
 extern int (*mbedtls_snprintf)(char *s, size_t n, const char *format, ...);
@@ -257,21 +236,6 @@ int mbedtls_platform_set_snprintf(int (*snprintf_func)(char *s, size_t n,
 #define mbedtls_snprintf   MBEDTLS_PLATFORM_STD_SNPRINTF
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_MACRO */
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
-
-/*
- * The function pointers for vsnprintf
- *
- * The vsnprintf implementation should conform to C99:
- * - it *must* always correctly zero-terminate the buffer
- *   (except when n == 0, then it must leave the buffer untouched)
- * - however it is acceptable to return -1 instead of the required length when
- *   the destination buffer is too short.
- */
-#if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
-#include <stdarg.h>
-/* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
-int mbedtls_platform_win32_vsnprintf(char *s, size_t n, const char *fmt, va_list arg);
-#endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
 #include <stdarg.h>

--- a/programs/psa/CMakeLists.txt
+++ b/programs/psa/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(executables
     aead_demo
     crypto_examples
+    generate_random_uuid
     hmac_demo
     key_ladder_demo
     psa_constant_names

--- a/programs/psa/generate_random_uuid.c
+++ b/programs/psa/generate_random_uuid.c
@@ -1,0 +1,88 @@
+/*
+ *  Generate a random UUID.
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include <psa/crypto.h>
+#include <mbedtls/platform.h>
+#include <mbedtls/platform_util.h>
+#include <stdio.h> // for stdout and stderr
+
+#if !defined(MBEDTLS_PSA_CRYPTO_CLIENT)
+int main(void)
+{
+    mbedtls_printf("MBEDTLS_PSA_CRYPTO_CLIENT not defined.\r\n");
+    return EXIT_SUCCESS;
+}
+#else
+
+int main(void)
+{
+    /* Initialize the PSA subsystem.
+     *
+     * This takes care of initializing the random generator and
+     * seeding it from the configured entropy source(s) and/or
+     * a nonvolatile seed (MBEDTLS_PLATFORM_NV_SEED).
+     *
+     * In client-server builds, psa_crypto_init() connects the client
+     * to a server. The server is where the random generator lives.
+     */
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "psa_crypto_init() failed (status=%d)\n",
+                        status);
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    /* Generate random data.
+     *
+     * This probably won't fail in this toy example, because we've just
+     * initialized the random generator. But in the real world,
+     * psa_generate_random() can fail if the random generator's security
+     * policy requires reseeding and the entropy source fails.
+     * So always check the return value of psa_generate_random()!
+     */
+    unsigned char uuid[16];
+    status = psa_generate_random(uuid, sizeof(uuid));
+    if (status != PSA_SUCCESS) {
+        mbedtls_fprintf(stderr, "psa_generate_random() failed (status=%d)\n",
+                        status);
+        mbedtls_exit(MBEDTLS_EXIT_FAILURE);
+    }
+
+    /* Force the UUID variant and version bits */
+    uuid[8] = (uuid[8] & 0x3f) | 0x80; // RFC 4122
+    uuid[6] = (uuid[6] & 0x0f) | 0x40; // v4 (random)
+
+    /* Don't let stdio buffering keep a copy of the UUID.
+     *
+     * This is useful if the UUID is secret, in case the program is breached
+     * later (or the memory is reclaimed by the operating system, and the
+     * memory content leaks later before it is wiped and reused).
+     */
+    mbedtls_setbuf(stdout, NULL);
+
+    /* Print out the UUID in the standard hexadecimal representation */
+    mbedtls_printf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",
+                   uuid[0], uuid[1], uuid[2], uuid[3],
+                   uuid[4], uuid[5], uuid[6], uuid[7],
+                   uuid[8], uuid[9], uuid[10], uuid[11],
+                   uuid[12], uuid[13], uuid[14], uuid[15]);
+
+    /* Wipe the copy of the UUID in our memory.
+     *
+     * This is useful if the UUID is secret, in case the program is breached
+     * later (or the memory is reclaimed by the operating system, and the
+     * memory content leaks later before it is wiped and reused).
+     */
+    mbedtls_platform_zeroize(uuid, sizeof(uuid));
+
+    /* Free resources associated with PSA.
+     * (This will happen automatically when the program exits anyway.
+     * The main reason to call this is if you're checking that your
+     * program has no resource leaks.) */
+    mbedtls_psa_crypto_free();
+}
+#endif /* !MBEDTLS_PSA_CRYPTO_CLIENT */

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -379,20 +379,17 @@ static unsigned long mbedtls_timing_hardclock(void)
 #define HAVE_HARDCLOCK
 
 static int hardclock_init = 0;
-static struct timeval tv_init;
+static mbedtls_ms_time_t ms_time_init;
 
 static unsigned long mbedtls_timing_hardclock(void)
 {
-    struct timeval tv_cur;
-
     if (hardclock_init == 0) {
-        gettimeofday(&tv_init, NULL);
+        ms_time_init = mbedtls_ms_time();
         hardclock_init = 1;
     }
 
-    gettimeofday(&tv_cur, NULL);
-    return (tv_cur.tv_sec  - tv_init.tv_sec) * 1000000U
-           + (tv_cur.tv_usec - tv_init.tv_usec);
+    mbedtls_ms_time_t now = mbedtls_ms_time();
+    return now - ms_time_init;
 }
 #endif /* !HAVE_HARDCLOCK */
 

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -302,7 +302,12 @@ static int convert_params(size_t cnt, char **params,
  * \return      0 for success else 1
  */
 #if defined(__GNUC__)
+#  if defined(__dietlibc__)
+/* __noinline__ is a macro in dietlibc... */
+__attribute__((noinline))
+#  else
 __attribute__((__noinline__))
+#  endif
 #endif
 static int test_snprintf(size_t n, const char *ref_buf, int ref_ret)
 {

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -23,6 +23,15 @@
 #endif
 #endif
 
+/* On Mingw-w64, force the use of a C99-compliant printf() and friends.
+ * This is necessary on older versions of Mingw and/or Windows runtimes
+ * where snprintf does not always zero-terminate the buffer, and does
+ * not support formats such as "%zu" for size_t and "%lld" for long long.
+ */
+#if !defined(__USE_MINGW_ANSI_STDIO)
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #include "mbedtls/build_info.h"
 
 /* Test code may use deprecated identifiers only if the preprocessor symbol

--- a/tests/suites/test_suite_config.crypto_combinations.data
+++ b/tests/suites/test_suite_config.crypto_combinations.data
@@ -23,11 +23,3 @@ pass:
 Config: ECC: Montgomery curves only
 depends_on:!MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED:MBEDTLS_ECP_MONTGOMERY_ENABLED
 pass:
-
-Config: built-in RNG and support for static assertions
-depends_on:MBEDTLS_PSA_CRYPTO_C:!MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG:MBEDTLS_STATIC_ASSERT_SUPPORT
-pass:
-
-Config: built-in RNG and no support for static assertions
-depends_on:MBEDTLS_PSA_CRYPTO_C:!MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG:!MBEDTLS_STATIC_ASSERT_SUPPORT
-pass:

--- a/tests/suites/test_suite_platform.function
+++ b/tests/suites/test_suite_platform.function
@@ -127,7 +127,7 @@ void check_mbedtls_calloc_overallocation(intmax_t num, intmax_t size)
     unsigned char *buf;
     buf = mbedtls_calloc((size_t) num, (size_t) size);
     /* Dummy usage of the pointer to prevent optimizing it */
-    mbedtls_printf("calloc pointer : %p\n", buf);
+    mbedtls_printf("calloc pointer : %p\n", (void *) buf);
     TEST_ASSERT(buf == NULL);
 
 exit:

--- a/tests/suites/test_suite_platform_printf.data
+++ b/tests/suites/test_suite_platform_printf.data
@@ -3,58 +3,83 @@
 # and strings through the test framework.
 
 printf "%d", 0
-printf_int:"%d":0:"0"
+printf_integer:"%d":PRINTF_CAST_INT:0:"0"
 
 printf "%d", -0
-printf_int:"%d":-0:"0"
+printf_integer:"%d":PRINTF_CAST_INT:-0:"0"
 
 printf "%d", 0x0
-printf_int:"%d":0x0:"0"
+printf_integer:"%d":PRINTF_CAST_INT:0x0:"0"
 
 printf "%d", 0x00
-printf_int:"%d":0x00:"0"
+printf_integer:"%d":PRINTF_CAST_INT:0x00:"0"
 
 printf "%d", 0x000000000000000000000000000000000000000000
-printf_int:"%d":0x000000000000000000000000000000000000000000:"0"
+printf_integer:"%d":PRINTF_CAST_INT:0x000000000000000000000000000000000000000000:"0"
 
 printf "%d", -0x0
-printf_int:"%d":-0x0:"0"
+printf_integer:"%d":PRINTF_CAST_INT:-0x0:"0"
 
 printf "%d", 1
-printf_int:"%d":1:"1"
+printf_integer:"%d":PRINTF_CAST_INT:1:"1"
 
 printf "%d", 0x1
-printf_int:"%d":0x1:"1"
+printf_integer:"%d":PRINTF_CAST_INT:0x1:"1"
 
 printf "%d", 0x0000000000000000000000000000000000000000001
-printf_int:"%d":0x0000000000000000000000000000000000000000001:"1"
+printf_integer:"%d":PRINTF_CAST_INT:0x0000000000000000000000000000000000000000001:"1"
 
 printf "%d", -1
-printf_int:"%d":-1:"-1"
+printf_integer:"%d":PRINTF_CAST_INT:-1:"-1"
 
 printf "%d", -0x1
-printf_int:"%d":-0x1:"-1"
+printf_integer:"%d":PRINTF_CAST_INT:-0x1:"-1"
 
 printf "%d", -0x0000000000000000000000000000000000000000001
-printf_int:"%d":-0x0000000000000000000000000000000000000000001:"-1"
+printf_integer:"%d":PRINTF_CAST_INT:-0x0000000000000000000000000000000000000000001:"-1"
 
 printf "%d", 2147483647
-printf_int:"%d":2147483647:"2147483647"
+printf_integer:"%d":PRINTF_CAST_INT:2147483647:"2147483647"
 
 printf "%d", 0x7fffffff
-printf_int:"%d":0x7fffffff:"2147483647"
+printf_integer:"%d":PRINTF_CAST_INT:0x7fffffff:"2147483647"
 
 printf "%d", -2147483647
-printf_int:"%d":-2147483647:"-2147483647"
+printf_integer:"%d":PRINTF_CAST_INT:-2147483647:"-2147483647"
 
 printf "%d", -0x7fffffff
-printf_int:"%d":-0x7fffffff:"-2147483647"
+printf_integer:"%d":PRINTF_CAST_INT:-0x7fffffff:"-2147483647"
 
 printf "%d", -2147483648
-printf_int:"%d":-2147483648:"-2147483648"
+printf_integer:"%d":PRINTF_CAST_INT:-2147483648:"-2147483648"
 
 printf "%d", -0x80000000
-printf_int:"%d":-0x80000000:"-2147483648"
+printf_integer:"%d":PRINTF_CAST_INT:-0x80000000:"-2147483648"
+
+printf "%u", 0x80000000
+printf_integer:"%u":PRINTF_CAST_INT:-0x80000000:"2147483648"
+
+printf "%zx", 0x12345678
+printf_integer:"%zx":PRINTF_CAST_SIZE_T:0x12345678:"12345678"
+
+printf "%zu", 0x80000000
+printf_integer:"%zu":PRINTF_CAST_SIZE_T:0x80000000:"2147483648"
+
+printf "%zx", 0xffffffff
+printf_integer:"%zx":PRINTF_CAST_SIZE_T:0xffffffff:"ffffffff"
+
+printf "%zx", 0xffffffffffffffff
+depends_on:SIZE_T_AT_LEAST_64_BIT
+printf_integer:"%zx":PRINTF_CAST_SIZE_T:0xffffffffffffffff:"ffffffffffffffff"
+
+printf "%lld", 0x7fffffffffffffff
+printf_integer:"%lld":PRINTF_CAST_LONG_LONG:0x7fffffffffffffff:"9223372036854775807"
+
+printf "%lld", -0x8000000000000000
+printf_integer:"%lld":PRINTF_CAST_LONG_LONG:-0x8000000000000000:"-9223372036854775808"
+
+printf "%llx", 0x102030405060708
+printf_integer:"%llx":PRINTF_CAST_UNSIGNED_LONG_LONG:0x0102030405060708:"102030405060708"
 
 # Test that LONG_MAX is coming out untruncated through the test framework.
 printf "%lx", LONG_MAX

--- a/tests/suites/test_suite_platform_printf.function
+++ b/tests/suites/test_suite_platform_printf.function
@@ -15,6 +15,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if SIZE_MAX >= 0xffffffffffffffff
+#define SIZE_T_AT_LEAST_64_BIT
+#endif
+
+typedef enum {
+    PRINTF_CAST_INT,
+    PRINTF_CAST_UNSIGNED,
+    PRINTF_CAST_SIZE_T,
+    PRINTF_CAST_LONG,
+    PRINTF_CAST_UNSIGNED_LONG,
+    PRINTF_CAST_LONG_LONG,
+    PRINTF_CAST_UNSIGNED_LONG_LONG,
+} printf_cast_type_t;
+
 #define NEWLINE_CHAR '\n'
 #define SPACE_CHAR ' '
 #define DOUBLE_QUOTE_CHAR '"'
@@ -22,18 +36,41 @@
 #define QUESTION_CHAR '?'
 #define BACKSLASH_CHAR '\\'
 #define LOWERCASE_N_CHAR 'n'
+
 /* END_HEADER */
 
 /* BEGIN_CASE */
-void printf_int(char *format, /* any format expecting one int argument, e.g. "%d" */
-                int x, char *result)
+void printf_integer(char *format, /* format expecting one foo_t argument */
+                    int type,     /* enum value from printf_cast_type_t */
+                    intmax_t value,
+                    char *result)
 {
     char *output = NULL;
     const size_t n = strlen(result);
+    int ret = 0;
 
     /* Nominal case: buffer just large enough */
     TEST_CALLOC(output, n + 1);
-    TEST_EQUAL(n, mbedtls_snprintf(output, n + 1, format, x));
+    switch (type) {
+        case PRINTF_CAST_INT:
+            ret = mbedtls_snprintf(output, n + 1, format, (int) value);
+            break;
+        case PRINTF_CAST_UNSIGNED:
+            ret = mbedtls_snprintf(output, n + 1, format, (unsigned) value);
+            break;
+        case PRINTF_CAST_SIZE_T:
+            ret = mbedtls_snprintf(output, n + 1, format, (size_t) value);
+            break;
+        case PRINTF_CAST_LONG_LONG:
+            ret = mbedtls_snprintf(output, n + 1, format, (long long) value);
+            break;
+        case PRINTF_CAST_UNSIGNED_LONG_LONG:
+            ret = mbedtls_snprintf(output, n + 1, format, (unsigned long long) value);
+            break;
+        default:
+            TEST_FAIL("Unsupported type");
+    }
+    TEST_EQUAL(n, ret);
     TEST_MEMORY_COMPARE(result, n + 1, output, n + 1);
     mbedtls_free(output);
     output = NULL;

--- a/tests/suites/test_suite_platform_unix.data
+++ b/tests/suites/test_suite_platform_unix.data
@@ -1,0 +1,12 @@
+<unistd.h> smoke test
+unistd_available:
+
+# At the time of writing, we don't actually use CLOCK_REALTIME.
+# But it's the only clock that's guaranteed by POSIX.
+clock_gettime(CLOCK_REALTIME) smoke test
+clock_gettime_available:CLOCK_REALTIME
+
+# Used for mbedtls_ms_time() on platforms where we don't think
+# CLOCK_BOOTTIME is available.
+clock_gettime(CLOCK_MONOTONIC) smoke test
+clock_gettime_available:CLOCK_MONOTONIC

--- a/tests/suites/test_suite_platform_unix.function
+++ b/tests/suites/test_suite_platform_unix.function
@@ -1,0 +1,45 @@
+/* BEGIN_HEADER */
+/* Test access to the Unix primitives used in platform_util.c and elsewhere.
+ * We aren't testing that they work, just getting an easy-to-understand
+ * diagnostic if they aren't available.
+ * (There is a separate test suite for the platform_util.h interfacces.)
+ */
+
+#include <mbedtls/platform_util.h>
+#include <mbedtls/platform.h>
+#include "tf_psa_crypto_common.h"
+
+#if defined(MBEDTLS_PLATFORM_IS_UNIXLIKE)
+
+#include <time.h>
+#include <unistd.h>
+
+#endif /* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) */
+
+/* END_HEADER */
+
+/* Note: we can't make the whole test suite depend on
+ * MBEDTLS_PLATFORM_IS_UNIXLIKE, because file-level dependencies can only
+ * come from build_info.h, platform.h or some test helper headers, not
+ * from internal macros. */
+/* BEGIN_DEPENDENCIES
+ * END_DEPENDENCIES */
+
+/* BEGIN_CASE depends_on:MBEDTLS_PLATFORM_IS_UNIXLIKE */
+void unistd_available()
+{
+    pid_t pid = getpid();
+    TEST_LE_S(1, pid);
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_PLATFORM_IS_UNIXLIKE */
+void clock_gettime_available(int clockid)
+{
+    struct timespec ts = { 0, 0 };
+    memset(&ts, 0, sizeof(ts));
+    int ret = clock_gettime(clockid, &ts);
+    TEST_ASSERT_ERRNO(ret == 0);
+    TEST_LE_S(1, ts.tv_sec);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_platform_unix.function
+++ b/tests/suites/test_suite_platform_unix.function
@@ -17,8 +17,12 @@
 #else /* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) */
 
 /* Constants used in the test data need to be defined even if no test
- * functions that use them are enabled. */
+ * functions that use them are enabled.
+ * Undefine the macros first in case a system header does define them
+ * even though we haven't recognized the platform as Unix-like. */
+#undef CLOCK_REALTIME
 #define CLOCK_REALTIME 0
+#undef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 0
 
 #endif /* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) */

--- a/tests/suites/test_suite_platform_unix.function
+++ b/tests/suites/test_suite_platform_unix.function
@@ -14,6 +14,13 @@
 #include <time.h>
 #include <unistd.h>
 
+#else /* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) */
+
+/* Constants used in the test data need to be defined even if no test
+ * functions that use them are enabled. */
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 0
+
 #endif /* defined(MBEDTLS_PLATFORM_IS_UNIXLIKE) */
 
 /* END_HEADER */

--- a/tests/suites/test_suite_platform_unix.function
+++ b/tests/suites/test_suite_platform_unix.function
@@ -51,6 +51,6 @@ void clock_gettime_available(int clockid)
     memset(&ts, 0, sizeof(ts));
     int ret = clock_gettime(clockid, &ts);
     TEST_ASSERT_ERRNO(ret == 0);
-    TEST_LE_S(1, ts.tv_sec);
+    TEST_ASSERT(ts.tv_sec != 0 || ts.tv_nsec != 0);
 }
 /* END_CASE */


### PR DESCRIPTION
Resolve https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/675

* Rewrite `MBEDTLS_STATIC_ASSERT` and make it actually assert everywhere. This may work on extremely exotic C99-but-not-C11 compilers or compiler warnings.
* Move feature requirement macros that need to be defined before including any system header to a new dedicated header `core/tf_psa_crypto_platform_requirements.h`.
* Redo feature requirement macros from scratch, so that they're simpler and justified. This could cause “exotic” platforms to break.
* Always use C99-compliant printf on MingW, removing the need for `MBEDTLS_PRINTF_SIZET` in `debug.h`.
* Remove the use of `gettimeofday()` (we use `clock_gettime()` for `mbedtls_ms_time()`.

Needs preceding PR: 
* [x] [Stop using `gettimeofday()` in Mbed TLS](https://github.com/Mbed-TLS/mbedtls/pull/10607) (needed to fix the build on FreeBSD)
* [x] framework https://github.com/Mbed-TLS/mbedtls-framework/pull/279
* [x] Prepare mbedtls for the MingW change: https://github.com/Mbed-TLS/mbedtls/pull/10625

## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10606
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/694
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/279
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10621 (only a small part that isn't disruptive)
- **tests**  provided + local testing (see https://github.com/Mbed-TLS/mbedtls/pull/10606)
