### PR TITLE
1.1 only: Fix the build when a driver calls the dispatch layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,8 @@ endif()
 # drivers, that are appended in `drivers/CMakeLists.txt`.
 #
 set(TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS
+        # psa_crypto_driver_wrappers.h is generated, so it may be in the build tree.
+        ${CMAKE_CURRENT_BINARY_DIR}/core
         ${CMAKE_CURRENT_SOURCE_DIR}/core
         ${CMAKE_CURRENT_SOURCE_DIR}/dispatch
         ${CMAKE_CURRENT_SOURCE_DIR}/extras

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -125,3 +125,18 @@ if (GEN_FILES)
             ${TF_PSA_CRYPTO_TARGET_PREFIX}libtfpsacrypto_generated_files_target)
     endforeach()
 endif()
+
+if(TF_PSA_CRYPTO_TEST_DRIVER)
+    foreach (target IN LISTS driver_targets driver_static_targets)
+        # Note: "tests/include/test" exists solely to provide access to
+        #       "mbedtls/build_info.h". That header is an alias of
+        #       "tf-psa-crypto/build_info.h".
+        #
+        #       It is included in framework headers and C modules because those
+        #       components are also used in the Mbed TLS context.
+        target_include_directories(${target} PRIVATE
+            ${TF_PSA_CRYPTO_FRAMEWORK_DIR}/tests/include
+            ${PROJECT_SOURCE_DIR}/tests/include/test
+        )
+    endforeach()
+endif()

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -16,6 +16,21 @@ set(TF_PSA_CRYPTO_DRIVERS_INCLUDE_DIRS
         ${CMAKE_CURRENT_SOURCE_DIR}/pqcp/include
 )
 
+# The core and drivers need to see the driver dispatch functions in
+# psa_crypto_driver_wrappers.h. (Note that drivers can call the dispatch layer
+# to perform sub-operations.) Some dispatch functions in
+# psa_crypto_driver_wrappers.h have inline function definitions. Hence code
+# that calls the dispatch layer also need to see the declarations of the
+# driver entry points. Those are in drivers' private directories.
+# Note that this needs to be done before adding the driver subdirectories.
+foreach(driver ${drivers})
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${driver}/src)
+        list(APPEND TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/${driver}/src)
+    endif()
+endforeach()
+set(TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS
+        "${TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS}" PARENT_SCOPE)
+
 if(CMAKE_COMPILER_IS_MSVC)
     if(MSVC_STATIC_RUNTIME)
         foreach(flag_var
@@ -102,15 +117,11 @@ add_subdirectory(p256-m)
 add_subdirectory(builtin)
 add_subdirectory(pqcp)
 
-#
-# Add to the list of directories with internal headers the driver ones that
-# must be visible by core and tests code.
-# Done after adding the driver sub-directories as drivers do not need to see
-# each other internal headers.
-#
-list(APPEND TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/builtin/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/pqcp/src
-)
-set(TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS
-        "${TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS}" PARENT_SCOPE)
+if (GEN_FILES)
+    # Make sure psa_crypto_driver_wrappers.h is available before building
+    # driver code.
+    foreach (target IN LISTS driver_targets driver_static_targets)
+        add_dependencies(${target}
+            ${TF_PSA_CRYPTO_TARGET_PREFIX}libtfpsacrypto_generated_files_target)
+    endforeach()
+endif()


### PR DESCRIPTION
Fix the build when a driver calls the dispatch layer. We don't currently do this in our code base, but partners who integrate their own drivers want to do this.

Done in `development` in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/704.

## PR checklist


- [x] **changelog** not required because: fixing something that we don't officially promise and that hasn't been reported as an issue
- [x] **framework PR** not required
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: only relevant after 1.0
- **tests**  not required because: fixing something that we don't officially promise
