### PR TITLE
platform: fix -Wcast-align warnings in memory_buffer_alloc.c

### DIFF
--- a/platform/memory_buffer_alloc.c
+++ b/platform/memory_buffer_alloc.c
@@ -294,7 +294,9 @@ static void *buffer_alloc_calloc(size_t n, size_t size)
     }
 
     p = ((unsigned char *) cur) + sizeof(memory_header) + len;
-    new = (memory_header *) p;
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    new = (memory_header *) (void *) p;
 
     new->size = cur->size - len - sizeof(memory_header);
     new->alloc = 0;
@@ -375,7 +377,9 @@ static void buffer_alloc_free(void *ptr)
     }
 
     p -= sizeof(memory_header);
-    hdr = (memory_header *) p;
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    hdr = (memory_header *) (void *) p;
 
     if (verify_header(hdr) != 0) {
         mbedtls_exit(1);
@@ -586,7 +590,9 @@ void mbedtls_memory_buffer_alloc_init(unsigned char *buf, size_t len)
     heap.buf = buf;
     heap.len = len;
 
-    heap.first = (memory_header *) buf;
+    /* Double casting is required to prevent compilation warning on Clang-based
+     * compilers when "-Wcast-align" is used. */
+    heap.first = (memory_header *) (void *) buf;
     heap.first->size = len - sizeof(memory_header);
     heap.first->magic1 = MAGIC1;
     heap.first->magic2 = MAGIC2;


### PR DESCRIPTION
Cast from 'unsigned char *' to 'memory_header *' through an intermediate 'void *' to suppress -Wcast-align warnings.

Some Clang-based toolchains (e.g. MetaWare/ARC) enable -Wcast-align as part of -Wall, unlike standard Clang on x86/ARM. Combined with -Werror this turns the casts into fatal build errors.

The casts are already alignment-safe at runtime:
- In mbedtls_memory_buffer_alloc_init(), buf is explicitly aligned to MBEDTLS_MEMORY_ALIGN_MULTIPLE before the cast.
- In buffer_alloc_calloc(), p is computed from an aligned base plus aligned offsets (sizeof(memory_header) and len are both multiples of MBEDTLS_MEMORY_ALIGN_MULTIPLE).
- In buffer_alloc_free(), p is derived from a previously aligned allocation pointer minus the aligned header size.

Original issue reported on zephyr: https://github.com/zephyrproject-rtos/zephyr/issues/106712

## PR checklist

- [x] **changelog** not required because: minor fix
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: no change there
- [x] **tf-psa-crypto 1.1 backport** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/757
- [x] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10692
- **tests** not required because: no new code to be tested