### PR TITLE
crypto: Mention compiler optimization in the threat model

### DIFF
--- a/ChangeLog.d/security-advice.txt
+++ b/ChangeLog.d/security-advice.txt
@@ -1,0 +1,2 @@
+Security
+   * Added advice about compiler options in SECURITY.md.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ model, they need to be mitigated by physical countermeasures.
 
 Mbed TLS is mostly written in C. We use standard C except with known compilers, so we do not expect compilers to introduce direct vulnerabilities. However, compilers can introduce [timing side channels](#timing-attacks) in code that was intended to be constant-time. Mbed TLS includes countermeasures to try to prevent this. But given the diversity of compilers, compiler options and target platforms, this prevention may not be complete.
 
-We recommend compiling Mbed TLS with commonly used levels of optimizations, such as `-O2` or `-Os`. Higher levels of optimization such as `-O3` or `-Oz` are likely to be safe but are less scrutinized. We do not recommend using less vetted optimization options unless your system is physically isolated.
+We recommend compiling Mbed TLS with commonly used levels of optimizations, such as `-O2` or `-Os`. We will generally treat exploitable timing side channels as a vulnerability if they appear with a common compiler at a common level of optimization. Higher levels of optimization such as `-O3` or `-Oz` are still likely to be safe but are less scrutinized. We do not recommend using individual options that might introduce data-dependent timing, and we will not try to work around such optimizations if they are not part of a commonly used level.
 
 #### Out-of-scope countermeasures
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,6 +104,12 @@ model, they need to be mitigated by physical countermeasures.
 
 ### Caveats
 
+#### Compiler-induced side channels
+
+Mbed TLS is mostly written in C. We use standard C except with known compilers, so we do not expect compilers to introduce direct vulnerabilities. However, compilers can introduce [timing side channels](#timing-attacks) in code that was intended to be constant-time. Mbed TLS includes countermeasures to try to prevent this. But given the diversity of compilers, compiler options and target platforms, this prevention may not be complete.
+
+We recommend compiling Mbed TLS with commonly used levels of optimizations, such as `-O2` or `-Os`. Higher levels of optimization such as `-O3` or `-Oz` are likely to be safe but are less scrutinized. We do not recommend using less vetted optimization options unless your system is physically isolated.
+
 #### Out-of-scope countermeasures
 
 TF-PSA-Crypto has evolved organically and a well defined threat model hasn't


### PR DESCRIPTION
Add a section to our public threat model about compiler options. Companion to https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-03-compiler-induced-constant-time-violations/ . Was previously [approved in private](https://github.com/Mbed-TLS/mbedtls-restricted/pull/1442).

## PR checklist

- [x] **changelog** provided | not required because: doc only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/736
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/735
- [x] **mbedtls development PR** https://github.com/Mbed-TLS/mbedtls/pull/10670
- [x] **mbedtls 4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10669
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10667
- **tests**  not required because: no code
