### PR TITLE
pkcs5: reject iteration count of 0 in PBKDF2-HMAC

### DIFF
--- a/utilities/pkcs5.c
+++ b/utilities/pkcs5.c
@@ -272,6 +272,10 @@ static int pkcs5_pbkdf2_hmac(mbedtls_md_context_t *ctx,
         return MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA;
     }
 #endif
+    /* count should be positive integer according to RFC 8018 */
+    if (iteration_count == 0) {
+        return MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA;
+    }
 
     if ((ret = mbedtls_md_hmac_starts(ctx, password, plen)) != 0) {
         return ret;


### PR DESCRIPTION



## Description

pkcs5: reject iteration count of 0 in PBKDF2-HMAC)
Fixes https://github.com/Mbed-TLS/mbedtls/issues/10836


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 4.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
