### PR TITLE
Backport 1.1: x PAKE getters test failure with GCC 15

### DIFF
--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -694,7 +694,7 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
 
 exit:
     psa_reset_key_attributes(&attributes);
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_pk_free(&pk);
     PSA_DONE();
 }
@@ -781,7 +781,7 @@ void pk_can_do_psa(int test_number, int pk_type, int key_type, int curve_or_keyb
     TEST_EQUAL(mbedtls_pk_can_do_psa(&pk, alg_check, usage_check), result);
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_pk_free(&pk);
     PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2451,7 +2451,7 @@ void aead_key_policy(int policy_usage_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_aead_abort(&operation));
+    psa_aead_abort(&operation);
     psa_destroy_key(key);
     PSA_DONE();
 }
@@ -3070,7 +3070,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     mbedtls_free(output);
     PSA_DONE();
 }
@@ -3109,7 +3109,7 @@ void hash_compare_fail(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -3213,7 +3213,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -4385,7 +4385,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                         output, output_length);
 
 exit:
-    PSA_ASSERT(psa_cipher_abort(&operation));
+    psa_cipher_abort(&operation);
     mbedtls_free(output);
     psa_cipher_abort(&operation);
     psa_destroy_key(key);
@@ -11420,8 +11420,8 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     mbedtls_free(output_buffer);
     PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -2899,7 +2899,7 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
 
 exit:
     /* Cleanup */
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_free(output_data);
     PSA_DONE();
     mbedtls_test_driver_aead_hooks = mbedtls_test_driver_aead_hooks_init();
@@ -3001,7 +3001,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_free(output_data);
     PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -789,8 +789,8 @@ void ecjpake_setup(int policy_alg_arg, int setup_alg_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     mbedtls_free(output_key_share);
     mbedtls_free(output_zk_public);
     mbedtls_free(output_zk_proof);
@@ -1058,8 +1058,8 @@ void pake_input_getters_password()
                PSA_ERROR_BAD_STATE);
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1103,8 +1103,8 @@ void pake_input_getters_cipher_suite()
                PSA_ERROR_BAD_STATE);
 
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_pake_abort(&operation);
+    psa_destroy_key(key);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1174,9 +1174,10 @@ void pake_input_getters_user()
 
         TEST_MEMORY_COMPARE(user_ret, buffer_len_ret, user, user_len);
     }
+
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_pake_abort(&operation);
+    psa_destroy_key(key);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1246,9 +1247,10 @@ void pake_input_getters_peer()
 
         TEST_MEMORY_COMPARE(peer_ret, buffer_len_ret, peer, peer_len);
     }
+
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_pake_abort(&operation);
+    psa_destroy_key(key);
     PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -596,7 +596,7 @@ void ecjpake_setup(int policy_alg_arg, int setup_alg_arg,
                    int expected_error_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     psa_algorithm_t policy_alg = policy_alg_arg;
     psa_algorithm_t setup_alg = setup_alg_arg;
     psa_pake_primitive_t primitive = primitive_arg;
@@ -808,8 +808,8 @@ void ecjpake_rounds_inject(int alg_arg, int primitive_arg,
                            int inject_in_second_round)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -863,8 +863,8 @@ void ecjpake_rounds(int alg_arg, int primitive_arg,
                     int err_stage_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t derive_alg = derive_alg_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
@@ -1003,7 +1003,7 @@ void ecjpake_size_macros()
 void pake_input_getters_password()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     const char *password = "password";
@@ -1065,7 +1065,7 @@ exit:
 void pake_input_getters_cipher_suite()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     psa_pake_cipher_suite_t cipher_suite_ret = psa_pake_cipher_suite_init();
     const char *password = "password";
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -1108,7 +1108,7 @@ exit:
 void pake_input_getters_user()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     const char *users[] = { "client", "server", "other" };
     uint8_t user_ret[20] = { 0 }; // max user length is 20 bytes
     size_t user_len_ret = 0;
@@ -1180,7 +1180,7 @@ exit:
 void pake_input_getters_peer()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     const char *peers[] = { "client", "server", "other" };
     uint8_t peer_ret[20] = { 0 }; // max peer length is 20 bytes
     size_t peer_len_ret = 0;

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -1026,14 +1026,6 @@ void pake_input_getters_password()
 
     PSA_ASSERT(psa_import_key(&attributes, (uint8_t *) password, strlen(password), &key));
 
-    TEST_EQUAL(psa_crypto_driver_pake_get_password(&operation.data.inputs,
-                                                   (uint8_t *) &password_ret,
-                                                   10, &buffer_len_ret),
-               PSA_ERROR_BAD_STATE);
-
-    TEST_EQUAL(psa_crypto_driver_pake_get_password_len(&operation.data.inputs, &password_len_ret),
-               PSA_ERROR_BAD_STATE);
-
     PSA_ASSERT(psa_pake_setup(&operation, key, &cipher_suite));
 
     TEST_EQUAL(psa_crypto_driver_pake_get_password_len(&operation.data.inputs, &password_len_ret),
@@ -1054,6 +1046,17 @@ void pake_input_getters_password()
                PSA_SUCCESS);
 
     TEST_MEMORY_COMPARE(password_ret, buffer_len_ret, password, strlen(password));
+
+
+    PSA_ASSERT(psa_pake_abort(&operation));
+
+    TEST_EQUAL(psa_crypto_driver_pake_get_password(&operation.data.inputs,
+                                                   (uint8_t *) &password_ret,
+                                                   10, &buffer_len_ret),
+               PSA_ERROR_BAD_STATE);
+    TEST_EQUAL(psa_crypto_driver_pake_get_password_len(&operation.data.inputs, &password_len_ret),
+               PSA_ERROR_BAD_STATE);
+
 exit:
     PSA_ASSERT(psa_destroy_key(key));
     PSA_ASSERT(psa_pake_abort(&operation));
@@ -1086,9 +1089,6 @@ void pake_input_getters_cipher_suite()
 
     PSA_ASSERT(psa_import_key(&attributes, (uint8_t *) password, strlen(password), &key));
 
-    TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
-               PSA_ERROR_BAD_STATE);
-
     PSA_ASSERT(psa_pake_setup(&operation, key, &cipher_suite));
 
     TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
@@ -1096,6 +1096,11 @@ void pake_input_getters_cipher_suite()
 
     TEST_MEMORY_COMPARE(&cipher_suite_ret, sizeof(cipher_suite_ret),
                         &cipher_suite, sizeof(cipher_suite));
+
+    PSA_ASSERT(psa_pake_abort(&operation));
+
+    TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
+               PSA_ERROR_BAD_STATE);
 
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/584, a problem in our tests that causes them to fail with GCC 15 at `-O0`.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/585
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/746
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10680
- **tests**  provided
