### PR TITLE
programs/fuzz: Fixed an MSVC compilation warning

### DIFF
--- a/programs/fuzz/fuzz_onefile.c
+++ b/programs/fuzz/fuzz_onefile.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
         return 1;
     }
     //opens the file, get its size, and reads it into a buffer
-    #ifdef WIN32
+    #if defined(_WIN32)
     errno_t err = 0;
     err = fopen_s(&fp, argv[1], "rb");
     if (err != 0) {

--- a/programs/fuzz/fuzz_onefile.c
+++ b/programs/fuzz/fuzz_onefile.c
@@ -1,9 +1,9 @@
 #define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 
+#include "fuzz_common.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "fuzz_common.h"
 
 /* Include a version of  build_info.h anyway in case it contains
  * platform-specific #defines related to malloc or stdio
@@ -23,21 +23,12 @@ int main(int argc, char **argv)
         return 1;
     }
     //opens the file, get its size, and reads it into a buffer
-    #if defined(_WIN32)
-    errno_t err = 0;
-    err = fopen_s(&fp, argv[1], "rb");
-    if (err != 0) {
-        fprintf(stderr, "%s: Error in fopen\n", argv0);
-        return err;
-    }
-    #else
     fp = fopen(argv[1], "rb");
     if (fp == NULL) {
         fprintf(stderr, "%s: Error in fopen\n", argv0);
         perror(argv[1]);
         return 2;
     }
-    #endif /* WIN32*/
 
     if (fseek(fp, 0L, SEEK_END) != 0) {
         fprintf(stderr, "%s: Error in fseek(SEEK_END)\n", argv0);


### PR DESCRIPTION
## Description

Resolves Mbed-TLS/mbedtls#10604


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: It fixes a bug in a program that is part of the library
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not required because: The reference program resides here
- [ ] **mbedtls 3.6 PR** not required because: Offending code does not exist in the equivalent program
- **tests**  provided | not required because: Testing programs is outside of the scope of our framework
