### PR TITLE
include tf_psa_crypto_platform_requirements.h in tf_psa_crypto_config.c

### DIFF
--- a/ChangeLog.d/issue784.txt
+++ b/ChangeLog.d/issue784.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fixed a bug which prevented the inclusion of standard C library header
+     files from the user provided configuration file. Fixes #784.

--- a/core/tf_psa_crypto_config.c
+++ b/core/tf_psa_crypto_config.c
@@ -6,6 +6,8 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "tf_psa_crypto_platform_requirements.h"
+
 /* Detect whether this is a normal build of the library, or a build of
  * libtestdriver1, where all identifiers starting with normal prefixes
  * have LIBTESTDRIVER1_ prepended. Do this without relying on


### PR DESCRIPTION
## Description

This is required because if the user defined configuration file (not the default one provided by tf-psa-crypto) includes files from the standard C library then __STDC_WANT_LIB_EXT1__ won't be defined there which cause weird build failures.

Resolves #784

## PR checklist

- [x] **changelog** not required because: minor fix?
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided: this one
- [x] **TF-PSA-Crypto 1.1 PR**  https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/785
- [x] **mbedtls development PR** https://github.com/Mbed-TLS/mbedtls/pull/10741
- [ ] **mbedtls 4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10742
- [x] **mbedtls 3.6 PR** not required because: code added after 3.6
- **tests** not required because: nothing to be tested