### PR TITLE
CMakeLists.txt: Added default auto-detection for GEN_FILES.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,17 +82,15 @@ option(ENABLE_PROGRAMS "Build TF-PSA-Crypto programs." ON)
 
 option(TF_PSA_CRYPTO_FATAL_WARNINGS "Compiler warnings treated as errors" ON)
 
-set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES ON)
-if(CMAKE_HOST_WIN32)
-    set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES OFF)
-elseif(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES OFF)
-endif()
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" AND NOT TF_PSA_CRYPTO_DEFAULT_GEN_FILES)
+set(tf_psa_crypto_default_gen_files ON)
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    set(tf_psa_crypto_default_gen_files OFF)
     message(STATUS "TF-PSA-Crypto Git metadata not found; GEN_FILES defaults to OFF.")
+elseif(CMAKE_HOST_WIN32)
+     set(tf_psa_crypto_default_gen_files OFF)
 endif()
 
-option(GEN_FILES "Generate the auto-generated files as needed" ${TF_PSA_CRYPTO_DEFAULT_GEN_FILES})
+option(GEN_FILES "Generate the auto-generated files as needed" ${tf_psa_crypto_default_gen_files})
 # Support for package config and install to be added later.
 option(DISABLE_PACKAGE_CONFIG_AND_INSTALL "Disable package configuration, target export and installation" ${TF_PSA_CRYPTO_AS_SUBPROJECT})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,15 +81,18 @@ ADD_CUSTOM_TARGET(${TF_PSA_CRYPTO_TARGET_PREFIX}tfpsacrypto-apidoc
 option(ENABLE_PROGRAMS "Build TF-PSA-Crypto programs." ON)
 
 option(TF_PSA_CRYPTO_FATAL_WARNINGS "Compiler warnings treated as errors" ON)
+
+set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES ON)
 if(CMAKE_HOST_WIN32)
-    # N.B. The comment on the next line is significant! If you change it,
-    # edit the sed command in prepare_release.sh that modifies
-    # CMakeLists.txt.
-    option(GEN_FILES "Generate the auto-generated files as needed" OFF) # off in development
-else()
-    option(GEN_FILES "Generate the auto-generated files as needed" ON)
+    set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES OFF)
+elseif(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    set(TF_PSA_CRYPTO_DEFAULT_GEN_FILES OFF)
+endif()
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git" AND NOT TF_PSA_CRYPTO_DEFAULT_GEN_FILES)
+    message(STATUS "TF-PSA-Crypto Git metadata not found; GEN_FILES defaults to OFF.")
 endif()
 
+option(GEN_FILES "Generate the auto-generated files as needed" ${TF_PSA_CRYPTO_DEFAULT_GEN_FILES})
 # Support for package config and install to be added later.
 option(DISABLE_PACKAGE_CONFIG_AND_INSTALL "Disable package configuration, target export and installation" ${TF_PSA_CRYPTO_AS_SUBPROJECT})
 


### PR DESCRIPTION
## Description

As part of the post release activities, fixing minor inconveniences of the tooling required to build a release.

This pr is adding an auto-detection logic to our build system to attempt to detect our source tree, and disable the default behavior of the file auto-generation.

This means that by default the files will not be auto-generated when there is not .git content, as it would be indicating that it is being consumed as part of the tar-balls.

The default user exposed behaviour set as option is still present, so if needed for other use cases they can still enable it

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls#10823
- [ ] **mbedtls 4.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
