### PR TITLE
Add driver and dispatch for MLDSA: followup

### DIFF
--- a/scripts/c_header_guards.py
+++ b/scripts/c_header_guards.py
@@ -20,6 +20,9 @@ where:
 - 'rel_path' is the path used in C files to include such header file.
 """
 
+## Copyright The Mbed TLS Contributors
+## SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import sys
 import os
 import re

--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -3,6 +3,9 @@
 """Generate C preprocessor code to check for bad configurations.
 """
 
+## Copyright The Mbed TLS Contributors
+## SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 from typing import Iterator
 
 import framework_scripts_path # pylint: disable=unused-import

--- a/scripts/maintainer/generate_mldsa_tests.py
+++ b/scripts/maintainer/generate_mldsa_tests.py
@@ -2,6 +2,9 @@
 """Generate ML-DSA test cases.
 """
 
+## Copyright The Mbed TLS Contributors
+## SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import sys
 
 import maintainer_scripts_path # pylint: disable=unused-import

--- a/tests/scripts/generate_tests_pk_can_do_psa.py
+++ b/tests/scripts/generate_tests_pk_can_do_psa.py
@@ -7,6 +7,9 @@ Generated test file is saved in 'tests/suites/test_suite_pk.pk_can_do_psa.data'
 for the time being.
 """
 
+## Copyright The Mbed TLS Contributors
+## SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import os
 import re
 

--- a/tests/suites/test_suite_dispatch_transparent.function
+++ b/tests/suites/test_suite_dispatch_transparent.function
@@ -177,7 +177,7 @@ void verify_message(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len - 1),
+                       buf, signature->len),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf  = NULL;
@@ -190,7 +190,7 @@ void verify_message(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len - 1),
+                       buf, signature->len - 1),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf  = NULL;
@@ -203,7 +203,7 @@ void verify_message(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len + 1),
+                       buf, signature->len + 1),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf = NULL;

--- a/tests/suites/test_suite_psa_crypto_mldsa.function
+++ b/tests/suites/test_suite_psa_crypto_mldsa.function
@@ -206,7 +206,7 @@ void verify_pure(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len - 1),
+                       buf, signature->len),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf  = NULL;
@@ -219,7 +219,7 @@ void verify_pure(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len - 1),
+                       buf, signature->len - 1),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf  = NULL;
@@ -232,7 +232,7 @@ void verify_pure(int type_arg, int bits_arg, int alg_arg,
                        public_key->x, public_key->len,
                        alg_arg,
                        message->x, message->len,
-                       signature->x, signature->len + 1),
+                       buf, signature->len + 1),
                    PSA_ERROR_INVALID_SIGNATURE);
         mbedtls_free(buf);
         buf = NULL;


### PR DESCRIPTION
Follow-up to https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/700. Minor fixes for things found during the review of the [partial 1.1 backport](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/750).

## PR checklist

- [x] **changelog** provided | not required because: nothing user-facing
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** here
- [x] **TF-PSA-Crypto 1.1 PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/750
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: stuff added after 1.0
- **tests**  provided
