### PR TITLE
Add fix for memset_s issue discovered with ATFE

### DIFF
--- a/core/tf_psa_crypto_platform_requirements.h
+++ b/core/tf_psa_crypto_platform_requirements.h
@@ -15,10 +15,13 @@
 #ifndef TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 #define TF_PSA_CRYPTO_TF_PSA_CRYPTO_PLATFORM_REQUIREMENTS_H
 
+/* Do not try to use the library extension with ATfE toolchain */
+#if !defined(__GNUC__) || !defined(__clang_major__)
 #ifndef __STDC_WANT_LIB_EXT1__
 /* Ask for the C11 gmtime_s() and memset_s() if available */
 #define __STDC_WANT_LIB_EXT1__ 1
 #endif
+#endif /* !__GNUC__ || !__clang_major__ */
 
 #if !defined(_POSIX_C_SOURCE)
 /* For standards-compliant access to


### PR DESCRIPTION
## Description

Add fix for memset_s issue discovered with ATFE resolves https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/754. Adds a patch currently being used by TF-M. Open issues are do we want to add additional testing to cover their use cases and do we want to backport it? Let me know what people think?

## PR checklist

- [ ] **changelog** not required because: No public changes
- [ ] **framework PR** provided not required
- [ ] **TF-PSA-Crypto development PR** provided #HERE
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: TBD
- [ ] **mbedtls development PR** not required because: No changes
- [ ] **mbedtls 4.1 PR** not required because: No changes
- [ ] **mbedtls 3.6 PR** not required because: No changes
- **tests**  not required because: TBD