### PR TITLE
Use an array for an unused byte

### DIFF
--- a/tests/suites/test_suite_sha3.function
+++ b/tests/suites/test_suite_sha3.function
@@ -133,7 +133,7 @@ void sha3_empty(int type, int len)
     uint8_t *output_update_null = NULL;
     uint8_t *output_update_nonnull = NULL;
     uint8_t *output_update_twice = NULL;
-    uint8_t byte = 'b';
+    uint8_t byte[1] = { 'b' };
 
     TEST_CALLOC(output_no_update, len);
     TEST_CALLOC(output_update_null, len);
@@ -148,12 +148,12 @@ void sha3_empty(int type, int len)
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output_update_null, len), 0);
 
     TEST_EQUAL(mbedtls_sha3_starts(&ctx, type), 0);
-    TEST_EQUAL(mbedtls_sha3_update(&ctx, &byte, 0), 0);
+    TEST_EQUAL(mbedtls_sha3_update(&ctx, byte, 0), 0);
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output_update_nonnull, len), 0);
 
     TEST_EQUAL(mbedtls_sha3_starts(&ctx, type), 0);
-    TEST_EQUAL(mbedtls_sha3_update(&ctx, &byte, 0), 0);
-    TEST_EQUAL(mbedtls_sha3_update(&ctx, &byte, 0), 0);
+    TEST_EQUAL(mbedtls_sha3_update(&ctx, byte, 0), 0);
+    TEST_EQUAL(mbedtls_sha3_update(&ctx, byte, 0), 0);
     TEST_EQUAL(mbedtls_sha3_finish(&ctx, output_update_twice, len), 0);
 
     TEST_MEMORY_COMPARE(output_no_update, 0, output_update_null, 0);


### PR DESCRIPTION
The code is fine either way. But using an array avoids a false positive from Coverity about using a scalar as an array (Coverity doesn't notice that it's an array of length 0).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided | not required because: test only
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: code not in 3.6
- **tests**  provided | not required because: 
