### PR TITLE
cmake: make Thread package search quiet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ endif()
 # We now potentially need to link all executables against PThreads, if available
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
+find_package(Threads QUIET)
 
 # If this is the root project add longer list of available CMAKE_BUILD_TYPE values
 if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)


### PR DESCRIPTION
## Description

This prevents printing message

"-- Could NOT find Threads (missing: Threads_FOUND)"

on platforms like Zephyr where threading is not provided by standard libraries.

## PR checklist

- [ ] **changelog** not required because: minor CMake message removal
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10649
- [ ] **mbedtls 3.6 PR** not required because: not backported
- **tests** not required because: only cmake change