### PR TITLE
pk: improve error code failure reporting when RSA public key parsing fails (2/2)

### DIFF
--- a/extras/pk_rsa.c
+++ b/extras/pk_rsa.c
@@ -74,7 +74,7 @@ int mbedtls_pk_rsa_set_pubkey(mbedtls_pk_context *pk, const unsigned char *key, 
 
     status = psa_import_key(&attr, key, key_len, &key_id);
     if (status != PSA_SUCCESS) {
-        return MBEDTLS_ERR_PK_INVALID_PUBKEY;
+        return psa_pk_status_to_mbedtls(status);
     }
 
     status = psa_get_key_attributes(key_id, &attr);

--- a/extras/pkparse.c
+++ b/extras/pkparse.c
@@ -1230,7 +1230,8 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context *ctx,
         return ret;
     }
     mbedtls_pk_free(ctx);
-    if (ret != MBEDTLS_ERR_PK_INVALID_PUBKEY) {
+    if ((ret != MBEDTLS_ERR_PK_INVALID_PUBKEY) &&
+        (ret != MBEDTLS_ERR_PK_INVALID_ALG)) {
         return ret;
     }
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */

--- a/extras/pkparse.c
+++ b/extras/pkparse.c
@@ -553,8 +553,6 @@ int mbedtls_pk_parse_subpubkey(unsigned char **p, const unsigned char *end,
                    (ret >= MBEDTLS_ERR_ASN1_BUF_TOO_SMALL)) {
             /* In case of ASN1 error codes add MBEDTLS_ERR_PK_INVALID_PUBKEY. */
             ret = MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PK_INVALID_PUBKEY, ret);
-        } else {
-            ret = MBEDTLS_ERR_PK_INVALID_PUBKEY;
         }
     } else
 #endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */


### PR DESCRIPTION
## Description

Improve error code failure reporting when RSA public key parsing fails.
This originated from an issue reported in Zephyr: https://github.com/zephyrproject-rtos/zephyr/issues/111855

The goal is to help the developer catch any heap memory allocation issue quicker than debugging manually because they received an `MBEDTLS_ERR_PK_INVALID_PUBKEY` failure.

 Merge order is:
1. https://github.com/Mbed-TLS/mbedtls/pull/10804
2. this one

## PR checklist

- [x] **changelog** not required because: the documentation of `mbedtls_pk_parse_public_key` says that on error it will return `0 if successful, or a specific PK or PEM error code`. Here we might change the return value in case of error, but the documentation is generic enough not to require an update IMO. But I would like to know the opinion of reviewers on this point.
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided: this one
- [x] **TF-PSA-Crypto 1.1 PR** provided: this looks like an enhancement to me so I would say no.
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10804
- [x] **mbedtls 4.1 PR** not required because: Change breaks the ABI so is not backportable
- [x] **mbedtls 3.6 PR** not required because: Change breaks the ABI so is not backportable
- **tests**  not required because: technically this PR does not change how error codes are generated, but only the reported value.