### PR TITLE
Detect getrandom() on Android (Bionic libc)

### DIFF
--- a/ChangeLog.d/bionic-getrandom.txt
+++ b/ChangeLog.d/bionic-getrandom.txt
@@ -1,0 +1,2 @@
+Features
+   * Use getrandom() rather than /dev/random on Android. Fixes #745.

--- a/platform/platform_util.c
+++ b/platform/platform_util.c
@@ -294,9 +294,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
  * Since there is no wrapper in the libc yet, use the generic syscall wrapper
  * available in GNU libc and compatible libc's (eg uClibc).
  */
-#if ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
+#if (defined(__linux__) && defined(__GLIBC__)) || \
+    defined(__BIONIC__) || \
+    defined(__midipix__)
 #include <unistd.h>
 #include <sys/syscall.h>
+
 #if defined(SYS_getrandom)
 #define HAVE_GETRANDOM
 #include <errno.h>
@@ -312,7 +315,7 @@ static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
     return (int) syscall(SYS_getrandom, buf, buflen, flags);
 }
 #endif /* SYS_getrandom */
-#endif /* __linux__ || __midipix__ */
+#endif /* __linux__ || ... */
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/param.h>


### PR DESCRIPTION
Fixes #745

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided here
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [ ] **mbedtls 3.6 PR** TODO
- **tests**  not required because: we don't test with Bionic
