### PR TITLE
Add outcome analysis to TF-PSA-Crypto

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,10 @@
+default:
+	@echo "This makefile only supports generating test data and key files."
+	@echo "It does not support actually building the test code."
+	@echo "The only officially supported build tool is CMake."
+	false
+
+include crypto-tests.make
+
+generated_files: $(TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES)
+generated_files: $(TF_PSA_CRYPTO_TESTS_GENERATED_C_FILES)

--- a/tests/crypto-tests.make
+++ b/tests/crypto-tests.make
@@ -2,7 +2,13 @@
 # This file is only meant to be included by tests/Makefile in Mbed TLS and
 # is unlikely to work in another context.
 
-GENERATED_BIGNUM_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+ifeq ($(origin TF_PSA_CRYPTO_PATH), undefined)
+  TF_PSA_CRYPTO_PATH := ..
+else ifeq ($(TF_PSA_CRYPTO_PATH),)
+  TF_PSA_CRYPTO_PATH := .
+endif
+
+GENERATED_BIGNUM_DATA_FILES := $(addprefix $(TF_PSA_CRYPTO_PATH)/,$(shell \
 	$(PYTHON) ../framework/scripts/generate_bignum_tests.py --list || \
 	echo FAILED \
 ))
@@ -27,15 +33,15 @@ generated_bignum_test_data: ../framework/scripts/mbedtls_framework/test_case.py
 generated_bignum_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
 generated_bignum_test_data:
 	echo "  Gen   $(GENERATED_BIGNUM_DATA_FILES)"
-	$(PYTHON) ../framework/scripts/generate_bignum_tests.py --directory ../tf-psa-crypto/tests/suites
+	$(PYTHON) ../framework/scripts/generate_bignum_tests.py --directory $(TF_PSA_CRYPTO_PATH)/tests/suites
 .SECONDARY: generated_bignum_test_data
 
-GENERATED_CRYPTO_CONFIG_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
-	$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_config_tests.py --list || \
+GENERATED_CRYPTO_CONFIG_DATA_FILES := $(addprefix $(TF_PSA_CRYPTO_PATH)/,$(shell \
+	$(PYTHON) $(TF_PSA_CRYPTO_PATH)/framework/scripts/generate_config_tests.py --list || \
 	echo FAILED \
 ))
 ifeq ($(GENERATED_CRYPTO_CONFIG_DATA_FILES),FAILED)
-$(error "$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_config_tests.py --list" failed)
+$(error "$(PYTHON) $(TF_PSA_CRYPTO_PATH)/framework/scripts/generate_config_tests.py --list" failed)
 endif
 TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES += $(GENERATED_CRYPTO_CONFIG_DATA_FILES)
 
@@ -52,10 +58,10 @@ generated_crypto_config_test_data: ../framework/scripts/mbedtls_framework/test_c
 generated_crypto_config_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
 generated_crypto_config_test_data:
 	echo "  Gen   $(GENERATED_CRYPTO_CONFIG_DATA_FILES)"
-	cd ../tf-psa-crypto && $(PYTHON) ./framework/scripts/generate_config_tests.py
+	cd $(TF_PSA_CRYPTO_PATH) && $(PYTHON) ./framework/scripts/generate_config_tests.py
 .SECONDARY: generated_crypto_config_test_data
 
-GENERATED_ECP_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+GENERATED_ECP_DATA_FILES := $(addprefix $(TF_PSA_CRYPTO_PATH)/,$(shell \
 	$(PYTHON) ../framework/scripts/generate_ecp_tests.py --list || \
 	echo FAILED \
 ))
@@ -72,10 +78,10 @@ generated_ecp_test_data: ../framework/scripts/mbedtls_framework/test_case.py
 generated_ecp_test_data: ../framework/scripts/mbedtls_framework/test_data_generation.py
 generated_ecp_test_data:
 	echo "  Gen   $(GENERATED_ECP_DATA_FILES)"
-	$(PYTHON) ../framework/scripts/generate_ecp_tests.py --directory ../tf-psa-crypto/tests/suites
+	$(PYTHON) ../framework/scripts/generate_ecp_tests.py --directory $(TF_PSA_CRYPTO_PATH)/tests/suites
 .SECONDARY: generated_ecp_test_data
 
-GENERATED_PSA_DATA_FILES := $(addprefix ../tf-psa-crypto/,$(shell \
+GENERATED_PSA_DATA_FILES := $(addprefix $(TF_PSA_CRYPTO_PATH)/,$(shell \
 	$(PYTHON) ../framework/scripts/generate_psa_tests.py --list || \
 	echo FAILED \
 ))
@@ -99,13 +105,13 @@ generated_psa_test_data: ../framework/scripts/mbedtls_framework/test_data_genera
 ## file all the time when switching between configurations, don't declare
 ## crypto_config.h as a dependency. Remove this file from your working tree
 ## if you've just added or removed an option in crypto_config.h.
-#generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_config.h
-generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_values.h
-generated_psa_test_data: ../tf-psa-crypto/include/psa/crypto_extra.h
-generated_psa_test_data: ../tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data
+#generated_psa_test_data: $(TF_PSA_CRYPTO_PATH)/include/psa/crypto_config.h
+generated_psa_test_data: $(TF_PSA_CRYPTO_PATH)/include/psa/crypto_values.h
+generated_psa_test_data: $(TF_PSA_CRYPTO_PATH)/include/psa/crypto_extra.h
+generated_psa_test_data: $(TF_PSA_CRYPTO_PATH)/tests/suites/test_suite_psa_crypto_metadata.data
 generated_psa_test_data:
 	echo "  Gen   $(GENERATED_PSA_DATA_FILES) ..."
-	$(PYTHON) ../framework/scripts/generate_psa_tests.py --directory ../tf-psa-crypto/tests/suites
+	$(PYTHON) ../framework/scripts/generate_psa_tests.py --directory $(TF_PSA_CRYPTO_PATH)/tests/suites
 .SECONDARY: generated_psa_test_data
 
 TF_PSA_CRYPTO_TESTS_DATA_FILES = $(filter-out $(TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES), $(wildcard $(TF_PSA_CRYPTO_PATH)/tests/suites/test_suite_*.data))
@@ -113,9 +119,9 @@ TF_PSA_CRYPTO_TESTS_DATA_FILES = $(filter-out $(TF_PSA_CRYPTO_TESTS_GENERATED_DA
 # exist yet when the makefile is parsed.
 TF_PSA_CRYPTO_TESTS_DATA_FILES += $(TF_PSA_CRYPTO_TESTS_GENERATED_DATA_FILES)
 
-../tf-psa-crypto/tests/include/test/test_keys.h: ../tf-psa-crypto/framework/scripts/generate_test_keys.py
+$(TF_PSA_CRYPTO_PATH)/tests/include/test/test_keys.h: $(TF_PSA_CRYPTO_PATH)/framework/scripts/generate_test_keys.py
 	echo "  Gen   $@"
-	$(PYTHON) ../tf-psa-crypto/framework/scripts/generate_test_keys.py --output $@
+	$(PYTHON) $(TF_PSA_CRYPTO_PATH)/framework/scripts/generate_test_keys.py --output $@
 
 TF_PSA_CRYPTO_TESTS_GENERATED_C_FILES = \
-	../tf-psa-crypto/tests/include/test/test_keys.h
+	$(TF_PSA_CRYPTO_PATH)/tests/include/test/test_keys.h

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+"""Analyze the test outcomes from a full CI run.
+
+This script can also run on outcomes from a partial run, but the results are
+less likely to be useful.
+"""
+
+import re
+import typing
+
+import scripts_path # pylint: disable=unused-import
+from mbedtls_framework import outcome_analysis
+
+
+class CoverageTask(outcome_analysis.CoverageTask):
+    """Justify test cases that are never executed."""
+
+    @staticmethod
+    def _has_word_re(words: typing.Iterable[str],
+                     exclude: typing.Optional[str] = None) -> typing.Pattern:
+        """Construct a regex that matches if any of the words appears.
+
+        The occurrence must start and end at a word boundary.
+
+        If exclude is specified, strings containing a match for that
+        regular expression will not match the returned pattern.
+        """
+        exclude_clause = r''
+        if exclude:
+            exclude_clause = r'(?!.*' + exclude + ')'
+        return re.compile(exclude_clause +
+                          r'.*\b(?:' + r'|'.join(words) + r')\b.*',
+                          re.DOTALL)
+
+    IGNORED_TESTS = {
+        'ssl-opt': [
+            # We don't run ssl-opt.sh with Valgrind on the CI because
+            # it's extremely slow. We don't intend to change this.
+            'DTLS client reconnect from same port: reconnect, nbio, valgrind',
+            # We don't have IPv6 in our CI environment.
+            # https://github.com/Mbed-TLS/mbedtls-test/issues/176
+            'DTLS cookie: enabled, IPv6',
+            # Disabled due to OpenSSL bug.
+            # https://github.com/openssl/openssl/issues/18887
+            'DTLS fragmenting: 3d, MTU=512, openssl client, DTLS 1.2',
+            # We don't run ssl-opt.sh with Valgrind on the CI because
+            # it's extremely slow. We don't intend to change this.
+            'DTLS fragmenting: proxy MTU: auto-reduction (with valgrind)',
+            # TLS doesn't use restartable ECDH yet.
+            # https://github.com/Mbed-TLS/mbedtls/issues/7294
+            re.compile(r'EC restart:.*no USE_PSA.*'),
+            # The following test fails intermittently on the CI with a frequency
+            # that significantly impacts CI throughput. They are thus disabled
+            # for the time being. See
+            # https://github.com/Mbed-TLS/mbedtls/issues/10652 for more
+            # information.
+            'DTLS proxy: 3d, openssl client, fragmentation',
+            'DTLS proxy: 3d, openssl client, fragmentation, nbio',
+            'DTLS proxy: 3d, gnutls client, fragmentation',
+            'DTLS proxy: 3d, gnutls client, fragmentation, nbio=2',
+        ],
+        'test_suite_config.mbedtls_boolean': [
+            # Missing coverage of test configurations.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9585
+            'Config: !MBEDTLS_SSL_DTLS_ANTI_REPLAY',
+            # Missing coverage of test configurations.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9585
+            'Config: !MBEDTLS_SSL_DTLS_HELLO_VERIFY',
+            # We don't run test_suite_config when we test this.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9586
+            'Config: !MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED',
+        ],
+        'test_suite_config.crypto_combinations': [
+            # New thing in crypto. Not intended to be tested separately
+            # in mbedtls.
+            # https://github.com/Mbed-TLS/mbedtls/issues/10300
+            'Config: entropy: NV seed only',
+        ],
+        'test_suite_config.psa_boolean': [
+            # We don't test with HMAC disabled.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9591
+            'Config: !PSA_WANT_ALG_HMAC',
+            # The DERIVE key type is always enabled.
+            'Config: !PSA_WANT_KEY_TYPE_DERIVE',
+            # More granularity of key pair type enablement macros
+            # than we care to test.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9590
+            'Config: !PSA_WANT_KEY_TYPE_DH_KEY_PAIR_EXPORT',
+            'Config: !PSA_WANT_KEY_TYPE_DH_KEY_PAIR_GENERATE',
+            'Config: !PSA_WANT_KEY_TYPE_DH_KEY_PAIR_IMPORT',
+            # More granularity of key pair type enablement macros
+            # than we care to test.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9590
+            'Config: !PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT',
+            'Config: !PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT',
+            # We don't test with HMAC disabled.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9591
+            'Config: !PSA_WANT_KEY_TYPE_HMAC',
+            # The PASSWORD key type is always enabled.
+            'Config: !PSA_WANT_KEY_TYPE_PASSWORD',
+            # The PASSWORD_HASH key type is always enabled.
+            'Config: !PSA_WANT_KEY_TYPE_PASSWORD_HASH',
+            # The RAW_DATA key type is always enabled.
+            'Config: !PSA_WANT_KEY_TYPE_RAW_DATA',
+            # More granularity of key pair type enablement macros
+            # than we care to test.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9590
+            'Config: !PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_EXPORT',
+            'Config: !PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT',
+            # Algorithm declared but not supported.
+            'Config: PSA_WANT_ALG_CBC_MAC',
+            # Algorithm declared but not supported.
+            'Config: PSA_WANT_ALG_XTS',
+            # More granularity of key pair type enablement macros
+            # than we care to test.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9590
+            'Config: PSA_WANT_KEY_TYPE_DH_KEY_PAIR_DERIVE',
+            'Config: PSA_WANT_KEY_TYPE_ECC_KEY_PAIR',
+            'Config: PSA_WANT_KEY_TYPE_RSA_KEY_PAIR',
+            'Config: PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_DERIVE',
+            # https://github.com/Mbed-TLS/mbedtls/issues/9583
+            'Config: !MBEDTLS_ECP_NIST_OPTIM',
+            # We never test without the PSA client code. Should we?
+            # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/112
+            'Config: !MBEDTLS_PSA_CRYPTO_CLIENT',
+                        # We only test multithreading with pthreads.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9584
+            'Config: !MBEDTLS_THREADING_PTHREAD',
+            # Built but not tested.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9587
+            'Config: MBEDTLS_AES_USE_HARDWARE_ONLY',
+            # Untested platform-specific optimizations.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9588
+            'Config: MBEDTLS_HAVE_SSE2',
+            # Untested aspect of the platform interface.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9589
+            'Config: MBEDTLS_PLATFORM_NO_STD_FUNCTIONS',
+            # In a client-server build, test_suite_config runs in the
+            # client configuration, so it will never report
+            # MBEDTLS_PSA_CRYPTO_SPM as enabled. That's ok.
+            'Config: MBEDTLS_PSA_CRYPTO_SPM',
+            # We don't test on armv8 yet.
+            'Config: MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY',
+            'Config: MBEDTLS_SHA512_USE_A64_CRYPTO_ONLY',
+            # We don't run test_suite_config when we test this.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9586
+            'Config: MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND',
+        ],
+        'test_suite_config.psa_combinations': [
+            # We don't test this unusual, but sensible configuration.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9592
+            'Config: PSA_WANT_ALG_DETERMINSTIC_ECDSA without PSA_WANT_ALG_ECDSA',
+        ],
+        'test_suite_pkcs12': [
+            # We never test with CBC/PKCS5/PKCS12 enabled but
+            # PKCS7 padding disabled.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9580
+            'PBE Decrypt, (Invalid padding & PKCS7 padding disabled)',
+            'PBE Encrypt, pad = 8 (PKCS7 padding disabled)',
+        ],
+        'test_suite_pkcs5': [
+            # We never test with CBC/PKCS5/PKCS12 enabled but
+            # PKCS7 padding disabled.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9580
+            'PBES2 Decrypt (Invalid padding & PKCS7 padding disabled)',
+            'PBES2 Encrypt, pad=6 (PKCS7 padding disabled)',
+            'PBES2 Encrypt, pad=8 (PKCS7 padding disabled)',
+        ],
+        'test_suite_psa_crypto': [
+            # We don't test this unusual, but sensible configuration.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9592
+            re.compile(r'.*ECDSA.*only deterministic supported'),
+        ],
+        'test_suite_psa_crypto_metadata': [
+            # Algorithms declared but not supported.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9579
+            'Asymmetric signature: Ed25519ph',
+            'Asymmetric signature: Ed448ph',
+            'Asymmetric signature: pure EdDSA',
+            'Cipher: XTS',
+            'MAC: CBC_MAC-3DES',
+            'MAC: CBC_MAC-AES-128',
+            'MAC: CBC_MAC-AES-192',
+            'MAC: CBC_MAC-AES-256',
+        ],
+        'test_suite_psa_crypto_not_supported.generated': [
+            # We never test with DH key support disabled but support
+            # for a DH group enabled. The dependencies of these test
+            # cases don't really make sense.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9574
+            re.compile(r'PSA \w+ DH_.*type not supported'),
+            # We only test partial support for DH with the 2048-bit group
+            # enabled and the other groups disabled.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9575
+            'PSA generate DH_KEY_PAIR(RFC7919) 2048-bit group not supported',
+            'PSA import DH_KEY_PAIR(RFC7919) 2048-bit group not supported',
+            'PSA import DH_PUBLIC_KEY(RFC7919) 2048-bit group not supported',
+        ],
+        'test_suite_psa_crypto_op_fail.generated': [
+            # We don't test this unusual, but sensible configuration.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9592
+            re.compile(r'.*: !ECDSA but DETERMINISTIC_ECDSA with ECC_.*'),
+            # We never test with the HMAC algorithm enabled but the HMAC
+            # key type disabled. Those dependencies don't really make sense.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9573
+            re.compile(r'.* !HMAC with HMAC'),
+            # We don't test with ECDH disabled but the key type enabled.
+            # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/161
+            re.compile(r'PSA key_agreement.* !ECDH with ECC_KEY_PAIR\(.*'),
+            # We don't test with FFDH disabled but the key type enabled.
+            # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/160
+            re.compile(r'PSA key_agreement.* !FFDH with DH_KEY_PAIR\(.*'),
+        ],
+        'test_suite_psa_crypto_op_fail.misc': [
+            # We don't test this unusual, but sensible configuration.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9592
+            'PSA sign DETERMINISTIC_ECDSA(SHA_256): !ECDSA but DETERMINISTIC_ECDSA with ECC_KEY_PAIR(SECP_R1)', #pylint: disable=line-too-long
+        ],
+        'tls13-misc': [
+            # Disabled due to OpenSSL bug.
+            # https://github.com/openssl/openssl/issues/10714
+            'TLS 1.3 O->m: resumption',
+            # Disabled due to OpenSSL command line limitation.
+            # https://github.com/Mbed-TLS/mbedtls/issues/9582
+            'TLS 1.3 m->O: resumption with early data',
+        ],
+    }
+
+# List of tasks with a function that can handle this task and additional arguments if required
+KNOWN_TASKS: typing.Dict[str, typing.Type[outcome_analysis.Task]] = {
+    'analyze_coverage': CoverageTask,
+}
+
+if __name__ == '__main__':
+    outcome_analysis.main(KNOWN_TASKS)

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -17,43 +17,6 @@ class CoverageTask(outcome_analysis.CoverageTask):
     """Justify test cases that are never executed."""
 
     IGNORED_TESTS = {
-        'ssl-opt': [
-            # We don't run ssl-opt.sh with Valgrind on the CI because
-            # it's extremely slow. We don't intend to change this.
-            'DTLS client reconnect from same port: reconnect, nbio, valgrind',
-            # We don't have IPv6 in our CI environment.
-            # https://github.com/Mbed-TLS/mbedtls-test/issues/176
-            'DTLS cookie: enabled, IPv6',
-            # Disabled due to OpenSSL bug.
-            # https://github.com/openssl/openssl/issues/18887
-            'DTLS fragmenting: 3d, MTU=512, openssl client, DTLS 1.2',
-            # We don't run ssl-opt.sh with Valgrind on the CI because
-            # it's extremely slow. We don't intend to change this.
-            'DTLS fragmenting: proxy MTU: auto-reduction (with valgrind)',
-            # TLS doesn't use restartable ECDH yet.
-            # https://github.com/Mbed-TLS/mbedtls/issues/7294
-            re.compile(r'EC restart:.*no USE_PSA.*'),
-            # The following test fails intermittently on the CI with a frequency
-            # that significantly impacts CI throughput. They are thus disabled
-            # for the time being. See
-            # https://github.com/Mbed-TLS/mbedtls/issues/10652 for more
-            # information.
-            'DTLS proxy: 3d, openssl client, fragmentation',
-            'DTLS proxy: 3d, openssl client, fragmentation, nbio',
-            'DTLS proxy: 3d, gnutls client, fragmentation',
-            'DTLS proxy: 3d, gnutls client, fragmentation, nbio=2',
-        ],
-        'test_suite_config.mbedtls_boolean': [
-            # Missing coverage of test configurations.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9585
-            'Config: !MBEDTLS_SSL_DTLS_ANTI_REPLAY',
-            # Missing coverage of test configurations.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9585
-            'Config: !MBEDTLS_SSL_DTLS_HELLO_VERIFY',
-            # We don't run test_suite_config when we test this.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9586
-            'Config: !MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED',
-        ],
         'test_suite_config.crypto_combinations': [
             # New thing in crypto. Not intended to be tested separately
             # in mbedtls.
@@ -199,14 +162,6 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # We don't test this unusual, but sensible configuration.
             # https://github.com/Mbed-TLS/mbedtls/issues/9592
             'PSA sign DETERMINISTIC_ECDSA(SHA_256): !ECDSA but DETERMINISTIC_ECDSA with ECC_KEY_PAIR(SECP_R1)', #pylint: disable=line-too-long
-        ],
-        'tls13-misc': [
-            # Disabled due to OpenSSL bug.
-            # https://github.com/openssl/openssl/issues/10714
-            'TLS 1.3 O->m: resumption',
-            # Disabled due to OpenSSL command line limitation.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9582
-            'TLS 1.3 m->O: resumption with early data',
         ],
     }
 

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -6,6 +6,9 @@ This script can also run on outcomes from a partial run, but the results are
 less likely to be useful.
 """
 
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import re
 import typing
 

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -169,6 +169,18 @@ class CoverageTask(outcome_analysis.CoverageTask):
         ],
     }
 
+    def __init__(self, options) -> None:
+        super().__init__(options)
+        self.internal_test_cases = outcome_analysis.TestCaseSet(INTERNAL_TEST_CASES)
+
+    def note_ignored_test(self, results: outcome_analysis.Results,
+                          test_suite: str, test_description: str) -> None:
+        """Enforce that we don't tell Mbed TLS to ignore a test case that we also ignore."""
+        super().note_ignored_test(results, test_suite, test_description)
+        if self.internal_test_cases.contains(test_suite, test_description):
+            results.error('Test case was ignored, but Mbed TLS will ignore it too: {};{}',
+                          test_suite, test_description)
+
 
 # List of tasks with a function that can handle this task and additional arguments if required
 KNOWN_TASKS: typing.Dict[str, typing.Type[outcome_analysis.Task]] = {

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -16,23 +16,6 @@ from mbedtls_framework import outcome_analysis
 class CoverageTask(outcome_analysis.CoverageTask):
     """Justify test cases that are never executed."""
 
-    @staticmethod
-    def _has_word_re(words: typing.Iterable[str],
-                     exclude: typing.Optional[str] = None) -> typing.Pattern:
-        """Construct a regex that matches if any of the words appears.
-
-        The occurrence must start and end at a word boundary.
-
-        If exclude is specified, strings containing a match for that
-        regular expression will not match the returned pattern.
-        """
-        exclude_clause = r''
-        if exclude:
-            exclude_clause = r'(?!.*' + exclude + ')'
-        return re.compile(exclude_clause +
-                          r'.*\b(?:' + r'|'.join(words) + r')\b.*',
-                          re.DOTALL)
-
     IGNORED_TESTS = {
         'ssl-opt': [
             # We don't run ssl-opt.sh with Valgrind on the CI because

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -31,9 +31,6 @@ class CoverageTask(outcome_analysis.CoverageTask):
         'test_suite_block_cipher': [
             re.compile('.*'),
         ],
-        'test_suite_ccm': [
-            re.compile('CCM finish check-boundary .*'),
-        ],
         'test_suite_cipher.aes': [
             re.compile('.*XTS.*'),
         ],

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -26,7 +26,7 @@ INTERNAL_TEST_CASES = {
 class CoverageTask(outcome_analysis.CoverageTask):
     """Justify test cases that are never executed."""
 
-    IGNORED_TESTS = {
+    UNCOVERED_TESTS = {
         'test_suite_config.psa_boolean': [
             # We don't test with HMAC disabled.
             # https://github.com/Mbed-TLS/mbedtls/issues/9591

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -26,6 +26,104 @@ INTERNAL_TEST_CASES = {
 class CoverageTask(outcome_analysis.CoverageTask):
     """Justify test cases that are never executed."""
 
+    # Tests that may not be covered by TF-PSA-Crypto testing, but are
+    # covered by Mbed TLS testing.
+    # https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/740
+    IGNORED_TESTS = {
+        'test_suite_aes.xts': [
+            re.compile('.*'),
+        ],
+        'test_suite_block_cipher': [
+            re.compile('.*'),
+        ],
+        'test_suite_ccm': [
+            re.compile('CCM finish check-boundary .*'),
+        ],
+        'test_suite_cipher.aes': [
+            re.compile('.*XTS.*'),
+        ],
+        'test_suite_config.psa_boolean': [
+            re.compile('.* !.*'),
+            'Config: MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH',
+            'Config: MBEDTLS_BLOCK_CIPHER_NO_DECRYPT',
+            'Config: MBEDTLS_DEPRECATED_WARNING',
+            'Config: MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED',
+            'Config: MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS',
+            'Config: MBEDTLS_PSA_CRYPTO_CLIENT',
+            'Config: MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG',
+            'Config: MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER',
+            'Config: MBEDTLS_PSA_P256M_DRIVER_ENABLED',
+            'Config: MBEDTLS_PSA_STATIC_KEY_SLOTS',
+            'Config: MBEDTLS_RSA_NO_CRT',
+        ],
+        'test_suite_config.psa_combinations': [
+            'Config: PSA_WANT_ALG_ECDSA without PSA_WANT_ALG_DETERMINISTIC_ECDSA',
+        ],
+        'test_suite_ctr_drbg': [
+            re.compile('.*AES-128.*'),
+            'CTR_DRBG entropy strength: 128 bits',
+        ],
+        'test_suite_pk': [
+            'PK size macro: MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES: only curve is P-256',
+            'PK size macro: MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES: only curve is P-256',
+            'PK size macro: MBEDTLS_PK_MAX_PUBKEY_RAW_LEN: RSA, !ECC',
+        ],
+        'test_suite_psa_crypto': [
+            'PSA MAC setup: algorithm known but not supported, long key',
+            'PSA MAC setup: algorithm known but not supported, short key',
+            'PSA MAC setup: bad algorithm (unsupported HMAC hash algorithm)',
+            'PSA generate key custom: RSA, e=3 with driver and no fallback (not yet supported)',
+            'PSA generate key: RSA, key pair size does not fit in static key buffer',
+            'PSA generate key: RSA, key pair size fits in static key buffer',
+            'PSA sign hash int (ops=inf): det ECDSA not supported',
+            'PSA sign hash int (ops=min): det ECDSA not supported',
+            'PSA sign hash int: ECDSA not supported',
+            'PSA sign hash: deterministic ECDSA not supported',
+            'PSA sign message: deterministic ECDSA not supported',
+            'PSA verify hash with keypair: deterministic ECDSA SECP256R1, only randomized supported',
+            'PSA verify hash: deterministic ECDSA SECP256R1, only randomized supported',
+        ],
+        'test_suite_psa_crypto_driver_wrappers': [
+            re.compile('PSA MAC .*'),
+            re.compile('PSA decrypt transparent driver: .*'),
+            re.compile('PSA encrypt transparent driver: .*'),
+            re.compile('PSA encrypt-decrypt transparent driver: .*'),
+        ],
+        'test_suite_psa_crypto_entropy': [
+            'Fake entropy: more than one block in two steps',
+            'Fake entropy: one block eventually',
+            'Fake entropy: one block in two steps',
+            re.compile('PSA external RNG failure: .*'),
+        ],
+        'test_suite_psa_crypto_not_supported.generated': [
+            re.compile('.*'),
+        ],
+        'test_suite_psa_crypto_op_fail.generated': [
+            re.compile('.* !.*'),
+        ],
+        'test_suite_psa_crypto_op_fail.misc': [
+            'PSA sign DETERMINISTIC_ECDSA(SHA_256): !DETERMINISTIC_ECDSA but ECDSA with ECC_KEY_PAIR(SECP_R1)',
+            'PSA sign RSA_PSS(SHA_256): RSA_PSS not enabled, key pair',
+        ],
+        'test_suite_psa_crypto_persistent_key': [
+            re.compile('Load key: owner=[^0].*'),
+        ],
+        'test_suite_psa_crypto_slot_management': [
+            'Copy persistent to persistent, same id but different owner',
+            'Create not supported',
+            'Non reusable key slots integrity in case of key slot starvation',
+        ],
+        'test_suite_psa_crypto_storage_format.misc': [
+            'PSA storage read: key larger than MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE',
+        ],
+        'test_suite_random': [
+            'PSA classic wrapper: HMAC_DRBG max',
+            'PSA classic wrapper: external RNG large',
+        ],
+    }
+
+    # Tests that are not covered for a tracked reason, and that
+    # were also not covered by Mbed TLS testing as of Mbed TLS 4.1.0.
     UNCOVERED_TESTS = {
         'test_suite_config.psa_boolean': [
             # We don't test with HMAC disabled.

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -15,15 +15,7 @@ import typing
 import scripts_path # pylint: disable=unused-import
 from mbedtls_framework import outcome_analysis
 
-
-# Test cases that it makes sense not to execute in Mbed TLS, because they
-# are about implementation details of TF-PSA-Crypto, e.g. optimization options.
-# This has the same format as `CoverageTask.IGNORED_TESTS`.
-INTERNAL_TEST_CASES = {
-    'test_suite_config.crypto_combinations': [
-        'Config: entropy: NV seed only',
-    ],
-}
+import tf_psa_crypto_test_case_info
 
 
 class CoverageTask(outcome_analysis.CoverageTask):
@@ -272,7 +264,8 @@ class CoverageTask(outcome_analysis.CoverageTask):
 
     def __init__(self, options) -> None:
         super().__init__(options)
-        self.internal_test_cases = outcome_analysis.TestCaseSet(INTERNAL_TEST_CASES)
+        self.internal_test_cases = outcome_analysis.TestCaseSet(
+            tf_psa_crypto_test_case_info.INTERNAL_TEST_CASES)
 
     def note_ignored_test(self, results: outcome_analysis.Results,
                           test_suite: str, test_description: str) -> None:

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -80,7 +80,7 @@ class CoverageTask(outcome_analysis.CoverageTask):
             'PSA sign hash int: ECDSA not supported',
             'PSA sign hash: deterministic ECDSA not supported',
             'PSA sign message: deterministic ECDSA not supported',
-            'PSA verify hash with keypair: deterministic ECDSA SECP256R1, only randomized supported',
+            'PSA verify hash with keypair: deterministic ECDSA SECP256R1, only randomized supported', #pylint: disable=line-too-long
             'PSA verify hash: deterministic ECDSA SECP256R1, only randomized supported',
         ],
         'test_suite_psa_crypto_driver_wrappers': [
@@ -102,7 +102,7 @@ class CoverageTask(outcome_analysis.CoverageTask):
             re.compile('.* !.*'),
         ],
         'test_suite_psa_crypto_op_fail.misc': [
-            'PSA sign DETERMINISTIC_ECDSA(SHA_256): !DETERMINISTIC_ECDSA but ECDSA with ECC_KEY_PAIR(SECP_R1)',
+            'PSA sign DETERMINISTIC_ECDSA(SHA_256): !DETERMINISTIC_ECDSA but ECDSA with ECC_KEY_PAIR(SECP_R1)', #pylint: disable=line-too-long
             'PSA sign RSA_PSS(SHA_256): RSA_PSS not enabled, key pair',
         ],
         'test_suite_psa_crypto_persistent_key': [

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -13,16 +13,20 @@ import scripts_path # pylint: disable=unused-import
 from mbedtls_framework import outcome_analysis
 
 
+# Test cases that it makes sense not to execute in Mbed TLS, because they
+# are about implementation details of TF-PSA-Crypto, e.g. optimization options.
+# This has the same format as `CoverageTask.IGNORED_TESTS`.
+INTERNAL_TEST_CASES = {
+    'test_suite_config.crypto_combinations': [
+        'Config: entropy: NV seed only',
+    ],
+}
+
+
 class CoverageTask(outcome_analysis.CoverageTask):
     """Justify test cases that are never executed."""
 
     IGNORED_TESTS = {
-        'test_suite_config.crypto_combinations': [
-            # New thing in crypto. Not intended to be tested separately
-            # in mbedtls.
-            # https://github.com/Mbed-TLS/mbedtls/issues/10300
-            'Config: entropy: NV seed only',
-        ],
         'test_suite_config.psa_boolean': [
             # We don't test with HMAC disabled.
             # https://github.com/Mbed-TLS/mbedtls/issues/9591
@@ -164,6 +168,7 @@ class CoverageTask(outcome_analysis.CoverageTask):
             'PSA sign DETERMINISTIC_ECDSA(SHA_256): !ECDSA but DETERMINISTIC_ECDSA with ECC_KEY_PAIR(SECP_R1)', #pylint: disable=line-too-long
         ],
     }
+
 
 # List of tasks with a function that can handle this task and additional arguments if required
 KNOWN_TASKS: typing.Dict[str, typing.Type[outcome_analysis.Task]] = {

--- a/tests/scripts/tf_psa_crypto_test_case_info.py
+++ b/tests/scripts/tf_psa_crypto_test_case_info.py
@@ -1,0 +1,26 @@
+"""Information about TF-PSA-Crypto test cases that Mbed TLS can access."""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# This module can be loaded either from a TF-PSA-Crypto script or from
+# an Mbed TLS script. As a consequence, it should avoid depending on
+# other modules from the project or the framework. It's only intended
+# to be a data module anyway.
+
+#import re
+
+# Test cases that it makes sense not to execute in Mbed TLS, because they
+# are about implementation details of TF-PSA-Crypto, e.g. optimization options.
+# This has the same format as `CoverageTask.IGNORED_TESTS` in outcome_analysis:
+# ```{ test_suite_name: [matcher, ...], ... }```
+# with each ``matcher`` being either of:
+# - a string, standing for an exact test case description;
+# - a regex, which must match the full test case description.
+# A test suite with no "." matches all test suites with the same .function
+# file. A test suite wiht a "." only matches that specific .data file.
+INTERNAL_TEST_CASES = {
+    'test_suite_config.crypto_combinations': [
+        'Config: entropy: NV seed only',
+    ],
+}

--- a/tests/scripts/tf_psa_crypto_test_case_info.py
+++ b/tests/scripts/tf_psa_crypto_test_case_info.py
@@ -13,15 +13,17 @@
 # don't keep adding and removing it as the matchers evolve.
 import re #pylint: disable=unused-import
 
-# Test cases that it makes sense not to execute in Mbed TLS, because they
-# are about implementation details of TF-PSA-Crypto, e.g. optimization options.
+# Test cases that it makes sense not to execute in Mbed TLS. Typically
+# this is because they relate to implementation details of TF-PSA-Crypto,
+# such as optimization options.
+#
 # This has the same format as `CoverageTask.IGNORED_TESTS` in outcome_analysis:
 # ```{ test_suite_name: [matcher, ...], ... }```
 # with each ``matcher`` being either of:
-# - a string, standing for an exact test case description;
+# - a string, which is an exact test case description;
 # - a regex, which must match the full test case description.
 # A test suite with no "." matches all test suites with the same .function
-# file. A test suite wiht a "." only matches that specific .data file.
+# file. A test suite with a "." only matches that specific .data file.
 INTERNAL_TEST_CASES = {
     'test_suite_config.crypto_combinations': [
         'Config: entropy: NV seed only',

--- a/tests/scripts/tf_psa_crypto_test_case_info.py
+++ b/tests/scripts/tf_psa_crypto_test_case_info.py
@@ -8,7 +8,10 @@
 # other modules from the project or the framework. It's only intended
 # to be a data module anyway.
 
-#import re
+# At any given time, there may or may not be a test case matcher that's
+# built with `re.compile`. Always include the `re` module so that we
+# don't keep adding and removing it as the matchers evolve.
+import re #pylint: disable=unused-import
 
 # Test cases that it makes sense not to execute in Mbed TLS, because they
 # are about implementation details of TF-PSA-Crypto, e.g. optimization options.


### PR DESCRIPTION
* Add `analyze_outcomes.py` to TF-PSA-Crypto.
* There is a list of ignored test cases (fully ignored, not just must-not-be-covered) for coverage analysis. It is still the responsibility of Mbed TLS to run these tests. We will gradually remove elements from this list as we add more configurations to TF-PSA-Crypto's `all.sh`. Tracked in https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/740.
* TF-PSA-Crypto defines `INTERNAL_TEST_CASES`, which Mbed TLS's outcome analysis can ignore.

Resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/315. Contributes to https://github.com/Mbed-TLS/mbedtls/issues/10221, which the companion Mbed TLS PR will resolve.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10676
- [x] **TF-PSA-Crypto development PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/729
- [x] **TF-PSA-Crypto 1.1 PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/748
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/292
- [ ] **4.1 PR** TODO
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10677
- **tests**  provided
