### PR TITLE
builtin: add support for RSASSA-PSS in mbedtls_pk_parse_subpubkey

### DIFF
--- a/ChangeLog.d/rsassa-pss-parsing.txt
+++ b/ChangeLog.d/rsassa-pss-parsing.txt
@@ -1,0 +1,2 @@
+Changes
+    * Certificates and CSRs containing rsassaPss keys can now be parsed

--- a/drivers/builtin/src/crypto_oid.h
+++ b/drivers/builtin/src/crypto_oid.h
@@ -102,6 +102,12 @@
 #define MBEDTLS_OID_PKCS1_RSA           MBEDTLS_OID_PKCS1 "\x01" /**< rsaEncryption OBJECT IDENTIFIER ::= { pkcs-1 1 } */
 
 /*
+ * RFC 4055
+ */
+#define MBEDTLS_OID_RSASSA_PSS          MBEDTLS_OID_PKCS1 "\x0a" /**< id-RSASSA-PSS ::= { pkcs-1 10 } */
+
+
+/*
  * Digest algorithms
  */
 #define MBEDTLS_OID_DIGEST_ALG_MD5              MBEDTLS_OID_RSA_COMPANY "\x02\x05" /**< id-mbedtls_md5 OBJECT IDENTIFIER ::= { iso(1) member-body(2) us(840) rsadsi(113549) digestAlgorithm(2) 5 } */

--- a/drivers/builtin/src/oid.c
+++ b/drivers/builtin/src/oid.c
@@ -125,6 +125,10 @@ static const oid_pk_alg_t oid_pk_alg[] =
         MBEDTLS_PK_RSA,
     },
     {
+        OID_DESCRIPTOR(MBEDTLS_OID_RSASSA_PSS,          "rsassaPss",        "RSASSA-PSS"),
+        MBEDTLS_PK_RSASSA_PSS,
+    },
+    {
         OID_DESCRIPTOR(MBEDTLS_OID_EC_ALG_UNRESTRICTED, "id-ecPublicKey",   "Generic EC key"),
         MBEDTLS_PK_ECKEY,
     },

--- a/drivers/builtin/src/pk.c
+++ b/drivers/builtin/src/pk.c
@@ -99,6 +99,7 @@ const mbedtls_pk_info_t *mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type)
     switch (pk_type) {
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
         case MBEDTLS_PK_RSA:
+        case MBEDTLS_PK_RSASSA_PSS:
             return &mbedtls_rsa_info;
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
 #if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)

--- a/drivers/builtin/src/pkparse.c
+++ b/drivers/builtin/src/pkparse.c
@@ -19,6 +19,7 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/private/error_common.h"
 #include "mbedtls/private/ecp.h"
+#include "mbedtls/private/rsa.h"
 #include "pk_internal.h"
 
 #include <string.h>
@@ -544,7 +545,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
     }
 
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
-    if (pk_alg == MBEDTLS_PK_RSA) {
+    if (pk_alg == MBEDTLS_PK_RSA || pk_alg == MBEDTLS_PK_RSASSA_PSS) {
         ret = mbedtls_pk_rsa_set_pubkey(pk, *p, (size_t) (end - *p));
         if (ret == 0) {
             /* On success all the input has been consumed by the parsing function. */
@@ -555,6 +556,10 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
             ret = MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_INVALID_PUBKEY, ret);
         } else {
             ret = MBEDTLS_ERR_PK_INVALID_PUBKEY;
+        }
+        /* For RSASSA-PSS, the padding must be set (by default, it is PKCS#1 v1.5) */
+        if (pk_alg == MBEDTLS_PK_RSASSA_PSS) {
+            ret = mbedtls_rsa_set_padding((mbedtls_rsa_context *) pk, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_NONE); 
         }
     } else
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */


### PR DESCRIPTION
## Description

This PR enables to parse certificates and CSRs containing a public key of type rsassaPss

Fixes Mbed-TLS/mbedtls#10580

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#287
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10632
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10633
- [x] **tests**  provided