### PR TITLE
Fix wrong option names in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,7 +134,7 @@ even remote. The attacks can result in key recovery.
 
 - Turn on hardware acceleration for AES. This is supported only on selected
   architectures and currently only available for AES. See configuration options
-  `TF_PSA_CRYPTO_AESCE_C` and `TF_PSA_CRYPTO_AESNI_C` for details.
+  `MBEDTLS_AESCE_C` and `MBEDTLS_AESNI_C` for details.
 - Add a secure alternative implementation (typically hardware acceleration) for
   the vulnerable cipher. See the [PSA Cryptography Driver Interface](
   docs/proposed/psa-driver-interface.md) for more information.


### PR DESCRIPTION
`SECURITY.md` was updated with `TF_PSA_CRYPTO_xxx` option names instead of `MBEDTLS_xxx` in #82, but we didn't end up doing a mass renaming of config options. Restore the correct names.

I think all other places have already been fixed, but I didn't look very hard.

## PR checklist

- [x] **changelog** provided | not required because: doc only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** here
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: crypto only
- **tests**  not required because: doc only
