### PR TITLE
1.1 only: Address gotcha for mypy on outcome_analysis.py in Mbed TLS

### DIFF
--- a/scripts/project_knowledge/tf_psa_crypto_test_case_info.py
+++ b/scripts/project_knowledge/tf_psa_crypto_test_case_info.py
@@ -12,6 +12,7 @@
 # built with `re.compile`. Always include the `re` module so that we
 # don't keep adding and removing it as the matchers evolve.
 import re #pylint: disable=unused-import
+from typing import Dict, List, Pattern, Union
 
 # Test cases that it makes sense not to execute in Mbed TLS. Typically
 # this is because they relate to implementation details of TF-PSA-Crypto,
@@ -24,7 +25,7 @@ import re #pylint: disable=unused-import
 # - a regex, which must match the full test case description.
 # A test suite with no "." matches all test suites with the same .function
 # file. A test suite with a "." only matches that specific .data file.
-INTERNAL_TEST_CASES = {
+INTERNAL_TEST_CASES: Dict[str, List[Union[str, Pattern]]] = {
     'test_suite_config.crypto_combinations': [
         'Config: entropy: NV seed only',
     ],

--- a/tests/scripts/tf_psa_crypto_test_case_info.py
+++ b/tests/scripts/tf_psa_crypto_test_case_info.py
@@ -12,6 +12,7 @@
 # built with `re.compile`. Always include the `re` module so that we
 # don't keep adding and removing it as the matchers evolve.
 import re #pylint: disable=unused-import
+from typing import Dict, List, Pattern, Union
 
 # Test cases that it makes sense not to execute in Mbed TLS. Typically
 # this is because they relate to implementation details of TF-PSA-Crypto,
@@ -24,7 +25,7 @@ import re #pylint: disable=unused-import
 # - a regex, which must match the full test case description.
 # A test suite with no "." matches all test suites with the same .function
 # file. A test suite with a "." only matches that specific .data file.
-INTERNAL_TEST_CASES = {
+INTERNAL_TEST_CASES: Dict[str, List[Union[str, Pattern]]] = {
     'test_suite_config.crypto_combinations': [
         'Config: entropy: NV seed only',
     ],


### PR DESCRIPTION
If we add a regex in `INTERNAL_TEST_CASES` in `tests/scripts/tf_psa_crypto_test_case_info.py`, then `check_python_files` from Mbed TLS's `all.sh` will fail unless we add a type annotation to help mypy. I did this in `development` in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/704. Better do it preemptively in 1.1 rather than try to debug it when it comes up later.

## PR checklist

- [x] **changelog** provided | not required because: test only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** was part of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/704
- [x] **TF-PSA-Crypto 1.1 PR** here
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: crypto only
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: crypto only
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: crypto only
- **tests**  provided
