### PR TITLE
[backport 1.1] include tf_psa_crypto_platform_requirements.h in tf_psa_crypto_config.c

### DIFF
--- a/ChangeLog.d/issue784.txt
+++ b/ChangeLog.d/issue784.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fixed a bug which prevented the inclusion of standard C library header
+     files from the user provided configuration file. Fixes #784.

--- a/core/tf_psa_crypto_config.c
+++ b/core/tf_psa_crypto_config.c
@@ -6,6 +6,8 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "tf_psa_crypto_platform_requirements.h"
+
 /* Detect whether this is a normal build of the library, or a build of
  * libtestdriver1, where all identifiers starting with normal prefixes
  * have LIBTESTDRIVER1_ prepended. Do this without relying on


### PR DESCRIPTION
## Description

Backport of #777

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/777
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: THIS ONE
- [ ] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10741
- [ ] **mbedtls 4.1 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10742
- [ ] **mbedtls 3.6 PR** not required because: as in #777
- **tests**  not required because: as in #777