### PR TITLE
Backport 1.1:Unsafe macros 

### DIFF
--- a/drivers/builtin/src/ecp_curves.c
+++ b/drivers/builtin/src/ecp_curves.c
@@ -3935,7 +3935,7 @@ int mbedtls_ecp_group_load(mbedtls_ecp_group *grp, mbedtls_ecp_group_id id)
 
 #else /* 64 bit */
 
-#define MAX32   ((X_limbs) * 2)
+#define MAX32   (X_limbs * 2)
 #define A(j)                                                \
     (j) % 2 ?                                               \
     (uint32_t) (X[(j) / 2] >> 32) :                         \

--- a/drivers/builtin/src/ecp_curves.c
+++ b/drivers/builtin/src/ecp_curves.c
@@ -3928,14 +3928,14 @@ int mbedtls_ecp_group_load(mbedtls_ecp_group *grp, mbedtls_ecp_group_id id)
 
 #if defined(MBEDTLS_HAVE_INT32)  /* 32 bit */
 
-#define MAX32       X_limbs
+#define MAX32       (X_limbs)
 #define A(j)        X[j]
 #define STORE32     X[i] = (mbedtls_mpi_uint) cur;
 #define STORE0      X[i] = 0;
 
 #else /* 64 bit */
 
-#define MAX32   X_limbs * 2
+#define MAX32   ((X_limbs) * 2)
 #define A(j)                                                \
     (j) % 2 ?                                               \
     (uint32_t) (X[(j) / 2] >> 32) :                         \

--- a/drivers/builtin/src/sha3.c
+++ b/drivers/builtin/src/sha3.c
@@ -73,7 +73,7 @@
  * YMMV.
  */
 /* Helper macro to set the values of the higher bits in unused low positions */
-#define H(b63, b31, b15) (b63 << 6 | b31 << 5 | b15 << 4)
+#define H(b63, b31, b15) (((b63) << 6) | ((b31) << 5) | ((b15) << 4))
 static const uint8_t iota_r_packed[24] = {
     H(0, 0, 0) | 0x01, H(0, 0, 1) | 0x82, H(1, 0, 1) | 0x8a, H(1, 1, 1) | 0x00,
     H(0, 0, 1) | 0x8b, H(0, 1, 0) | 0x01, H(1, 1, 1) | 0x81, H(1, 0, 1) | 0x09,

--- a/extras/pk_internal.h
+++ b/extras/pk_internal.h
@@ -98,7 +98,7 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_c
 #endif /* PSA_WANT_ECC_MONTGOMERY_255 || PSA_WANT_ECC_MONTGOMERY_448 */
 
 #define MBEDTLS_PK_IS_RFC8410_GROUP_ID(id)  \
-    ((id == MBEDTLS_ECP_DP_CURVE25519) || (id == MBEDTLS_ECP_DP_CURVE448))
+    (((id) == MBEDTLS_ECP_DP_CURVE25519) || ((id) == MBEDTLS_ECP_DP_CURVE448))
 
 static inline int mbedtls_pk_is_rfc8410(const mbedtls_pk_context *pk)
 {

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1044,7 +1044,7 @@ typedef uint32_t psa_pake_primitive_t;
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step)               \
     (PSA_ALG_IS_JPAKE(alg) &&                                         \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
-                                     PSA_ECC_FAMILY_SECP_R1, 256) ?    \
+                                       PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
          (output_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                \
          (output_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                \
@@ -1074,7 +1074,7 @@ typedef uint32_t psa_pake_primitive_t;
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step)                 \
     (PSA_ALG_IS_JPAKE(alg) &&                                         \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
-                                     PSA_ECC_FAMILY_SECP_R1, 256) ?    \
+                                       PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
          (input_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                 \
          (input_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                 \

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1042,12 +1042,12 @@ typedef uint32_t psa_pake_primitive_t;
  *                      return 0.
  */
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step)               \
-    (PSA_ALG_IS_JPAKE(alg) &&                                           \
-     primitive == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,      \
+    (PSA_ALG_IS_JPAKE((alg)) &&                                         \
+     (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
-         output_step == PSA_PAKE_STEP_KEY_SHARE ? 65 :                   \
-         output_step == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                   \
+         (output_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                \
+         (output_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                \
          32                                                              \
      ) :                                                               \
      0)
@@ -1072,12 +1072,12 @@ typedef uint32_t psa_pake_primitive_t;
  *                      the parameters are incompatible, return 0.
  */
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step)                 \
-    (PSA_ALG_IS_JPAKE(alg) &&                                           \
-     primitive == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,      \
+    (PSA_ALG_IS_JPAKE((alg)) &&                                         \
+     (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
-         input_step == PSA_PAKE_STEP_KEY_SHARE ? 65 :                    \
-         input_step == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                    \
+         (input_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                 \
+         (input_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                 \
          32                                                              \
      ) :                                                               \
      0)

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1042,7 +1042,7 @@ typedef uint32_t psa_pake_primitive_t;
  *                      return 0.
  */
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step)               \
-    (PSA_ALG_IS_JPAKE((alg)) &&                                         \
+    (PSA_ALG_IS_JPAKE(alg) &&                                         \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
@@ -1072,7 +1072,7 @@ typedef uint32_t psa_pake_primitive_t;
  *                      the parameters are incompatible, return 0.
  */
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step)                 \
-    (PSA_ALG_IS_JPAKE((alg)) &&                                         \
+    (PSA_ALG_IS_JPAKE(alg) &&                                         \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -583,7 +583,7 @@
                          0))
 
 /** Check if the curve of given family is Weierstrass elliptic curve. */
-#define PSA_ECC_FAMILY_IS_WEIERSTRASS(family) ((family & 0xc0) == 0)
+#define PSA_ECC_FAMILY_IS_WEIERSTRASS(family) (((family) & 0xc0) == 0)
 
 /** SEC Koblitz curves over prime fields.
  *


### PR DESCRIPTION
## Description

Backport 1.1:Unsafe macros contributes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/712

## PR checklist

- [x] **changelog** not required because:  No public changes
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/716
- [x] **TF-PSA-Crypto 1.1 PR** provided #HERE
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [x] **mbedtls 4.1 PR** not required because: Only crypto changes
- [x] **mbedtls 3.6 PR** not required because: https://github.com/Mbed-TLS/mbedtls/pull/10805
- **tests**  not required because: No changes