### PR TITLE
Add 1.1 line to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,12 @@ Please remove the segment/s on either side of the | symbol as appropriate, and a
 If the provided content is part of the present PR remove the # symbol.
 
 - [ ] **changelog** provided | not required because: 
-- [ ] **prerequisite framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **backport 1.1 PR** provided # | not required because: 
-- [ ] **consuming mbedtls PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **backport mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
+- [ ] **TF-PSA-Crypto development PR** provided # | not required because: 
+- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
+- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **mbedtls 4.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ If the provided content is part of the present PR remove the # symbol.
 
 - [ ] **changelog** provided | not required because: 
 - [ ] **prerequisite framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **backport 1.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **backport 1.1 PR** provided # | not required because: 
 - [ ] **consuming mbedtls PR** provided Mbed-TLS/mbedtls# | not required because: 
 - [ ] **backport mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ If the provided content is part of the present PR remove the # symbol.
 
 - [ ] **changelog** provided | not required because: 
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
+- [ ] **1.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
 - [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,10 @@ Please remove the segment/s on either side of the | symbol as appropriate, and a
 If the provided content is part of the present PR remove the # symbol.
 
 - [ ] **changelog** provided | not required because: 
-- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **1.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **prerequisite framework PR** provided Mbed-TLS/mbedtls-framework# | not required
+- [ ] **backport 1.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **consuming mbedtls PR** provided Mbed-TLS/mbedtls# | not required because: 
+- [ ] **backport mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
 - **tests**  provided | not required because: 
 
 


### PR DESCRIPTION
Starting now, pull requests may need backports to the upcoming LTS branches (TF-PSA-Crypto 1.1 and Mbed TLS 4.1).

## PR checklist

- [x] **changelog** provided | not required because: github only
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/290
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/719
- [x] **TF-PSA-Crypto 1.1 PR** not required because: only for default branch
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10647
- [x] **mbedtls 4.1 PR** not required because: only for default branch
- [x] **mbedtls 3.6 PR** not required because: only for default branch
- **tests**  not required because: no code
