### PR TITLE
Backport 1.1: IAR build fixes after 1.1.0

### DIFF
--- a/ChangeLog.d/iar-1.1.0.txt
+++ b/ChangeLog.d/iar-1.1.0.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix some IAR warnings.

--- a/core/tf_psa_crypto_common.h
+++ b/core/tf_psa_crypto_common.h
@@ -26,6 +26,30 @@
  * headers what we expect of them. */
 #include "tf_psa_crypto_platform_requirements.h"
 
+#if defined(__IAR_SYSTEMS_ICC__)
+/* In IAR (at least IAR 9.40 for Arm), enabling the C11 annex K functions
+ * (memset_s(), memcpy_s(), ...) with `#define __STDC_WANT_LIB_EXT1__ 1`
+ * causes the non-s functions to be declared as deprecatd. We want some
+ * s functions (specifically memset_s() and gmtime_s()), but we also want
+ * to be able to use the non-s functions. Try to hack around this:
+ *
+ * - tf_psa_crypto_platform_requirements.h enables annex K functions.
+ * - tf_psa_crypto_platform_requirements.h does not include any system
+ *   header, so that a parent project such as Mbed TLS can declare
+ *   more platform requirements after including only
+ *   tf_psa_crypto_platform_requirements.h.
+ * - Then, here, we include a system header that causes the effects of
+ *   `__STDC_WANT_LIB_EXT1__` to be analyzed.
+ * - These effects include the definition of the macro `__DEPREC`, but
+ *   not yet the declaration of functions that use it (because stddef.h
+ *   doesn't declare any affected function). We redeclare this macro
+ *   to make the subsequent function declarations not be deprecated.
+ */
+#include <stddef.h>
+#undef __DEPREC
+#define __DEPREC
+#endif
+
 /* From this point onwards, ensure we have the library configuration and
  * the configuration-derived macros. */
 #include "tf-psa-crypto/build_info.h"

--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -18,6 +18,8 @@
 #ifndef __STDC_WANT_LIB_EXT1__
 /* Ask for the C11 gmtime_s() and memset_s() if available */
 #define __STDC_WANT_LIB_EXT1__ 1
+/* This causes IAR to deprecate non-s functions that have an Annex K
+ * equivalent. We hack around this in tf_psa_crypto_common.h. */
 #endif
 
 #if !defined(_POSIX_C_SOURCE)

--- a/drivers/builtin/src/aes.c
+++ b/drivers/builtin/src/aes.c
@@ -498,10 +498,11 @@ mbedtls_aes_implementation mbedtls_aes_get_implementation(void)
     }
 #endif
 
-#if !defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+#if defined(MBEDTLS_AES_USE_HARDWARE_ONLY)
+    return MBEDTLS_AES_IMP_UNKNOWN;
+#else
     return MBEDTLS_AES_IMP_SOFTWARE;
 #endif
-    return MBEDTLS_AES_IMP_UNKNOWN;
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)

--- a/drivers/builtin/src/bignum.c
+++ b/drivers/builtin/src/bignum.c
@@ -38,7 +38,14 @@
 
 #include "mbedtls/platform.h"
 
-
+#if defined(__IAR_SYSTEMS_ICC__)
+/* Suppress a very overeager warning from IAR: it dislikes a forward goto
+ * that bypasses the initialization of a variable, even if that variable
+ * is not used after the jump. (This is perfectly valid C; it would only
+ * be invalid C if jumping into a block from outside that block.)
+ */
+#pragma diag_suppress=Pe546 // transfer of control bypasses initialization
+#endif
 
 /*
  * Conditionally select an MPI sign in constant time.

--- a/drivers/builtin/src/psa_crypto_cipher.c
+++ b/drivers/builtin/src/psa_crypto_cipher.c
@@ -20,6 +20,15 @@
 
 #include <string.h>
 
+#if defined(__IAR_SYSTEMS_ICC__)
+/* Suppress a very overeager warning from IAR: it dislikes a forward goto
+ * that bypasses the initialization of a variable, even if that variable
+ * is not used after the jump. (This is perfectly valid C; it would only
+ * be invalid C if jumping into a block from outside that block.)
+ */
+#pragma diag_suppress=Pe546 // transfer of control bypasses initialization
+#endif
+
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER) || \
     defined(MBEDTLS_PSA_BUILTIN_AEAD) || \
     defined(MBEDTLS_PSA_BUILTIN_KEY_TYPE_AES) || \

--- a/platform/platform_util.c
+++ b/platform/platform_util.c
@@ -89,7 +89,7 @@ void mbedtls_platform_zeroize(void *buf, size_t len)
          */
         __msan_unpoison(buf, len);
 #endif
-#elif defined(__STDC_LIB_EXT1__) && !defined(__IAR_SYSTEMS_ICC__)
+#elif defined(__STDC_LIB_EXT1__)
         memset_s(buf, len, 0, len);
 #elif defined(_WIN32)
         SecureZeroMemory(buf, len);

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -39,7 +39,7 @@ static int verify_int(char *str, intmax_t *p_value)
     /* Limit the range to long: for large integers, the test framework will
      * use expressions anyway. */
     long value = strtol(str, &end, 0);
-    if (errno == EINVAL || *end != '\0') {
+    if (*end != '\0' || end == str) {
         mbedtls_fprintf(stderr,
                         "Expected integer for parameter and got: %s\n", str);
         return KEY_VALUE_MAPPING_NOT_FOUND;

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -55,6 +55,15 @@ __MBEDTLS_TEST_TEMPLATE__TEST_COMMON_HELPERS
 /* Test Suite Code */
 
 
+#if defined(__IAR_SYSTEMS_ICC__)
+/* Suppress a very overeager warning from IAR: it dislikes a forward goto
+ * that bypasses the initialization of a variable, even if that variable
+ * is not used after the jump. (This is perfectly valid C; it would only
+ * be invalid C if jumping into a block from outside that block.)
+ */
+#pragma diag_suppress=Pe546 // transfer of control bypasses initialization
+#endif
+
 #define TEST_SUITE_ACTIVE
 
 __MBEDTLS_TEST_TEMPLATE__FUNCTIONS_CODE
@@ -218,7 +227,6 @@ static int check_test(size_t func_idx)
 
     return ret;
 }
-
 
 __MBEDTLS_TEST_TEMPLATE__PLATFORM_CODE
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -68,6 +68,15 @@ __MBEDTLS_TEST_TEMPLATE__TEST_COMMON_HELPERS
  * be invalid C if jumping into a block from outside that block.)
  */
 #pragma diag_suppress=Pe546 // transfer of control bypasses initialization
+
+/* Temporarily suppress a perfectly reasonable warning from IAR that
+ * comes up very often in our unit tests: silent conversion of int to
+ * an enum type.
+ *
+ * Remove this when https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/707
+ * is fixed.
+ */
+#pragma diag_suppress=Pe188 // enumerated type mixed with another type
 #endif
 
 #define TEST_SUITE_ACTIVE

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -32,6 +32,12 @@
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
 
+#if defined(__IAR_SYSTEMS_ICC__)
+/* With IAR, enable support for ::FILE functions in stdio.h.
+ */
+#define _DLIB_FILE_DESCRIPTOR 1
+#endif
+
 #include "mbedtls/build_info.h"
 
 /* Test code may use deprecated identifiers only if the preprocessor symbol

--- a/tests/suites/test_suite_alignment.function
+++ b/tests/suites/test_suite_alignment.function
@@ -158,12 +158,6 @@ void mbedtls_byteswap(char *input_str, int size, char *expected_str)
 /* BEGIN_CASE */
 void get_byte()
 {
-    uint8_t data[16];
-
-    for (size_t i = 0; i < sizeof(data); i++) {
-        data[i] = (uint8_t) i;
-    }
-
     uint64_t u64 = 0x0706050403020100;
     for (size_t b = 0; b < 8; b++) {
         uint8_t expected = b;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -827,8 +827,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
                 /* Error didn't trigger, make test fail */
                 if (inject_error == 1) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -933,8 +933,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
                 /* Error didn't trigger, make test fail */
                 if (inject_error == 1) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -1001,8 +1001,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
             /* Error didn't trigger, make test fail */
             if (inject_error == 2) {
-                TEST_ASSERT(
-                    !"One of the last psa_pake_input() calls should have returned the expected error.");
+                TEST_FAIL(
+                    "One of the last psa_pake_input() calls should have returned the expected error.");
             }
 
             break;
@@ -1068,8 +1068,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
                 /* Error didn't trigger, make test fail */
                 if (inject_error == 3) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -1128,8 +1128,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
                 /* Error didn't trigger, make test fail */
                 if (inject_error == 3) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -1168,8 +1168,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
 
             /* Error didn't trigger, make test fail */
             if (inject_error == 4) {
-                TEST_ASSERT(
-                    !"One of the last psa_pake_input() calls should have returned the expected error.");
+                TEST_FAIL(
+                    "One of the last psa_pake_input() calls should have returned the expected error.");
             }
 
             break;

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -254,8 +254,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
                 /* Error didn't trigger, make test fail */
                 if ((err_stage >= ERR_INJECT_ROUND1_SERVER_KEY_SHARE_PART1) &&
                     (err_stage <= ERR_INJECT_ROUND1_SERVER_ZK_PROOF_PART2)) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -348,8 +348,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
                 /* Error didn't trigger, make test fail */
                 if ((err_stage >= ERR_INJECT_ROUND1_SERVER_KEY_SHARE_PART1) &&
                     (err_stage <= ERR_INJECT_ROUND1_SERVER_ZK_PROOF_PART2)) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -381,8 +381,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
             /* Error didn't trigger, make test fail */
             if ((err_stage >= ERR_INJECT_ROUND1_CLIENT_KEY_SHARE_PART1) &&
                 (err_stage <= ERR_INJECT_ROUND1_CLIENT_ZK_PROOF_PART2)) {
-                TEST_ASSERT(
-                    !"One of the last psa_pake_input() calls should have returned the expected error.");
+                TEST_FAIL(
+                    "One of the last psa_pake_input() calls should have returned the expected error.");
             }
 
             break;
@@ -437,8 +437,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
                 /* Error didn't trigger, make test fail */
                 if ((err_stage >= ERR_INJECT_ROUND2_SERVER_KEY_SHARE) &&
                     (err_stage <= ERR_INJECT_ROUND2_SERVER_ZK_PROOF)) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -501,8 +501,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
                 /* Error didn't trigger, make test fail */
                 if ((err_stage >= ERR_INJECT_ROUND2_SERVER_KEY_SHARE) &&
                     (err_stage <= ERR_INJECT_ROUND2_SERVER_ZK_PROOF)) {
-                    TEST_ASSERT(
-                        !"One of the last psa_pake_input() calls should have returned the expected error.");
+                    TEST_FAIL(
+                        "One of the last psa_pake_input() calls should have returned the expected error.");
                 }
             }
 
@@ -528,8 +528,8 @@ static void ecjpake_do_round(psa_algorithm_t alg, unsigned int primitive,
             /* Error didn't trigger, make test fail */
             if ((err_stage >= ERR_INJECT_ROUND2_CLIENT_KEY_SHARE) &&
                 (err_stage <= ERR_INJECT_ROUND2_CLIENT_ZK_PROOF)) {
-                TEST_ASSERT(
-                    !"One of the last psa_pake_input() calls should have returned the expected error.");
+                TEST_FAIL(
+                    "One of the last psa_pake_input() calls should have returned the expected error.");
             }
 
             break;

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -832,7 +832,7 @@ void mbedtls_rsa_validate_params(char *input_N,
                                             have_D ? &D : NULL,
                                             have_E ? &E : NULL,
                                             prng ? mbedtls_test_rnd_std_rand : NULL,
-                                            prng ? NULL : NULL) == result);
+                                            NULL) == result);
 
 exit:
     mbedtls_mpi_free(&N);


### PR DESCRIPTION
Fix the build of the library and the unit tests with IAR.

This is the 1.1 version. I'll do the development version once the 1.1 version is approved or close to being appoved, since development is a moving target and there's already one more warning (in the new MLDSA code) now.

The build was already broken in 1.0.0, but https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/694 made it worse by adding deprecation warnings on the use of many standard library functions.

Needs preceding PR: submodule update, although this is only needed to actually fix the IAR build, not to pass our CI.

Needs preceding PR:
* [x] https://github.com/Mbed-TLS/mbedtls-framework/pull/289
* [ ] https://github.com/Mbed-TLS/mbedtls-framework/pull/299

## PR checklist

- [x] **changelog** provided
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10635
- [ ] **mbedtls 4.1 PR** TODO
- [ ] **TF-PSA-Crypto development PR** TODO
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/708
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/289; https://github.com/Mbed-TLS/mbedtls-framework/pull/299
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10636 
- **tests**  built (but did not link) the library, the unit test support code and the unit tests (but not the programs) in the baremetal config with IAR 9.40 for Arm
