### PR TITLE
Backport 1.1: Shorter code in asn1 write

### DIFF
--- a/utilities/asn1write.c
+++ b/utilities/asn1write.c
@@ -403,7 +403,6 @@ int mbedtls_asn1_write_integer(unsigned char **p,
                                size_t integer_length)
 {
 
-    int asn1_frame_size = 0;
     unsigned int number_of_leading_zeros = 0;
     size_t output_buffer_size = (*p-start);
     const unsigned char *integer_start = NULL;
@@ -454,12 +453,6 @@ int mbedtls_asn1_write_integer(unsigned char **p,
         }
     }
 
-    asn1_frame_size =
-        mbedtls_asn1_write_len_and_tag(p, start, integer_length, MBEDTLS_ASN1_INTEGER);
-    if (asn1_frame_size < 0) {
-        return asn1_frame_size;//TC4 mbedtls_asn1_write_len_and_tag failed.
-    }
-
-    return asn1_frame_size;
+    return mbedtls_asn1_write_len_and_tag(p, start, integer_length, MBEDTLS_ASN1_INTEGER);
 }
 #endif /* MBEDTLS_ASN1_WRITE_C */


### PR DESCRIPTION
## Description

Backport 1.1: Shorter code in asn1 write

## PR checklist

- [ ] **changelog** not required because: No public changes
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/715
- [ ] **TF-PSA-Crypto 1.1 PR** provided HERE
- [ ] **mbedtls development PR** not required because: crypto only
- [ ] **mbedtls 4.1 PR**not required because: crypto only
- [ ] **mbedtls 3.6 PR** not required because:  not required on branch
- **tests**   not required because: No changes