### PR TITLE
Fix getrandom detection with musl libc

### DIFF
--- a/ChangeLog.d/musl_getrandom.txt
+++ b/ChangeLog.d/musl_getrandom.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix PSA crypto initialization needlessly blocking on `/dev/random` on
+     Linux 5.6 and earlier when using a libc such as musl.

--- a/ChangeLog.d/musl_getrandom.txt
+++ b/ChangeLog.d/musl_getrandom.txt
@@ -1,5 +1,5 @@
 Features
-   * Use the `getrandom` system call for PSA crypto initialization on Linux
+   * Use the getrandom() system call for PSA crypto initialization on Linux
      when supported by the C library, including musl, uClibc and Android
-     bionic, avoiding unnecessary reliance on `/dev/random` on Linux 5.6 and
+     bionic, avoiding unnecessary reliance on /dev/random on Linux 5.6 and
      earlier.

--- a/ChangeLog.d/musl_getrandom.txt
+++ b/ChangeLog.d/musl_getrandom.txt
@@ -1,3 +1,5 @@
-Bugfix
-   * Fix PSA crypto initialization needlessly blocking on `/dev/random` on
-     Linux 5.6 and earlier when using a libc such as musl.
+Features
+   * Use the `getrandom` system call for PSA crypto initialization on Linux
+     when supported by the C library, including musl, uClibc and Android
+     bionic, avoiding unnecessary reliance on `/dev/random` on Linux 5.6 and
+     earlier.

--- a/platform/platform_util.c
+++ b/platform/platform_util.c
@@ -291,26 +291,16 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
 
 /*
  * Test for Linux getrandom() support.
- * Prefer the libc wrapper when sys/random.h is available. This includes
- * libcs such as musl which provide getrandom() but not __GLIBC__.
+ * Use the generic syscall wrapper when sys/syscall.h is available.
  */
 #if defined(__linux__) && defined(__has_include)
-#if __has_include(<sys/random.h>)
-#define MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H
+#if __has_include(<sys/syscall.h>)
+#define MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H
 #endif
 #endif
 
-#if defined(MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H)
-#include <errno.h>
-#include <sys/random.h>
-#define HAVE_GETRANDOM
-
-static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
-{
-    return (int) getrandom(buf, buflen, flags);
-}
-#elif ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
-/* Use the generic syscall wrapper when the libc has no getrandom() wrapper. */
+#if defined(MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H) || \
+    (defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__)
 #include <unistd.h>
 #include <sys/syscall.h>
 #if defined(SYS_getrandom)
@@ -328,9 +318,9 @@ static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
     return (int) syscall(SYS_getrandom, buf, buflen, flags);
 }
 #endif /* SYS_getrandom */
-#endif /* getrandom() wrapper or generic syscall wrapper */
+#endif /* sys/syscall.h or a known generic syscall wrapper */
 
-#undef MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H
+#undef MBEDTLS_PLATFORM_HAS_SYS_SYSCALL_H
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/param.h>

--- a/platform/platform_util.c
+++ b/platform/platform_util.c
@@ -291,10 +291,26 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
 
 /*
  * Test for Linux getrandom() support.
- * Since there is no wrapper in the libc yet, use the generic syscall wrapper
- * available in GNU libc and compatible libc's (eg uClibc).
+ * Prefer the libc wrapper when sys/random.h is available. This includes
+ * libcs such as musl which provide getrandom() but not __GLIBC__.
  */
-#if ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
+#if defined(__linux__) && defined(__has_include)
+#if __has_include(<sys/random.h>)
+#define MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H
+#endif
+#endif
+
+#if defined(MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H)
+#include <errno.h>
+#include <sys/random.h>
+#define HAVE_GETRANDOM
+
+static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
+{
+    return (int) getrandom(buf, buflen, flags);
+}
+#elif ((defined(__linux__) && defined(__GLIBC__)) || defined(__midipix__))
+/* Use the generic syscall wrapper when the libc has no getrandom() wrapper. */
 #include <unistd.h>
 #include <sys/syscall.h>
 #if defined(SYS_getrandom)
@@ -312,7 +328,9 @@ static int getrandom_wrapper(void *buf, size_t buflen, unsigned int flags)
     return (int) syscall(SYS_getrandom, buf, buflen, flags);
 }
 #endif /* SYS_getrandom */
-#endif /* __linux__ || __midipix__ */
+#endif /* getrandom() wrapper or generic syscall wrapper */
+
+#undef MBEDTLS_PLATFORM_HAS_SYS_RANDOM_H
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/param.h>


### PR DESCRIPTION
## Description

On Linux, the platform entropy implementation currently enables the
getrandom syscall path only for glibc and Midipix. This excludes musl and
other libc implementations that can use the same syscall path, so affected
builds fall back to `/dev/random`. On older Linux kernels, a subsequent
process may block during PSA crypto initialization after earlier reads
have depleted the available entropy count.

Use `__has_include(<sys/syscall.h>)` on Linux when supported by the
compiler, and enable the existing syscall wrapper only when
`SYS_getrandom` is defined. Preserve the glibc/Midipix condition for older
toolchains and the existing fallback when the kernel returns `ENOSYS`.

The initial `<sys/random.h>`/libc-wrapper detection was replaced during
review because it broke dietlibc builds. The final implementation reuses
`syscall(SYS_getrandom, ...)` and adds no public configuration option.

## Validation

Manual validation of this development PR, reported on August 3:

- glibc 2.43 / GCC 16.1: build passed; syscall path selected; two consecutive initializations passed.
- musl / GCC 12.4: full build passed; syscall path selected; two consecutive initializations passed.
- dietlibc 0.34: build passed; `SYS_getrandom` is absent and the existing fallback remained selected.
- uClibc-ng 1.0.54 / GCC 14.3: static build passed; syscall path selected; two consecutive initializations passed.
- Android bionic / NDK r29 / API 21 / x86_64: dynamic and static builds passed; syscall path selected; the static binary passed two consecutive initializations.
- AppleClang 21 Debug build passed, followed by 132/132 CTest tests.
- ChangeLog assembly check passed.

The individual backport PRs document their separate validation results.

## PR checklist

- [x] **changelog** provided.
- [x] **framework PR** not required.
- [x] **TF-PSA-Crypto development PR** this PR.
- [x] **TF-PSA-Crypto 1.1 PR** Mbed-TLS/TF-PSA-Crypto#893.
- [x] **mbedtls development PR** not required because the implementation is maintained in TF-PSA-Crypto.
- [x] **mbedtls 4.1 PR** not provided; the corresponding submodule update can follow the TF-PSA-Crypto backport.
- [x] **mbedtls 3.6 PR** Mbed-TLS/mbedtls#10945.
- **tests** no new committed test cases; manual libc testing was accepted during review and is recorded above.
