### PR TITLE
psa_crypto.c: Fix ifdefs to avoid build warning

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -6958,7 +6958,9 @@ static int psa_key_derivation_allows_free_form_secret_input(
 psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
                                       psa_algorithm_t alg)
 {
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     psa_status_t status;
+#endif
 
     if (operation->alg != 0) {
         return PSA_ERROR_BAD_STATE;
@@ -6991,10 +6993,12 @@ psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     if (status == PSA_SUCCESS) {
         operation->alg = alg;
     }
     return status;
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 }
 
 #if defined(BUILTIN_ALG_ANY_HKDF)


### PR DESCRIPTION
## Description

Add a couple of missing ifdefs to avoid having unreachable code with AT_LEAST_ONE_BUILTIN_KDF not defined, which otherwise causes a build warning with clang.

## PR checklist

- [x] **changelog** not required because: Just a build warning fix
- [x] **framework PR** not required
- [x] **mbedtls development PR**  not required because: no changes
- [x] **mbedtls 3.6 PR**  provided: https://github.com/Mbed-TLS/mbedtls/pull/10679
- [x] **tf-psa-crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/741
- **tests**: not required: no new code to be tested