### PR TITLE
[1.1] psa_crypto.c: Fix ifdefs to avoid build warning

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -6946,7 +6946,9 @@ static int psa_key_derivation_allows_free_form_secret_input(
 psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
                                       psa_algorithm_t alg)
 {
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     psa_status_t status;
+#endif
 
     if (operation->alg != 0) {
         return PSA_ERROR_BAD_STATE;
@@ -6979,10 +6981,12 @@ psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     if (status == PSA_SUCCESS) {
         operation->alg = alg;
     }
     return status;
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 }
 
 #if defined(BUILTIN_ALG_ANY_HKDF)


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/723

## PR checklist

- [x] **changelog** not required because: minor change
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **tf-psa-crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/723
- [x] **mbedtls 3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10679
- **tests**  not required because: no new code to be tested
