### PR TITLE
Add MLDSA test programs

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -115,6 +115,11 @@ if(USE_STATIC_TF_PSA_CRYPTO_LIBRARY)
         ${target_objects})
     tf_psa_crypto_set_base_compile_options(${tfpsacrypto_static_target})
     tf_psa_crypto_set_extra_compile_options(${tfpsacrypto_static_target})
+    if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
+        target_compile_options(${tfpsacrypto_static_target} PRIVATE
+            -ffunction-sections
+            -fdata-sections)
+    endif()
     set_target_properties(${tfpsacrypto_static_target} PROPERTIES OUTPUT_NAME tfpsacrypto)
     target_link_libraries(${tfpsacrypto_static_target} PUBLIC ${libs})
 
@@ -138,6 +143,11 @@ if(USE_SHARED_TF_PSA_CRYPTO_LIBRARY)
         ${target_objects})
     tf_psa_crypto_set_base_compile_options(${tfpsacrypto_target})
     tf_psa_crypto_set_extra_compile_options(${tfpsacrypto_target})
+    if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
+        target_compile_options(${tfpsacrypto_target} PRIVATE
+            -ffunction-sections
+            -fdata-sections)
+    endif()
     set_target_properties(${tfpsacrypto_target} PROPERTIES VERSION ${TF_PSA_CRYPTO_VERSION} SOVERSION ${TF_PSA_CRYPTO_SOVERSION})
     target_link_libraries(${tfpsacrypto_target} PUBLIC ${libs})
 

--- a/drivers/pqcp/CMakeLists.txt
+++ b/drivers/pqcp/CMakeLists.txt
@@ -11,4 +11,9 @@ foreach (target IN LISTS target_libraries)
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
         PRIVATE mldsa-native/mldsa
     )
+    if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
+        target_compile_options(${target} PRIVATE
+            -ffunction-sections
+            -fdata-sections)
+    endif()
 endforeach(target)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -4,3 +4,14 @@ add_custom_target(${programs_target})
 add_subdirectory(psa)
 add_subdirectory(test)
 add_subdirectory(fuzz)
+
+# The driver-dispatch test configuration enables test-only PSA driver hooks in
+# the core library. The ML-DSA demo programs link only against tfpsacrypto, so
+# they do not pull in the test support objects that satisfy those references.
+#
+# test_psa_crypto_drivers enables this mode via CFLAGS, not via the
+# TF_PSA_CRYPTO_TEST_DRIVER CMake option, so detect both forms here.
+if(NOT TF_PSA_CRYPTO_TEST_DRIVER AND
+   NOT CMAKE_C_FLAGS MATCHES "(^| )-DPSA_CRYPTO_DRIVER_TEST([= ]|$)")
+    add_subdirectory(mldsa)
+endif()

--- a/programs/mldsa/CMakeLists.txt
+++ b/programs/mldsa/CMakeLists.txt
@@ -1,3 +1,10 @@
+function(tfpsacrypto_mldsa_enable_dead_code_elimination exe)
+    if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
+        set_property(TARGET ${exe} APPEND_STRING PROPERTY
+            LINK_FLAGS " -Wl,--gc-sections")
+    endif()
+endfunction()
+
 # mldsa_export_pubkey
 tfpsacrypto_build_program_common(mldsa_export_public mldsa_export_public.c asn1_file_io.c)
 target_include_directories(mldsa_export_public PRIVATE
@@ -5,6 +12,7 @@ target_include_directories(mldsa_export_public PRIVATE
       ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
 )
 
+tfpsacrypto_mldsa_enable_dead_code_elimination(mldsa_export_public)
 target_link_libraries(mldsa_export_public PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})
 
 # mldsa_sign
@@ -14,6 +22,7 @@ target_include_directories(mldsa_sign PRIVATE
       ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
 )
 
+tfpsacrypto_mldsa_enable_dead_code_elimination(mldsa_sign)
 target_link_libraries(mldsa_sign PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})
 
 # mldsa_verify
@@ -23,4 +32,5 @@ target_include_directories(mldsa_verify PRIVATE
       ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
 )
 
+tfpsacrypto_mldsa_enable_dead_code_elimination(mldsa_verify)
 target_link_libraries(mldsa_verify PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})

--- a/programs/mldsa/CMakeLists.txt
+++ b/programs/mldsa/CMakeLists.txt
@@ -1,0 +1,26 @@
+# mldsa_export_pubkey
+tfpsacrypto_build_program_common(mldsa_export_public mldsa_export_public.c asn1_file_io.c)
+target_include_directories(mldsa_export_public PRIVATE
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/src
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
+)
+
+target_link_libraries(mldsa_export_public PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})
+
+# mldsa_sign
+tfpsacrypto_build_program_common(mldsa_sign mldsa_sign.c asn1_file_io.c)
+target_include_directories(mldsa_sign PRIVATE
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/src
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
+)
+
+target_link_libraries(mldsa_sign PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})
+
+# mldsa_verify
+tfpsacrypto_build_program_common(mldsa_verify mldsa_verify.c asn1_file_io.c)
+target_include_directories(mldsa_verify PRIVATE
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/src
+      ${PROJECT_SOURCE_DIR}/drivers/pqcp/mldsa-native/mldsa/
+)
+
+target_link_libraries(mldsa_verify PRIVATE ${tfpsacrypto_static_target} ${CMAKE_THREAD_LIBS_INIT})

--- a/programs/mldsa/asn1_file_io.c
+++ b/programs/mldsa/asn1_file_io.c
@@ -1,0 +1,154 @@
+#include "asn1_file_io.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mbedtls/asn1.h"
+#include "mbedtls/asn1write.h"
+
+#if defined(MBEDTLS_ASN1_WRITE_C) && !defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+
+static int asn1_open_file(FILE **file, const char *path, const char *mode)
+{
+#if defined(_WIN32)
+    return fopen_s(file, path, mode);
+#else
+    *file = fopen(path, mode);
+    return *file == NULL ? -1 : 0;
+#endif
+}
+
+static int asn1_write_len_file(FILE *file, size_t len)
+{
+    unsigned char encoded_len[1 + sizeof(size_t)];
+    size_t encoded_len_size = 0;
+    size_t i;
+
+    if (len < 0x80) {
+        encoded_len[0] = (unsigned char) len;
+        encoded_len_size = 1;
+    } else {
+        size_t len_bytes = 0;
+        size_t tmp = len;
+
+        while (tmp != 0) {
+            encoded_len[sizeof(encoded_len) - 1 - len_bytes] =
+                (unsigned char) (tmp & 0xff);
+            tmp >>= 8;
+            len_bytes++;
+        }
+
+        encoded_len[0] = 0x80u | (unsigned char) len_bytes;
+        for (i = 0; i < len_bytes; i++) {
+            encoded_len[1 + i] =
+                encoded_len[sizeof(encoded_len) - len_bytes + i];
+        }
+        encoded_len_size = 1 + len_bytes;
+    }
+
+    if (fwrite(encoded_len, 1, encoded_len_size, file) != encoded_len_size) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int asn1_write_octet_string_file(const char *path,
+                                 const uint8_t *buffer,
+                                 size_t buffer_len)
+{
+    unsigned char tag = MBEDTLS_ASN1_OCTET_STRING;
+    FILE *file = NULL;
+
+    if (asn1_open_file(&file, path, "wb") != 0) {
+        return -1;
+    }
+
+    if (fwrite(&tag, 1, 1, file) != 1) {
+        fclose(file);
+        return -1;
+    }
+
+    if (asn1_write_len_file(file, buffer_len) != 0) {
+        fclose(file);
+        return -1;
+    }
+
+    if (fwrite(buffer, 1, buffer_len, file) != buffer_len) {
+        fclose(file);
+        return -1;
+    }
+
+    if (fclose(file) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int asn1_read_octet_string_file(const char *path,
+                                uint8_t *buffer,
+                                size_t buffer_len)
+{
+    int ret;
+    long file_len_long;
+    size_t file_len;
+    size_t octet_len;
+    unsigned char *der = NULL;
+    unsigned char *p = NULL;
+    FILE *file = NULL;
+
+    if (asn1_open_file(&file, path, "rb") != 0) {
+        return -1;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return -1;
+    }
+
+    file_len_long = ftell(file);
+    if (file_len_long <= 0) {
+        fclose(file);
+        return -1;
+    }
+
+    if (fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return -1;
+    }
+
+    file_len = (size_t) file_len_long;
+    der = malloc(file_len);
+    if (der == NULL) {
+        fclose(file);
+        return -1;
+    }
+
+    if (fread(der, 1, file_len, file) != file_len) {
+        fclose(file);
+        free(der);
+        return -1;
+    }
+
+    if (fclose(file) != 0) {
+        free(der);
+        return -1;
+    }
+
+    p = der;
+    ret = mbedtls_asn1_get_tag(&p, der + file_len, &octet_len,
+                               MBEDTLS_ASN1_OCTET_STRING);
+    if (ret != 0 || octet_len != buffer_len ||
+        p + octet_len != der + file_len) {
+        free(der);
+        return -1;
+    }
+
+    memcpy(buffer, p, buffer_len);
+    free(der);
+    return 0;
+}
+
+#endif /* MBEDTLS_ASN1_WRITE_C */

--- a/programs/mldsa/asn1_file_io.h
+++ b/programs/mldsa/asn1_file_io.h
@@ -1,0 +1,14 @@
+#ifndef TF_PSA_CRYPTO_PROGRAMS_ASN1_FILE_IO_H
+#define TF_PSA_CRYPTO_PROGRAMS_ASN1_FILE_IO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+int asn1_write_octet_string_file(const char *path,
+                                 const uint8_t *buffer,
+                                 size_t buffer_len);
+
+int asn1_read_octet_string_file(const char *path,
+                                uint8_t *buffer,
+                                size_t buffer_len);
+#endif

--- a/programs/mldsa/mldsa_constants.h
+++ b/programs/mldsa/mldsa_constants.h
@@ -1,0 +1,28 @@
+#ifndef TF_PSA_CRYPTO_PROGRAMS_MLDSA_CONSTANTS_H
+#define TF_PSA_CRYPTO_PROGRAMS_MLDSA_CONSTANTS_H
+
+#include <stdint.h>
+
+#define KEY_LENGTH 87
+
+#define MLDSA_RNDBYTES 32
+
+// Message from tf-psa-crypto/tests/suites/test_suite_pqcp_mldsa.dilithium_py.data:
+static const uint8_t message[] = {
+    0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20,
+    0x61, 0x20, 0x74, 0x65, 0x73, 0x74, 0x00
+};
+// Seed from tf-psa-crypto/tests/suites/test_suite_pqcp_mldsa.dilithium_py.data:
+static const uint8_t seed[] = {
+    0x54, 0x68, 0x65, 0x72, 0x65, 0x20, 0x77, 0x61,
+    0x73, 0x20, 0x6F, 0x6E, 0x63, 0x65, 0x20, 0x75,
+    0x70, 0x6F, 0x6E, 0x20, 0x61, 0x20, 0x74, 0x69,
+    0x6D, 0x65, 0x20, 0x61, 0x20, 0x2E, 0x2E, 0x2E
+};
+/* Native API detail used by the existing tests for pure ML-DSA, empty context. */
+static const uint8_t prefix[2] = { 0, 0 };
+static const uint8_t rnd[MLDSA_RNDBYTES] = { 0 };
+static const char signature_file[] = "signature.sig";
+static const char pub_key_file[] = "pubkey.key";
+static const char key_file[] = "key.key";
+#endif /* TF_PSA_CRYPTO_PROGRAMS_MLDSA_CONSTANTS_H */

--- a/programs/mldsa/mldsa_demo.sh
+++ b/programs/mldsa/mldsa_demo.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+. "${0%/*}/../../framework/scripts/demo_common.sh"
+
+msg <<'EOF'
+This program demonstrates the use of the PSA cryptography interface to
+sign a fixed message.
+EOF
+
+depends_on TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED MBEDTLS_ASN1_WRITE_C MBEDTLS_PSA_BUILTIN_GET_ENTROPY
+
+mldsa_export_public="${0%/*}"/mldsa_export_public
+mldsa_sign="${0%/*}"/mldsa_sign
+mldsa_verify="${0%/*}"/mldsa_verify
+files_to_clean="$files_to_clean pubkey.key signature.sig"
+
+"$mldsa_export_public"
+"$mldsa_sign"
+"$mldsa_verify"
+
+cleanup

--- a/programs/mldsa/mldsa_export_public.c
+++ b/programs/mldsa/mldsa_export_public.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+
+#include <tf-psa-crypto/build_info.h>
+
+#include "wrap_mldsa_native.h"
+#include "psa_crypto_mldsa.h"
+#include "mbedtls/platform.h"
+#include "mldsa_constants.h"
+#include "asn1_file_io.h"
+#include "psa/crypto.h"
+
+int main(void)
+{
+#if !defined(TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED) || \
+    !defined(TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED) || \
+    !defined(MBEDTLS_PSA_BUILTIN_GET_ENTROPY) || \
+    !defined(MBEDTLS_ASN1_WRITE_C) || \
+    defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) || \
+    defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+    puts(
+        "These programs require TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED MBEDTLS_ASN1_WRITE_C !MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS !MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG to be enabled in crypto_config.h");
+    return 0;
+#else
+
+    uint8_t public_key[MLDSA_PUBLICKEYBYTES(KEY_LENGTH)];
+
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    size_t public_key_length = SIZE_MAX;
+
+    psa_crypto_init();
+
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ML_DSA_KEY_PAIR);
+    psa_set_key_bits(&attributes, KEY_LENGTH);
+
+    /* Export into an exact-size buffer */
+    if (tf_psa_crypto_mldsa_export_public_key(&attributes,
+                                              seed, sizeof(seed),
+                                              public_key,
+                                              MLDSA_PUBLICKEYBYTES(KEY_LENGTH),
+                                              &public_key_length) != PSA_SUCCESS) {
+        mbedtls_printf("key generation failed\n");
+        return 1;
+    }
+
+    if (asn1_write_octet_string_file(pub_key_file, public_key, public_key_length) != 0) {
+        mbedtls_printf("key export failed\n");
+        return 1;
+    }
+#endif
+}

--- a/programs/mldsa/mldsa_sign.c
+++ b/programs/mldsa/mldsa_sign.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+
+#include <tf-psa-crypto/build_info.h>
+
+#include "wrap_mldsa_native.h"
+#include "psa_crypto_mldsa.h"
+#include "mbedtls/platform.h"
+#include "mldsa_constants.h"
+#include "asn1_file_io.h"
+#include "psa/crypto.h"
+
+int main(void)
+{
+#if !defined(TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED) || \
+    !defined(TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED) || \
+    !defined(MBEDTLS_PSA_BUILTIN_GET_ENTROPY) || \
+    !defined(MBEDTLS_ASN1_WRITE_C) || \
+    defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) || \
+    defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+    puts(
+        "These programs require TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED MBEDTLS_ASN1_WRITE_C !MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS !MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG to be enabled in crypto_config.h");
+    return 0;
+#else
+
+    uint8_t signature[MLDSA_BYTES(KEY_LENGTH)];
+    size_t signature_length = 0;
+
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_crypto_init();
+
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ML_DSA_KEY_PAIR);
+    psa_set_key_bits(&attributes, KEY_LENGTH);
+
+    /* Sign into an exact-size buffer */
+    if (tf_psa_crypto_mldsa_sign_message(&attributes, seed, sizeof(seed),
+                                         PSA_ALG_DETERMINISTIC_ML_DSA,
+                                         message, sizeof(message),
+                                         signature, MLDSA_BYTES(KEY_LENGTH),
+                                         &signature_length) != 0) {
+        mbedtls_printf("sign failed\n");
+        return 1;
+    }
+
+    if (signature_length != sizeof(signature) ||
+        asn1_write_octet_string_file(signature_file, signature, signature_length) != PSA_SUCCESS) {
+        mbedtls_printf("signature export failed\n");
+        return 1;
+    }
+#endif
+}

--- a/programs/mldsa/mldsa_verify.c
+++ b/programs/mldsa/mldsa_verify.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+
+#include <tf-psa-crypto/build_info.h>
+
+#include "wrap_mldsa_native.h"
+#include "psa_crypto_mldsa.h"
+#include "mbedtls/platform.h"
+#include "mldsa_constants.h"
+#include "asn1_file_io.h"
+#include "psa/crypto.h"
+
+int main(void)
+{
+#if !defined(TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED) || \
+    !defined(TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED) || \
+    !defined(MBEDTLS_PSA_BUILTIN_GET_ENTROPY) || \
+    !defined(MBEDTLS_ASN1_WRITE_C) || \
+    defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS) || \
+    defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
+    puts(
+        "These programs require TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED MBEDTLS_ASN1_WRITE_C !MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS !MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG to be enabled in crypto_config.h");
+    return 0;
+#else
+
+    unsigned char public_key[MLDSA_PUBLICKEYBYTES(KEY_LENGTH)];
+    unsigned char signature[MLDSA_BYTES(KEY_LENGTH)];
+
+    if (asn1_read_octet_string_file(signature_file, signature, sizeof(signature)) != 0 ||
+        asn1_read_octet_string_file(pub_key_file, public_key, sizeof(public_key)) != 0) {
+        return 1;
+    }
+
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    psa_crypto_init();
+
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_ML_DSA_PUBLIC_KEY);
+    psa_set_key_bits(&attributes, KEY_LENGTH);
+
+    if (tf_psa_crypto_mldsa_verify_message(&attributes,
+                                           public_key, MLDSA_PUBLICKEYBYTES(KEY_LENGTH),
+                                           PSA_ALG_DETERMINISTIC_ML_DSA,
+                                           message, sizeof(message),
+                                           signature, sizeof(signature)) != PSA_SUCCESS) {
+        mbedtls_printf("verify failed\n");
+        return 1;
+    }
+#endif
+}

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -515,6 +515,13 @@ component_test_pqcp_own_shake_no_builtin () {
     ctest
 }
 
+support_build_mldsa_program_symbol_partition () {
+    case "$OSTYPE" in
+        msys*|cygwin*|win32*) false ;;
+        *) type nm >/dev/null 2>/dev/null ;;
+    esac
+}
+
 component_build_mldsa_program_symbol_partition () {
     msg "build: ML-DSA program symbol partition"
 
@@ -524,7 +531,9 @@ component_build_mldsa_program_symbol_partition () {
 
     cd "$OUT_OF_SOURCE_DIR"
     cmake -DENABLE_PROGRAMS=ON -DENABLE_TESTING=OFF "$TF_PSA_CRYPTO_ROOT_DIR"
-    cmake --build . --target mldsa_export_public mldsa_sign mldsa_verify
+    cmake --build . --target mldsa_export_public
+    cmake --build . --target mldsa_sign
+    cmake --build . --target mldsa_verify
 
     nm -C --defined-only programs/mldsa/mldsa_sign > mldsa_sign.syms
     nm -C --defined-only programs/mldsa/mldsa_verify > mldsa_verify.syms

--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -514,3 +514,34 @@ component_test_pqcp_own_shake_no_builtin () {
     msg "test: TF_PSA_CRYPTO_PQCP_OWN_SHAKE, built-in SHA3/SHAKE disabled"
     ctest
 }
+
+component_build_mldsa_program_symbol_partition () {
+    msg "build: ML-DSA program symbol partition"
+
+    scripts/config.py set TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED
+    scripts/config.py set TF_PSA_CRYPTO_PQCP_MLDSA_87_ENABLED
+    scripts/config.py set MBEDTLS_ASN1_WRITE_C
+
+    cd "$OUT_OF_SOURCE_DIR"
+    cmake -DENABLE_PROGRAMS=ON -DENABLE_TESTING=OFF "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake --build . --target mldsa_export_public mldsa_sign mldsa_verify
+
+    nm -C --defined-only programs/mldsa/mldsa_sign > mldsa_sign.syms
+    nm -C --defined-only programs/mldsa/mldsa_verify > mldsa_verify.syms
+    nm -C --defined-only programs/mldsa/mldsa_export_public > mldsa_export_public.syms
+
+    grep -Eq \
+        'tf_psa_crypto_mldsa_sign_message|tf_psa_crypto_pqcp_mldsa87_signature_internal' \
+        mldsa_sign.syms
+
+    not grep -Eq \
+        'tf_psa_crypto_mldsa_sign_message|tf_psa_crypto_pqcp_mldsa87_signature_internal' \
+        mldsa_verify.syms
+    not grep -Eq \
+        'tf_psa_crypto_mldsa_sign_message|tf_psa_crypto_pqcp_mldsa87_signature_internal' \
+        mldsa_export_public.syms
+
+    grep -Eq \
+        'tf_psa_crypto_mldsa_verify_message|tf_psa_crypto_pqcp_mldsa87_verify' \
+        mldsa_verify.syms
+}


### PR DESCRIPTION
## Description

1. Add the mldsa test programs mldsa_export_public.c mldsa_sign.c, mldsa_verify.c and create a demo script. 
2. Modify the build so the programs only include the symbols that are needed by them.
3. Add an all.sh component to verify the mldsa_sign is the only program that includes the sign symbols.

resolves: https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/644

## PR checklist

- [ ] **changelog** provided | not required because: TBC
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** provided #HERE
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: No Backports
- [ ] **mbedtls development PR** not required because: No changes
- [ ] **mbedtls 4.1 PR** not required because: No changes
- [ ] **mbedtls 3.6 PR**  not required because: No changes
- **tests**  provided
