### PR TITLE
Backport 1.1: Move some scripts from mbedtls into the framework: impact on TF-PSA-Crypto

### DIFF
--- a/docs/architecture/psa-shared-memory.md
+++ b/docs/architecture/psa-shared-memory.md
@@ -682,4 +682,4 @@ To make sure that we can correctly detect functions that access their input/outp
 
 Then, we could write a test that uses this function with memory poisoning and ensure that it fails. Since we are expecting a failure due to memory-poisoning, we would run this test separately from the rest of the memory-poisoning testing.
 
-This testing is implemented in `framework/tests/programs/metatest.c`, which is a program designed to check that test failures happen correctly. It may be run via the script `tests/scripts/run-metatests.sh`.
+This testing is implemented in `framework/tests/programs/metatest.c`, which is a program designed to check that test failures happen correctly. It may be run via the script `framework/scripts/run-metatests.sh`.

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -1,6 +1,7 @@
 # Python package requirements for Mbed TLS testing.
 
 -r driver.requirements.txt
+-r ../framework/scripts/ci.requirements.txt
 
 # The dependencies below are only used in scripts that we run on the Linux CI.
 
@@ -16,16 +17,6 @@ pylint == 2.4.4; platform_system == 'Linux'
 #   https://github.com/Mbed-TLS/mbedtls-framework/issues/50
 # mypy 0.942 is the version in Ubuntu 22.04.
 mypy == 0.942; platform_system == 'Linux'
-
-# At the time of writing, only needed for tests/scripts/audit-validity-dates.py.
-# It needs >=35.0.0 for correct operation, and that requires Python >=3.6.
-# >=35.0.0 also requires Rust to build from source, which we are forced to do on
-# FreeBSD, since PyPI doesn't carry binary wheels for the BSDs.
-cryptography >= 35.0.0; platform_system == 'Linux'
-
-# For building `framework/data_files/server9-bad-saltlen.crt` and check python
-# files.
-asn1crypto; platform_system == 'Linux'
 
 # More requirements for scripts in the framework that might not work in
 # older versions of Python. Note that requirements that are not available


### PR DESCRIPTION
Backpotr of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/728

## PR checklist

- [x] **changelog** provided | not required because: nothing user-facing
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/283
- [x] **TF-PSA-Crypto development PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/728
- [x] **TF-PSA-Crypto 1.1 PR**https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/749
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10624 (also merged in 4.1)
- [x] **mbedtls 4.1 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10624 (also merged in development)
- [x] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10629 + https://github.com/Mbed-TLS/mbedtls/pull/10658
- **tests**  provided
