### PR TITLE
1.1: core/alignment.h: Fix 'MBEDTLS_GCC_VERSION' is not defined error

### DIFF
--- a/ChangeLog.d/mbedtls_gcc_version.txt
+++ b/ChangeLog.d/mbedtls_gcc_version.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * library/alignment.h: Fix 'MBEDTLS_GCC_VERSION' is not defined error

--- a/core/alignment.h
+++ b/core/alignment.h
@@ -293,7 +293,7 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 /*
  * Detect GCC built-in byteswap routines
  */
-#if defined(__GNUC__)
+#if defined(MBEDTLS_COMPILER_IS_GCC)
 #if MBEDTLS_GCC_VERSION >= 40800
 #define MBEDTLS_BSWAP16 __builtin_bswap16
 #endif
@@ -301,7 +301,7 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #define MBEDTLS_BSWAP64 __builtin_bswap64
 #endif
-#endif /* defined(__GNUC__) */
+#endif /* defined(MBEDTLS_COMPILER_IS_GCC) */
 
 /*
  * Detect Clang built-in byteswap routines


### PR DESCRIPTION
Only check 'MBEDTLS_GCC_VERSION' when 'MBEDTLS_COMPILER_IS_GCC' is defined

## Description
Only check 'MBEDTLS_GCC_VERSION' when 'MBEDTLS_COMPILER_IS_GCC' is defined

## PR checklist
- [ ] **changelog** provided | not required because: 
- [x] **framework PR**  not required
- [x] **TF-PSA-Crypto development PR** provided #800
- [x] **TF-PSA-Crypto 1.1 PR** provided here
- [x] **mbedtls development PR** not required because: TF-PSA-Crypto code 
- [x] **mbedtls 4.1 PR** not required because: TF-PSA-Crypto code
- [x] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls#10731
- **tests**  provided | not required because: 
