### PR TITLE
[1.1] Inconsistent return value of mbedtls_pk_parse_key breaks mbedtls_pk_check_pair sometimes

### DIFF
--- a/ChangeLog.d/pkcs8-rsa-public-key-parsing.txt
+++ b/ChangeLog.d/pkcs8-rsa-public-key-parsing.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fixed a PKCS#8 bug where the public part of RSA key was not correctly
+     added to the PK context when the key was parsed. This could cause
+     other unexpected failures when using that PK context for other operations.
+     Fixes #807.

--- a/extras/pkparse.c
+++ b/extras/pkparse.c
@@ -796,9 +796,8 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_unencrypted_der(
 
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
     if (pk_alg == MBEDTLS_PK_RSA) {
-        ret = mbedtls_pk_rsa_set_key(pk, p, len) ||
-              mbedtls_pk_set_pubkey_from_prv(pk);
-        if (ret != 0) {
+        if (((ret = mbedtls_pk_rsa_set_key(pk, p, len)) != 0) ||
+            ((ret = mbedtls_pk_set_pubkey_from_prv(pk)) != 0)) {
             mbedtls_pk_free(pk);
             return ret;
         }

--- a/extras/pkparse.c
+++ b/extras/pkparse.c
@@ -796,7 +796,9 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_pk_parse_key_pkcs8_unencrypted_der(
 
 #if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
     if (pk_alg == MBEDTLS_PK_RSA) {
-        if ((ret = mbedtls_pk_rsa_set_key(pk, p, len)) != 0) {
+        ret = mbedtls_pk_rsa_set_key(pk, p, len) ||
+              mbedtls_pk_set_pubkey_from_prv(pk);
+        if (ret != 0) {
             mbedtls_pk_free(pk);
             return ret;
         }

--- a/tests/suites/test_suite_pkparse.function
+++ b/tests/suites/test_suite_pkparse.function
@@ -131,8 +131,6 @@ void pk_parse_keyfile_rsa(char *key_file, char *password, int result)
         TEST_EQUAL(mbedtls_pk_get_bitlen(&ctx), ctx.bits);
         TEST_EQUAL(mbedtls_pk_get_len(&ctx), PSA_BITS_TO_BYTES(ctx.bits));
 
-        TEST_ASSERT(mbedtls_pk_set_pubkey_from_prv(&ctx) == 0);
-
 #if defined(MBEDTLS_PSA_CRYPTO_C)
         TEST_ASSERT(test_psa_bridge(&ctx, PSA_KEY_USAGE_SIGN_HASH));
         TEST_ASSERT(test_psa_bridge(&ctx, PSA_KEY_USAGE_SIGN_MESSAGE));

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -256,11 +256,6 @@ void pk_write_public_from_private(char *priv_key_file, char *pub_key_file)
     USE_PSA_INIT();
 
     TEST_EQUAL(mbedtls_pk_parse_keyfile(&priv_key, priv_key_file, NULL), 0);
-#if defined(PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY)
-    if (mbedtls_pk_get_type(&priv_key) == MBEDTLS_PK_RSA) {
-        TEST_EQUAL(mbedtls_pk_set_pubkey_from_prv(&priv_key), 0);
-    }
-#endif /* PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY */
     TEST_EQUAL(mbedtls_pk_load_file(pub_key_file, &pub_key_raw,
                                     &pub_key_len), 0);
 


### PR DESCRIPTION
## Description

Backport of #811

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** provided: #811
- [x] **TF-PSA-Crypto 1.1 PR** provided: this one
- [x] **mbedtls development PR** not required because: no change there
- [x] **mbedtls 4.1 PR** not required because: no change there
- [x] **mbedtls 3.6 PR** not required because: no change there
- **tests**  provided: the same as in #811