### PR TITLE
Add GCC15 O2 test-driver component

### DIFF
--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -74,6 +74,37 @@ support_test_tf_psa_crypto_gcc_latest_opt () {
     type "$GCC_LATEST" >/dev/null 2>/dev/null
 }
 
+# Prepare for a non-regression for https://github.com/Mbed-TLS/mbedtls/issues/9814 :
+# test with GCC 15.
+# Eventually, $GCC_LATEST will be GCC 15 or above, and we can remove this
+# separate component.
+# For the time being, we don't make $GCC_LATEST be GCC 15 on the CI
+# platform, because that would break branches where #9814 isn't fixed yet.
+support_test_tf_psa_crypto_gcc15_drivers_opt () {
+    if type gcc-15 >/dev/null 2>/dev/null; then
+        GCC_15=gcc-15
+    elif [ -x /usr/local/gcc-15/bin/gcc-15 ]; then
+        GCC_15=/usr/local/gcc-15/bin/gcc-15
+    else
+        return 1
+    fi
+}
+
+component_test_tf_psa_crypto_gcc15_drivers_opt () {
+    msg "build: GCC 15: full + test drivers dispatching to builtins"
+    scripts/config.py full
+
+    cd $OUT_OF_SOURCE_DIR
+    cmake -DCMAKE_C_COMPILER="$GCC_15" \
+          -DCMAKE_C_FLAGS="$ASAN_CFLAGS -O2" \
+          -DCMAKE_EXE_LINKER_FLAGS="$ASAN_CFLAGS" \
+          -DTF_PSA_CRYPTO_TEST_DRIVER=On "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake --build .
+
+    msg "test: GCC 15: full + test drivers dispatching to builtins"
+    ctest
+}
+
 component_test_tf_psa_crypto_gcc_earliest_opt () {
     scripts/config.py full
     test_build_opt 'full config' "$GCC_EARLIEST" -O2


### PR DESCRIPTION
## Description

Add component_test_gcc15_drivers_opt in components-compiler.sh
Fix: https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/304
Most code is copied from mbedtls: https://github.com/Mbed-TLS/mbedtls/blob/3bb373867917b674265067cbd38b9d252c43d014/tests/scripts/components-compiler.sh#L76-L102, with minor script change from make to cmake.



## PR checklist

- [x] **changelog** not required because: test only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided HERE
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/842
- [x] **mbedtls development PR** not required because: PSA only
- [x] **mbedtls 4.1 PR** not required because: PSA only
- [x] **mbedtls 3.6 PR**  not required because: PSA only
- **tests**  provided

