### PR TITLE
Backport 1.1: Don't copy buffers for low-risk PSA operations

### DIFF
--- a/ChangeLog.d/psa-buffer-copying.txt
+++ b/ChangeLog.d/psa-buffer-copying.txt
@@ -1,0 +1,4 @@
+Features
+   * PSA hash, MAC and XOF functions no longer use intermediate buffers on
+     the heap for their inputs and outputs, even when
+     MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS is disabled. Fixes #795.

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -2497,22 +2497,15 @@ psa_status_t psa_xof_set_context(psa_xof_operation_t *operation,
     }
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(context_external, context);
 
     operation->has_context = 1;
 
-    LOCAL_INPUT_ALLOC(context_external, context_length, context);
     status = psa_driver_wrapper_xof_set_context(operation,
                                                 context, context_length);
-    // Label otherwise unused when MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS is enabled
-    goto exit;
 
-exit:
     if (status != PSA_SUCCESS) {
         psa_xof_abort(operation);
     }
-
-    LOCAL_INPUT_FREE(context_external, context);
     return status;
 }
 

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -2501,7 +2501,7 @@ psa_status_t psa_xof_set_context(psa_xof_operation_t *operation,
     operation->has_context = 1;
 
     status = psa_driver_wrapper_xof_set_context(operation,
-                                                context, context_length);
+                                                context_external, context_length);
 
     if (status != PSA_SUCCESS) {
         psa_xof_abort(operation);

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -2266,7 +2266,6 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
                              size_t input_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(input_external, input);
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;
@@ -2279,22 +2278,19 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
         return PSA_SUCCESS;
     }
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
-    status = psa_driver_wrapper_hash_update(operation, input, input_length);
+    status = psa_driver_wrapper_hash_update(operation, input_external, input_length);
 
 exit:
     if (status != PSA_SUCCESS) {
         psa_hash_abort(operation);
     }
-
-    LOCAL_INPUT_FREE(input_external, input);
     return status;
 }
 
-static psa_status_t psa_hash_finish_internal(psa_hash_operation_t *operation,
-                                             uint8_t *hash,
-                                             size_t hash_size,
-                                             size_t *hash_length)
+psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
+                             uint8_t *hash,
+                             size_t hash_size,
+                             size_t *hash_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
@@ -2310,24 +2306,6 @@ static psa_status_t psa_hash_finish_internal(psa_hash_operation_t *operation,
     return status;
 }
 
-psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
-                             uint8_t *hash_external,
-                             size_t hash_size,
-                             size_t *hash_length)
-{
-    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_OUTPUT_DECLARE(hash_external, hash);
-
-    LOCAL_OUTPUT_ALLOC(hash_external, hash_size, hash);
-    status = psa_hash_finish_internal(operation, hash, hash_size, hash_length);
-
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-exit:
-#endif
-    LOCAL_OUTPUT_FREE(hash_external, hash);
-    return status;
-}
-
 psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
                              const uint8_t *hash_external,
                              size_t hash_length)
@@ -2335,9 +2313,8 @@ psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
     uint8_t actual_hash[PSA_HASH_MAX_SIZE];
     size_t actual_hash_length;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(hash_external, hash);
 
-    status = psa_hash_finish_internal(
+    status = psa_hash_finish(
         operation,
         actual_hash, sizeof(actual_hash),
         &actual_hash_length);
@@ -2351,8 +2328,7 @@ psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
         goto exit;
     }
 
-    LOCAL_INPUT_ALLOC(hash_external, hash_length, hash);
-    if (mbedtls_ct_memcmp(hash, actual_hash, actual_hash_length) != 0) {
+    if (mbedtls_ct_memcmp(hash_external, actual_hash, actual_hash_length) != 0) {
         status = PSA_ERROR_INVALID_SIGNATURE;
     }
 
@@ -2361,7 +2337,6 @@ exit:
     if (status != PSA_SUCCESS) {
         psa_hash_abort(operation);
     }
-    LOCAL_INPUT_FREE(hash_external, hash);
     return status;
 }
 
@@ -2371,24 +2346,14 @@ psa_status_t psa_hash_compute(psa_algorithm_t alg,
                               size_t *hash_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(input_external, input);
-    LOCAL_OUTPUT_DECLARE(hash_external, hash);
 
     *hash_length = 0;
     if (!PSA_ALG_IS_HASH(alg)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
-    LOCAL_OUTPUT_ALLOC(hash_external, hash_size, hash);
-    status = psa_driver_wrapper_hash_compute(alg, input, input_length,
-                                             hash, hash_size, hash_length);
-
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-exit:
-#endif
-    LOCAL_INPUT_FREE(input_external, input);
-    LOCAL_OUTPUT_FREE(hash_external, hash);
+    status = psa_driver_wrapper_hash_compute(alg, input_external, input_length,
+                                             hash_external, hash_size, hash_length);
     return status;
 }
 
@@ -2400,17 +2365,13 @@ psa_status_t psa_hash_compare(psa_algorithm_t alg,
     size_t actual_hash_length;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    LOCAL_INPUT_DECLARE(input_external, input);
-    LOCAL_INPUT_DECLARE(hash_external, hash);
-
     if (!PSA_ALG_IS_HASH(alg)) {
         status = PSA_ERROR_INVALID_ARGUMENT;
         return status;
     }
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
     status = psa_driver_wrapper_hash_compute(
-        alg, input, input_length,
+        alg, input_external, input_length,
         actual_hash, sizeof(actual_hash),
         &actual_hash_length);
     if (status != PSA_SUCCESS) {
@@ -2421,17 +2382,12 @@ psa_status_t psa_hash_compare(psa_algorithm_t alg,
         goto exit;
     }
 
-    LOCAL_INPUT_ALLOC(hash_external, hash_length, hash);
-    if (mbedtls_ct_memcmp(hash, actual_hash, actual_hash_length) != 0) {
+    if (mbedtls_ct_memcmp(hash_external, actual_hash, actual_hash_length) != 0) {
         status = PSA_ERROR_INVALID_SIGNATURE;
     }
 
 exit:
     mbedtls_platform_zeroize(actual_hash, sizeof(actual_hash));
-
-    LOCAL_INPUT_FREE(input_external, input);
-    LOCAL_INPUT_FREE(hash_external, hash);
-
     return status;
 }
 
@@ -2578,7 +2534,6 @@ psa_status_t psa_xof_update(psa_xof_operation_t *operation,
     }
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(input_external, input);
 
     operation->has_input = 1;
 
@@ -2588,17 +2543,11 @@ psa_status_t psa_xof_update(psa_xof_operation_t *operation,
         return PSA_SUCCESS;
     }
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
-    status = psa_driver_wrapper_xof_update(operation, input, input_length);
-    // Label otherwise unused when MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS is enabled
-    goto exit;
+    status = psa_driver_wrapper_xof_update(operation, input_external, input_length);
 
-exit:
     if (status != PSA_SUCCESS) {
         psa_xof_abort(operation);
     }
-
-    LOCAL_INPUT_FREE(input_external, input);
     return status;
 }
 
@@ -2617,7 +2566,6 @@ psa_status_t psa_xof_output(psa_xof_operation_t *operation,
     }
 
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_OUTPUT_DECLARE(output_external, output);
 
     operation->has_output = 1;
 
@@ -2627,17 +2575,11 @@ psa_status_t psa_xof_output(psa_xof_operation_t *operation,
         return PSA_SUCCESS;
     }
 
-    LOCAL_OUTPUT_ALLOC(output_external, output_length, output);
-    status = psa_driver_wrapper_xof_output(operation, output, output_length);
-    // Label otherwise unused when MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS is enabled
-    goto exit;
+    status = psa_driver_wrapper_xof_output(operation, output_external, output_length);
 
-exit:
     if (status != PSA_SUCCESS) {
         psa_xof_abort(operation);
     }
-
-    LOCAL_OUTPUT_FREE(output_external, output);
     return status;
 }
 
@@ -2797,7 +2739,6 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
                             size_t input_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(input_external, input);
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;
@@ -2811,18 +2752,11 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
         return status;
     }
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
-    status = psa_driver_wrapper_mac_update(operation, input, input_length);
+    status = psa_driver_wrapper_mac_update(operation, input_external, input_length);
 
     if (status != PSA_SUCCESS) {
         psa_mac_abort(operation);
     }
-
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-exit:
-#endif
-    LOCAL_INPUT_FREE(input_external, input);
-
     return status;
 }
 
@@ -2833,8 +2767,6 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_OUTPUT_DECLARE(mac_external, mac);
-    LOCAL_OUTPUT_ALLOC(mac_external, mac_size, mac);
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;
@@ -2860,7 +2792,8 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
 
 
     status = psa_driver_wrapper_mac_sign_finish(operation,
-                                                mac, operation->mac_size,
+                                                mac_external,
+                                                operation->mac_size,
                                                 mac_length);
 
 exit:
@@ -2875,13 +2808,11 @@ exit:
         operation->mac_size = 0;
     }
 
-    if (mac != NULL) {
-        psa_wipe_tag_output_buffer(mac, status, mac_size, *mac_length);
+    if (mac_external != NULL) {
+        psa_wipe_tag_output_buffer(mac_external, status, mac_size, *mac_length);
     }
 
     abort_status = psa_mac_abort(operation);
-    LOCAL_OUTPUT_FREE(mac_external, mac);
-
     return status == PSA_SUCCESS ? abort_status : status;
 }
 
@@ -2891,7 +2822,6 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(mac_external, mac);
 
     if (operation->id == 0) {
         status = PSA_ERROR_BAD_STATE;
@@ -2908,13 +2838,11 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
         goto exit;
     }
 
-    LOCAL_INPUT_ALLOC(mac_external, mac_length, mac);
     status = psa_driver_wrapper_mac_verify_finish(operation,
-                                                  mac, mac_length);
+                                                  mac_external, mac_length);
 
 exit:
     abort_status = psa_mac_abort(operation);
-    LOCAL_INPUT_FREE(mac_external, mac);
 
     return status == PSA_SUCCESS ? abort_status : status;
 }
@@ -2988,21 +2916,9 @@ psa_status_t psa_mac_compute(mbedtls_svc_key_id_t key,
                              size_t *mac_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    LOCAL_INPUT_DECLARE(input_external, input);
-    LOCAL_OUTPUT_DECLARE(mac_external, mac);
-
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
-    LOCAL_OUTPUT_ALLOC(mac_external, mac_size, mac);
     status = psa_mac_compute_internal(key, alg,
-                                      input, input_length,
-                                      mac, mac_size, mac_length, 1);
-
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-exit:
-#endif
-    LOCAL_INPUT_FREE(input_external, input);
-    LOCAL_OUTPUT_FREE(mac_external, mac);
-
+                                      input_external, input_length,
+                                      mac_external, mac_size, mac_length, 1);
     return status;
 }
 
@@ -3016,12 +2932,9 @@ psa_status_t psa_mac_verify(mbedtls_svc_key_id_t key,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     uint8_t actual_mac[PSA_MAC_MAX_SIZE];
     size_t actual_mac_length;
-    LOCAL_INPUT_DECLARE(input_external, input);
-    LOCAL_INPUT_DECLARE(mac_external, mac);
 
-    LOCAL_INPUT_ALLOC(input_external, input_length, input);
     status = psa_mac_compute_internal(key, alg,
-                                      input, input_length,
+                                      input_external, input_length,
                                       actual_mac, sizeof(actual_mac),
                                       &actual_mac_length, 0);
     if (status != PSA_SUCCESS) {
@@ -3033,17 +2946,13 @@ psa_status_t psa_mac_verify(mbedtls_svc_key_id_t key,
         goto exit;
     }
 
-    LOCAL_INPUT_ALLOC(mac_external, mac_length, mac);
-    if (mbedtls_ct_memcmp(mac, actual_mac, actual_mac_length) != 0) {
+    if (mbedtls_ct_memcmp(mac_external, actual_mac, actual_mac_length) != 0) {
         status = PSA_ERROR_INVALID_SIGNATURE;
         goto exit;
     }
 
 exit:
     mbedtls_platform_zeroize(actual_mac, sizeof(actual_mac));
-    LOCAL_INPUT_FREE(input_external, input);
-    LOCAL_INPUT_FREE(mac_external, mac);
-
     return status;
 }
 

--- a/tests/include/test/psa_test_wrappers.h
+++ b/tests/include/test/psa_test_wrappers.h
@@ -715,6 +715,21 @@ psa_status_t mbedtls_test_wrap_psa_purge_key(
 #define psa_purge_key(arg0_key) \
     mbedtls_test_wrap_psa_purge_key(arg0_key)
 
+psa_status_t mbedtls_test_wrap_psa_random_deplete(void);
+#define psa_random_deplete() \
+    mbedtls_test_wrap_psa_random_deplete()
+
+psa_status_t mbedtls_test_wrap_psa_random_reseed(
+    const uint8_t *arg0_perso,
+    size_t arg1_perso_size);
+#define psa_random_reseed(arg0_perso, arg1_perso_size) \
+    mbedtls_test_wrap_psa_random_reseed(arg0_perso, arg1_perso_size)
+
+psa_status_t mbedtls_test_wrap_psa_random_set_prediction_resistance(
+    unsigned arg0_enabled);
+#define psa_random_set_prediction_resistance(arg0_enabled) \
+    mbedtls_test_wrap_psa_random_set_prediction_resistance(arg0_enabled)
+
 psa_status_t mbedtls_test_wrap_psa_raw_key_agreement(
     psa_algorithm_t arg0_alg,
     mbedtls_svc_key_id_t arg1_private_key,

--- a/tests/src/psa_test_wrappers.c
+++ b/tests/src/psa_test_wrappers.c
@@ -714,15 +714,7 @@ psa_status_t mbedtls_test_wrap_psa_hash_compare(
     const uint8_t *arg3_hash,
     size_t arg4_hash_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_input, arg2_input_length);
-    MBEDTLS_TEST_MEMORY_POISON(arg3_hash, arg4_hash_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_hash_compare)(arg0_alg, arg1_input, arg2_input_length, arg3_hash, arg4_hash_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_input, arg2_input_length);
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg3_hash, arg4_hash_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -735,15 +727,7 @@ psa_status_t mbedtls_test_wrap_psa_hash_compute(
     size_t arg4_hash_size,
     size_t *arg5_hash_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_input, arg2_input_length);
-    MBEDTLS_TEST_MEMORY_POISON(arg3_hash, arg4_hash_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_hash_compute)(arg0_alg, arg1_input, arg2_input_length, arg3_hash, arg4_hash_size, arg5_hash_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_input, arg2_input_length);
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg3_hash, arg4_hash_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -754,13 +738,7 @@ psa_status_t mbedtls_test_wrap_psa_hash_finish(
     size_t arg2_hash_size,
     size_t *arg3_hash_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_hash, arg2_hash_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_hash_finish)(arg0_operation, arg1_hash, arg2_hash_size, arg3_hash_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_hash, arg2_hash_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -779,13 +757,7 @@ psa_status_t mbedtls_test_wrap_psa_hash_update(
     const uint8_t *arg1_input,
     size_t arg2_input_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_hash_update)(arg0_operation, arg1_input, arg2_input_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -795,13 +767,7 @@ psa_status_t mbedtls_test_wrap_psa_hash_verify(
     const uint8_t *arg1_hash,
     size_t arg2_hash_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_hash, arg2_hash_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_hash_verify)(arg0_operation, arg1_hash, arg2_hash_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_hash, arg2_hash_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1030,15 +996,7 @@ psa_status_t mbedtls_test_wrap_psa_mac_compute(
     size_t arg5_mac_size,
     size_t *arg6_mac_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg2_input, arg3_input_length);
-    MBEDTLS_TEST_MEMORY_POISON(arg4_mac, arg5_mac_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_mac_compute)(arg0_key, arg1_alg, arg2_input, arg3_input_length, arg4_mac, arg5_mac_size, arg6_mac_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg2_input, arg3_input_length);
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg4_mac, arg5_mac_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1049,13 +1007,7 @@ psa_status_t mbedtls_test_wrap_psa_mac_sign_finish(
     size_t arg2_mac_size,
     size_t *arg3_mac_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_mac, arg2_mac_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_mac_sign_finish)(arg0_operation, arg1_mac, arg2_mac_size, arg3_mac_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_mac, arg2_mac_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1075,13 +1027,7 @@ psa_status_t mbedtls_test_wrap_psa_mac_update(
     const uint8_t *arg1_input,
     size_t arg2_input_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_mac_update)(arg0_operation, arg1_input, arg2_input_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1094,15 +1040,7 @@ psa_status_t mbedtls_test_wrap_psa_mac_verify(
     const uint8_t *arg4_mac,
     size_t arg5_mac_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg2_input, arg3_input_length);
-    MBEDTLS_TEST_MEMORY_POISON(arg4_mac, arg5_mac_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_mac_verify)(arg0_key, arg1_alg, arg2_input, arg3_input_length, arg4_mac, arg5_mac_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg2_input, arg3_input_length);
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg4_mac, arg5_mac_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1112,13 +1050,7 @@ psa_status_t mbedtls_test_wrap_psa_mac_verify_finish(
     const uint8_t *arg1_mac,
     size_t arg2_mac_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_mac, arg2_mac_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_mac_verify_finish)(arg0_operation, arg1_mac, arg2_mac_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_mac, arg2_mac_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1286,13 +1218,7 @@ psa_status_t mbedtls_test_wrap_psa_random_reseed(
     const uint8_t *arg0_perso,
     size_t arg1_perso_size)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg0_perso, arg1_perso_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_random_reseed)(arg0_perso, arg1_perso_size);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg0_perso, arg1_perso_size);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1507,13 +1433,7 @@ psa_status_t mbedtls_test_wrap_psa_xof_output(
     uint8_t *arg1_output,
     size_t arg2_output_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_output, arg2_output_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_xof_output)(arg0_operation, arg1_output, arg2_output_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_output, arg2_output_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1523,13 +1443,7 @@ psa_status_t mbedtls_test_wrap_psa_xof_set_context(
     const uint8_t *arg1_context,
     size_t arg2_context_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_context, arg2_context_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_xof_set_context)(arg0_operation, arg1_context, arg2_context_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_context, arg2_context_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 
@@ -1548,13 +1462,7 @@ psa_status_t mbedtls_test_wrap_psa_xof_update(
     const uint8_t *arg1_input,
     size_t arg2_input_length)
 {
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_POISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     psa_status_t status = (psa_xof_update)(arg0_operation, arg1_input, arg2_input_length);
-#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
-    MBEDTLS_TEST_MEMORY_UNPOISON(arg1_input, arg2_input_length);
-#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
     return status;
 }
 

--- a/tests/src/psa_test_wrappers.c
+++ b/tests/src/psa_test_wrappers.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#if !defined(__USE_MINGW_ANSI_STDIO)
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
+
 #include <mbedtls/build_info.h>
 
 #if defined(MBEDTLS_PSA_CRYPTO_C) && defined(MBEDTLS_TEST_HOOKS) && \
@@ -1267,6 +1271,36 @@ psa_status_t mbedtls_test_wrap_psa_purge_key(
     mbedtls_svc_key_id_t arg0_key)
 {
     psa_status_t status = (psa_purge_key)(arg0_key);
+    return status;
+}
+
+/* Wrapper for psa_random_deplete */
+psa_status_t mbedtls_test_wrap_psa_random_deplete(void)
+{
+    psa_status_t status = (psa_random_deplete)();
+    return status;
+}
+
+/* Wrapper for psa_random_reseed */
+psa_status_t mbedtls_test_wrap_psa_random_reseed(
+    const uint8_t *arg0_perso,
+    size_t arg1_perso_size)
+{
+#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
+    MBEDTLS_TEST_MEMORY_POISON(arg0_perso, arg1_perso_size);
+#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
+    psa_status_t status = (psa_random_reseed)(arg0_perso, arg1_perso_size);
+#if !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS)
+    MBEDTLS_TEST_MEMORY_UNPOISON(arg0_perso, arg1_perso_size);
+#endif /* !defined(MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS) */
+    return status;
+}
+
+/* Wrapper for psa_random_set_prediction_resistance */
+psa_status_t mbedtls_test_wrap_psa_random_set_prediction_resistance(
+    unsigned arg0_enabled)
+{
+    psa_status_t status = (psa_random_set_prediction_resistance)(arg0_enabled);
     return status;
 }
 


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/795

Needs preceding PR: framework prerequisite

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/306
- [ ] **TF-PSA-Crypto development TODO
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/796
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [ ] **mbedtls 3.6 PR** TODO
- **tests**  provided | not required because: 
