### PR TITLE
[1.1] Fix alignment problems with IAR and Zephyr

### DIFF
--- a/ChangeLog.d/iar-alignment-fix.txt
+++ b/ChangeLog.d/iar-alignment-fix.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * Fix a problem in library/alignment.h where the Zephyr Project use
+     a pre-defined macro '__packed' which collides with the IAR keyword
+     '__packed', causing the typedefs of unaligned types to remain aligned.
+     Fixes mbedtls issue #10334
+

--- a/core/alignment.h
+++ b/core/alignment.h
@@ -47,14 +47,27 @@
 #pragma language=extended
 #define MBEDTLS_POP_IAR_LANGUAGE_PRAGMA
 /* IAR recommend this technique for accessing unaligned data in
- * https://www.iar.com/knowledge/support/technical-notes/compiler/accessing-unaligned-data
+ * https://mypages.iar.com/s/article/Accessing-Unaligned-Data
  * This results in a single load / store instruction (if unaligned access is supported).
  * According to that document, this is only supported on certain architectures.
  */
-    #define UINT_UNALIGNED
+#define UINT_UNALIGNED
+/* Some products, like Zephyr, defines __packed as a macro for attribute(packed) and
+ * that does not work with typedefs, so if __packed is defined, undef it for the
+ * typedefs and restore it afterwards.
+ */
+#ifdef __packed
+#pragma push_macro("__packed")
+#undef __packed
+#define MBEDTLS_IAR_PACKED_MACRO_USED
+#endif
 typedef uint16_t __packed mbedtls_uint16_unaligned_t;
 typedef uint32_t __packed mbedtls_uint32_unaligned_t;
 typedef uint64_t __packed mbedtls_uint64_unaligned_t;
+#ifdef MBEDTLS_IAR_PACKED_MACRO_USED
+#undef MBEDTLS_IAR_PACKED_MACRO_USED
+#pragma pop_macro("__packed")
+#endif
 #elif defined(MBEDTLS_COMPILER_IS_GCC) && (MBEDTLS_GCC_VERSION >= 40504) && \
     ((MBEDTLS_GCC_VERSION < 60300) || (!defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)))
 /*


### PR DESCRIPTION
Since __packed is a reserved keyword for IAR compilers, and Zephyr defines it to attribute(__packed__), some typedef constructs in TF-PSA-Crypto does not work with attribute(packed), only with the keyword __packed.

Added changelog entry.

This fix temporary undefs the macro and restores it after the typedefs.

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided 
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/410
- [x] **TF-PSA-Crypto 1.1 PR** here
- [ ] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10202
- **tests**  not required because: integration fix, up to the integrator to validate
