### PR TITLE
fix: zeroize stack buffer containing private key in deterministic ECDSA

### DIFF
--- a/ChangeLog.d/zeroize-ecdsa-stack.txt
+++ b/ChangeLog.d/zeroize-ecdsa-stack.txt
@@ -1,0 +1,5 @@
+Security
+   * Zeroize the stack buffer containing the private key in
+     mbedtls_ecdsa_sign_det_restartable() after use for HMAC-DRBG seeding.
+     Previously, up to 66 bytes of key material remained on the stack until
+     overwritten by subsequent calls.

--- a/drivers/builtin/src/ecdsa.c
+++ b/drivers/builtin/src/ecdsa.c
@@ -434,6 +434,7 @@ sign:
                                          f_rng_blind, p_rng_blind, rs_ctx);
 
 cleanup:
+    mbedtls_platform_zeroize(data, sizeof(data));
     mbedtls_hmac_drbg_free(&rng_ctx);
     mbedtls_mpi_free(&h);
 


### PR DESCRIPTION
## Summary

In `mbedtls_ecdsa_sign_det_restartable()`, the local stack buffer `data[2 * MBEDTLS_ECP_MAX_BYTES]` holds the raw ECDSA private key `d` (written via `mbedtls_mpi_write_binary()`) for HMAC-DRBG seeding per RFC 6979. After use, the buffer is not cleared in the cleanup path, leaving up to 66 bytes of key material on the stack until overwritten by subsequent calls.

## Fix

Add `mbedtls_platform_zeroize(data, sizeof(data))` to the cleanup path, before `mbedtls_hmac_drbg_free()`.

## Rationale

This brings `ecdsa.c` to parity with peer modules:
- `hmac_drbg.c`: zeroes `K[]`, `seed[]`, `buf[]` at cleanup (5 call sites)
- `rsa.c`: zeroes `buf[]`, `mask[]`, `lhash[]` at cleanup (4 call sites)
- `ecdsa.c`: currently has **zero** uses of `mbedtls_platform_zeroize` in the entire file

## Scope

Defense-in-depth hardening. The threat model (SECURITY.md) excludes direct local memory access, so this is not classified as a vulnerability fix — it is a missing cleanup consistent with existing project conventions.

## Checklist

- [x] Signed-off-by matching author email
- [x] ChangeLog entry in `ChangeLog.d/zeroize-ecdsa-stack.txt`
- [x] Based on `development` branch
- [ ] Tests: no functional behavior change; existing test suites cover ECDSA signing correctness