### PR TITLE
Fix ML-DSA signing error propagation

### DIFF
--- a/ChangeLog.d/mldsa-sign-error.txt
+++ b/ChangeLog.d/mldsa-sign-error.txt
@@ -1,3 +1,0 @@
-Bugfix
-   * Fix ML-DSA signing to report internal mldsa-native failures instead of
-     reporting success without a signature.

--- a/ChangeLog.d/mldsa-sign-error.txt
+++ b/ChangeLog.d/mldsa-sign-error.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix ML-DSA signing to report internal mldsa-native failures instead of
+     reporting success without a signature.

--- a/drivers/pqcp/src/psa_crypto_mldsa.c
+++ b/drivers/pqcp/src/psa_crypto_mldsa.c
@@ -27,18 +27,19 @@
 
 static psa_status_t pqcp_to_psa_error(int ret)
 {
-    /* At the time of writing, mldsa-native has very few documented error
-     * conditions: only invalid signature on verification, and self-test
-     * failure. But this will change when we update mldsa-native
-     * with support for heap allocation of intermediate values.
-     */
     if (ret == 0) {
         return PSA_SUCCESS;
     } else if (ret == MLD_ERR_OUT_OF_MEMORY) {
         return PSA_ERROR_INSUFFICIENT_MEMORY;
     } else {
-        /* Not really hardware, but this is the fallback error code for
-         * something unexpectedly going wrong in a driver. */
+        /* MLD_ERR_RNG_FAIL is intentionally not mapped: we don't install
+         * mldsa-native's RNG callback (mu is computed on our side for
+         * hedged ML-DSA), so it shouldn't be reachable. It would land
+         * here and be reported as a generic driver failure.
+         *
+         * Not really hardware, but PSA_ERROR_HARDWARE_FAILURE is the
+         * fallback error code for something unexpectedly going wrong
+         * in a driver. */
         return PSA_ERROR_HARDWARE_FAILURE;
     }
 }

--- a/drivers/pqcp/src/psa_crypto_mldsa.c
+++ b/drivers/pqcp/src/psa_crypto_mldsa.c
@@ -34,6 +34,8 @@ static psa_status_t pqcp_to_psa_error(int ret)
      */
     if (ret == 0) {
         return PSA_SUCCESS;
+    } else if (ret == MLD_ERR_OUT_OF_MEMORY) {
+        return PSA_ERROR_INSUFFICIENT_MEMORY;
     } else {
         /* Not really hardware, but this is the fallback error code for
          * something unexpectedly going wrong in a driver. */
@@ -145,7 +147,6 @@ psa_status_t tf_psa_crypto_mldsa_sign_message(
                                                         rnd,
                                                         secret,
                                                         0);
-    ret = 0;
 
 cleanup:
     mbedtls_platform_zeroize(secret, sizeof(secret));


### PR DESCRIPTION
## Description

The ML-DSA PSA signing wrapper called mldsa-native to produce a signature, but
then overwrote the mldsa-native return value with success before returning.

This PR preserves the mldsa-native return value so internal signing failures are
reported through the PSA status code. It also maps mldsa-native allocation
failure to `PSA_ERROR_INSUFFICIENT_MEMORY`.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided #THIS_PR
- [x] **TF-PSA-Crypto 1.1 PR** not required because: ML-DSA support is only on the development branch
- [x] **mbedtls development PR** not required because: this PR only changes TF-PSA-Crypto source; Mbed TLS can update the submodule separately after this lands
- [x] **mbedtls 4.1 PR** not required because: this PR only changes TF-PSA-Crypto development
- [x] **mbedtls 3.6 PR** not required because: ML-DSA support is not present there
- **tests** not required because: the existing ML-DSA tests cover the normal signing path, and the failure path fixed here requires mldsa-native internal failure injection or custom allocation plumbing to trigger directly.
