### PR TITLE
Fix -Wundef warnings for MBEDTLS_GCC_VERSION in alignment.h

### DIFF
--- a/core/alignment.h
+++ b/core/alignment.h
@@ -281,10 +281,10 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
  * Detect GCC built-in byteswap routines
  */
 #if defined(__GNUC__)
-#if MBEDTLS_GCC_VERSION >= 40800
+#if defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 40800
 #define MBEDTLS_BSWAP16 __builtin_bswap16
 #endif
-#if MBEDTLS_GCC_VERSION >= 40300
+#if defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 40300
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #define MBEDTLS_BSWAP64 __builtin_bswap64
 #endif


### PR DESCRIPTION
## Description

`MBEDTLS_GCC_VERSION` is only defined when the compiler is GCC (not clang or other compilers). Lines 284 and 287 of `alignment.h` used it in bare `#if` directives without a `defined()` guard, triggering `-Wundef` warnings when compiling with clang and `-Werror,-Wundef`.

Add `defined(MBEDTLS_COMPILER_IS_GCC)` guard to both lines.

### Reproduce

The issue triggers when compiling with clang and `-Wundef`, since clang is excluded from the `MBEDTLS_GCC_VERSION` definition in `build_info.h`:

```
gcc -fsyntax-only -Wundef -Werror \
      -I ../include -I core -I include \
      -I drivers/builtin/include \
      core/alignment.h
```

```
clang -fsyntax-only -Wundef -Werror \
    -I include \
    -I core \
    -I drivers/builtin/include \
    core/tf_psa_crypto_common.h
```

### Testing

* Reproduce step
* Build and SSL test suites pass 

A corresponding fix for the 3.6 LTS branch will be submitted as a separate PR against `Mbed-TLS/mbedtls:mbedtls-3.6`.

## PR checklist

- [ ] **changelog** not required because: trivial warning fix, no behavior change
- [ ] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided (this PR)
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: can backport after merge
- [ ] **mbedtls development PR** not required because: file is in tf-psa-crypto submodule
- [ ] **mbedtls 4.1 PR** not required because: file is in tf-psa-crypto submodule
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#([will add link after creating](https://github.com/Mbed-TLS/mbedtls/pull/10717))
- **tests** not required because: compile-time warning fix only, no runtime behavior change