### PR TITLE
pull_request_template: add field for TF-PSA-Crypto 1.1 branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,11 +9,13 @@ Please write a few sentences describing the overall goals of the pull request's 
 Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
 If the provided content is part of the present PR remove the # symbol.
 
-- [ ] **changelog** provided | not required because: 
+- [ ] **changelog** provided | not required because:
+- [ ] **TF-PSA-Crypto PR** provided # | not required because:
+- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because:
 - [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
-- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
-- **tests**  provided | not required because: 
+- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because:
+- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because:
+- **tests**  provided | not required because:
 
 
 


### PR DESCRIPTION
## Description

Update the PR template message to include a line for the 1.1 branch.

## PR checklist

- [ ] **changelog** not required because: not visible to the user
- [ ] **framework PR** not required
- [ ] **mbedtls development PR** not sure: do I need to also update that one? I think the answer is yes if there is a PR on `mbedtls-4.1` branch that needs to update the tf-psa-crypto part. Is that correct?
- [ ] **mbedtls 3.6 PR** not required because: not backported
- **tests** not required because: no code to be tested