### PR TITLE
psa: parenthesize truncation test in PSA_MAC_LENGTH

### DIFF
--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -311,7 +311,7 @@
  *                      with the algorithm.
  */
 #define PSA_MAC_LENGTH(key_type, key_bits, alg)                                   \
-    ((alg) & PSA_ALG_MAC_TRUNCATION_MASK ? PSA_MAC_TRUNCATED_LENGTH(alg) :        \
+    (((alg) & PSA_ALG_MAC_TRUNCATION_MASK) ? PSA_MAC_TRUNCATED_LENGTH(alg) :      \
      PSA_ALG_IS_HMAC(alg) ? PSA_HASH_LENGTH(PSA_ALG_HMAC_GET_HASH(alg)) :         \
      PSA_ALG_IS_BLOCK_CIPHER_MAC(alg) ? PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type) : \
      ((void) (key_type), (void) (key_bits), 0u))


### PR DESCRIPTION
## Description

This makes the `PSA_MAC_LENGTH` macro’s `PSA_ALG_MAC_TRUNCATION_MASK` check explicit, avoiding precedence surprises in the ternary condition. This gets picked up by static checkers such as `cppcheck` to avoid implicit reliance to operator precedence where bitwise operations are involved, i.e. `Clarify calculation precedence for '&' and '?'. [clarifyCalculation]`.

## PR checklist
- [x] **changelog** not required because: Trivial
- [x] **framework PR**  not required
- [x] **mbedtls development PR** not required because: Not strictly needed
- [x] **mbedtls 3.6 PR** not required because: No backport - supresses a warning, not bugfix
- **tests**  not required because: Trivial
