### PR TITLE
Backport 1.1: Remove pattern constraint from location field

### DIFF
--- a/scripts/data_files/driver_jsons/driver_opaque_schema.json
+++ b/scripts/data_files/driver_jsons/driver_opaque_schema.json
@@ -14,8 +14,7 @@
       "const": "opaque"
     },
     "location": {
-      "type": ["integer","string"],
-      "pattern": "^(0x|0X)?[a-fA-F0-9]+$"
+      "type": ["integer","string"]
     },
     "mbedtls/h_condition": {
       "type": "string"


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/720

## PR checklist
- [x] **changelog** not required because: minor enhancement to functionality that isn't officially documented
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/720
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/851
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: 3.6 has less than a year to live, so we don't encourage new driver developments
- **tests**  not required because: we don't test driver wrapper generators
