### PR TITLE
Keystoreless mode prototype

### DIFF
--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -1137,6 +1137,7 @@ psa_status_t psa_wipe_key_slot(psa_key_slot_t *slot)
 {
     psa_status_t status = psa_remove_key_data_from_memory(slot);
 
+#if !defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
     /*
      * As the return error code may not be handled in case of multiple errors,
      * do our best to report an unexpected amount of registered readers or
@@ -1175,6 +1176,7 @@ psa_status_t psa_wipe_key_slot(psa_key_slot_t *slot)
             /* The slot's state is invalid. */
             status = PSA_ERROR_CORRUPTION_DETECTED;
     }
+#endif /* !defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE) */
 
 #if defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
     size_t slice_index = slot->slice_index;
@@ -1282,6 +1284,13 @@ psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key)
         }
     }
 #endif /* defined(MBEDTLS_PSA_CRYPTO_STORAGE_C) */
+
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    /* Without a key store, nobody else is there to take care of
+     * wiping and freeing the data. */
+    psa_wipe_key_slot(slot);
+    mbedtls_zeroize_and_free(slot, sizeof(*slot));
+#endif
 
 exit:
     /* Unregister from reading the slot. If we are the last active reader

--- a/core/psa_crypto_core.h
+++ b/core/psa_crypto_core.h
@@ -31,6 +31,7 @@ typedef struct {
      * reduces the code size. */
     psa_key_attributes_t attr;
 
+#if !defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
     /*
      * The current state of the key slot, as described in
      * docs/architecture/psa-thread-safety/psa-thread-safety.md.
@@ -51,6 +52,7 @@ typedef struct {
      * PSA_SLOT_FULL.
      */
     psa_key_slot_state_t state;
+#endif
 
 #if defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
     /* The index of the slice containing this slot.
@@ -68,6 +70,7 @@ typedef struct {
     uint8_t slice_index;
 #endif /* MBEDTLS_PSA_KEY_STORE_DYNAMIC */
 
+#if !defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
     union {
         struct {
             /* The index of the next slot in the free list for this
@@ -119,6 +122,7 @@ typedef struct {
             size_t registered_readers;
         } occupied;
     } var;
+#endif
 
     /* Dynamically allocated key data buffer.
      * Format as specified in psa_export_key(). */
@@ -185,7 +189,12 @@ typedef struct {
  */
 static inline int psa_key_slot_has_readers(const psa_key_slot_t *slot)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    (void) slot;
+    return 0;
+#else
     return slot->var.occupied.registered_readers > 0;
+#endif
 }
 
 /** Completely wipe a slot in memory, including its policy.

--- a/core/psa_crypto_slot_management.c
+++ b/core/psa_crypto_slot_management.c
@@ -27,6 +27,56 @@
 
 
 
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+
+psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
+                                       psa_key_slot_t **p_slot)
+{
+    psa_key_slot_t *slot = (psa_key_slot_t*) key;
+
+    /* Sanity check: detect invalid or already-freed slot pointers,
+     * with a decent probability under non-hostile conditions. */
+    if (slot->attr.id != key) {
+        *p_slot = NULL;
+        return PSA_ERROR_INVALID_HANDLE;
+    }
+
+    *p_slot = slot;
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_reserve_free_key_slot(psa_key_id_t *volatile_key_id,
+                                       psa_key_slot_t **p_slot)
+{
+    *p_slot = mbedtls_calloc(1, sizeof(psa_key_slot_t));
+    if (*p_slot == NULL) {
+        return PSA_ERROR_INSUFFICIENT_MEMORY;
+    }
+
+    *volatile_key_id = (psa_key_id_t) (*p_slot);
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_purge_key(mbedtls_svc_key_id_t key)
+{
+    /* No effect on volatile keys */
+    (void) key;
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_validate_key_persistence(psa_key_lifetime_t lifetime)
+{
+    if (PSA_KEY_LIFETIME_IS_VOLATILE(lifetime)) {
+        return PSA_SUCCESS;
+    } else {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+#else /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
+
+
+
 /* Make sure we have distinct ranges of key identifiers for distinct
  * purposes. */
 MBEDTLS_STATIC_ASSERT(PSA_KEY_ID_USER_MIN < PSA_KEY_ID_USER_MAX,
@@ -53,7 +103,6 @@ MBEDTLS_STATIC_ASSERT(PSA_KEY_ID_VENDOR_MIN <= PSA_KEY_ID_VOLATILE_MIN &&
 MBEDTLS_STATIC_ASSERT(PSA_KEY_ID_VOLATILE_MAX < MBEDTLS_PSA_KEY_ID_BUILTIN_MIN ||
                       MBEDTLS_PSA_KEY_ID_BUILTIN_MAX < PSA_KEY_ID_VOLATILE_MIN,
                       "Overlap between builtin key IDs and volatile key IDs");
-
 
 
 #if defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
@@ -994,5 +1043,7 @@ void mbedtls_psa_get_stats(mbedtls_psa_stats_t *stats)
         }
     }
 }
+
+#endif /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 
 #endif /* MBEDTLS_PSA_CRYPTO_C */

--- a/core/psa_crypto_slot_management.h
+++ b/core/psa_crypto_slot_management.h
@@ -24,11 +24,17 @@
 
 /** The minimum value for a volatile key identifier.
  */
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+#define PSA_KEY_ID_VOLATILE_MIN ((psa_key_id_t) 1)
+#else
 #define PSA_KEY_ID_VOLATILE_MIN  PSA_KEY_ID_VENDOR_MIN
+#endif
 
 /** The maximum value for a volatile key identifier.
  */
-#if defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+#define PSA_KEY_ID_VOLATILE_MAX ((psa_key_id_t) -1)
+#elif defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
 #define PSA_KEY_ID_VOLATILE_MAX (MBEDTLS_PSA_KEY_ID_BUILTIN_MIN - 1)
 #else /* MBEDTLS_PSA_KEY_STORE_DYNAMIC */
 #define PSA_KEY_ID_VOLATILE_MAX                                 \
@@ -97,7 +103,15 @@ psa_status_t psa_get_and_lock_key_slot(mbedtls_svc_key_id_t key,
  * \retval #PSA_SUCCESS
  *         Currently this function always succeeds.
  */
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+static inline psa_status_t psa_initialize_key_slots(void)
+{
+    /* Nothing to do */
+    return PSA_SUCCESS;
+}
+#else
 psa_status_t psa_initialize_key_slots(void);
+#endif
 
 #if defined(MBEDTLS_TEST_HOOKS) && defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
 /* Allow test code to customize the key slice length. We use this in tests
@@ -122,7 +136,13 @@ size_t psa_key_slot_volatile_slice_count(void);
  * state and reader count. It should only be called when no slot is in use.
  *
  * This does not affect persistent storage. */
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+static inline void psa_wipe_all_key_slots(void) {
+    /* There's nothing we can do. */
+}
+#else
 void psa_wipe_all_key_slots(void);
+#endif
 
 /** Find a free key slot and reserve it to be filled with a key.
  *
@@ -205,10 +225,16 @@ static inline psa_status_t psa_key_slot_state_transition(
     psa_key_slot_t *slot, psa_key_slot_state_t expected_state,
     psa_key_slot_state_t new_state)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    (void) slot;
+    (void) expected_state;
+    (void) new_state;
+#else
     if (slot->state != expected_state) {
         return PSA_ERROR_CORRUPTION_DETECTED;
     }
     slot->state = new_state;
+#endif
     return PSA_SUCCESS;
 }
 
@@ -228,11 +254,15 @@ static inline psa_status_t psa_key_slot_state_transition(
  */
 static inline psa_status_t psa_register_read(psa_key_slot_t *slot)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    (void) slot;
+#else
     if ((slot->state != PSA_SLOT_FULL) ||
         (slot->var.occupied.registered_readers >= SIZE_MAX)) {
         return PSA_ERROR_CORRUPTION_DETECTED;
     }
     slot->var.occupied.registered_readers++;
+#endif
 
     return PSA_SUCCESS;
 }
@@ -261,7 +291,15 @@ static inline psa_status_t psa_register_read(psa_key_slot_t *slot)
  *             PSA_SLOT_PENDING_DELETION.
  *             Or registered_readers was equal to 0.
  */
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+static inline psa_status_t psa_unregister_read(psa_key_slot_t *slot)
+{
+    (void) slot;
+    return PSA_SUCCESS;
+}
+#else
 psa_status_t psa_unregister_read(psa_key_slot_t *slot);
+#endif
 
 /** Wrap a call to psa_unregister_read in the global key slot mutex.
  *
@@ -282,7 +320,15 @@ psa_status_t psa_unregister_read(psa_key_slot_t *slot);
  *             PSA_SLOT_PENDING_DELETION.
  *             Or registered_readers was equal to 0.
  */
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+static inline psa_status_t psa_unregister_read_under_mutex(psa_key_slot_t *slot)
+{
+    (void) slot;
+    return PSA_SUCCESS;
+}
+#else
 psa_status_t psa_unregister_read_under_mutex(psa_key_slot_t *slot);
+#endif
 
 /** Test whether a lifetime designates a key in an external cryptoprocessor.
  *
@@ -323,8 +369,13 @@ psa_status_t psa_validate_key_persistence(psa_key_lifetime_t lifetime);
  */
 static inline int psa_key_id_is_user(psa_key_id_t key_id)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    (void) key_id;
+    return 0;
+#else
     return (key_id >= PSA_KEY_ID_USER_MIN) &&
            (key_id <= PSA_KEY_ID_USER_MAX);
+#endif
 }
 
 #endif /* TF_PSA_CRYPTO_PSA_CRYPTO_SLOT_MANAGEMENT_H */

--- a/core/tf_psa_crypto_check_config.h
+++ b/core/tf_psa_crypto_check_config.h
@@ -511,6 +511,27 @@
 #error "MBEDTLS_PSA_CRYPTO_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+#  if defined(MBEDTLS_PSA_CRYPTO_SPM)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with a PSA Crypto server build"
+#  endif
+#  if defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with a multi-owner build"
+#  endif
+#  if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with persistent keys"
+#  endif
+#  if defined(MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with built-in keys"
+#  endif
+#  if defined(MBEDTLS_PSA_STATIC_KEY_SLOTS)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with MBEDTLS_PSA_STATIC_KEY_SLOTS"
+#  endif
+#  if defined(MBEDTLS_PSA_KEY_STORE_DYNAMIC)
+#    error "MBEDTLS_PSA_CRYPTO_NO_KEY_STORE is incompatible with MBEDTLS_PSA_KEY_STORE_DYNAMIC"
+#  endif
+#endif
+
 #if defined(MBEDTLS_PSA_CRYPTO_SPM) && !defined(MBEDTLS_PSA_CRYPTO_C)
 #error "MBEDTLS_PSA_CRYPTO_SPM defined, but not all prerequisites"
 #endif

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -1085,6 +1085,43 @@
 #define MBEDTLS_PSA_CRYPTO_C
 
 /**
+ * \def MBEDTLS_PSA_CRYPTO_NO_KEY_STORE
+ *
+ * Implement most of the PSA Crypto API without a key store.
+ * Key IDs are pointers instead of references.
+ * This reduces the code size, but is incompatible with some features and
+ * turns many cases of API misuse into memory corruption.
+ *
+ * \note This option is experimental.
+ *       It may be removed without notice.
+ *       Its effect may change without notice.
+ *
+ * \note Here are some known limitations of this option.
+ *       - It is incompatible with persistent keys
+ *         (#MBEDTLS_PSA_CRYPTO_STORAGE_C).
+ *       - It is incompatible with built-in keys
+ *         (#MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS).
+ *       - It is incompatible with tracking key owners
+ *         (#MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER).
+ *       - The type psa_key_id_t is still an unsigned integer type, but
+ *         it may be larger than the standard 32 bits.
+ *       - Forged key identifiers cannot be detected.
+ *       - Any attempt to use a destroyed key is a memory violation.
+ *         This includes calling psa_destroy_key() twice on the same key.
+ *       - It requires heap memory.
+ *
+ * \warning This option is dangerous!
+ *          Many cases of API misuse, which would normally be detected
+ *          at runtime, instead cause memory corruption.
+ *
+ * Module:  core/psa_crypto.c
+ *
+ * Requires: - MBEDTLS_PSA_CRYPTO_C
+ *           - calloc() and free()
+ */
+//#define MBEDTLS_PSA_CRYPTO_NO_KEY_STORE
+
+/**
  * \def MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS
  *
  * Assume all buffers passed to PSA functions are owned exclusively by the

--- a/include/psa/crypto_types.h
+++ b/include/psa/crypto_types.h
@@ -252,6 +252,13 @@ typedef uint8_t psa_key_persistence_t;
  */
 typedef uint32_t psa_key_location_t;
 
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+/** Encoding of key identifiers as seen inside the PSA Crypto implementation.
+ *
+ * A key identifier is a pointer to a key store entry.
+ */
+typedef uintptr_t psa_key_id_t;
+#else
 /** Encoding of identifiers of persistent keys.
  *
  * - Applications may freely choose key identifiers in the range
@@ -266,6 +273,7 @@ typedef uint32_t psa_key_location_t;
  *       consideration to allow backward compatibility.
  */
 typedef uint32_t psa_key_id_t;
+#endif
 
 /** Encoding of key identifiers as seen inside the PSA Crypto implementation.
  *

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -2444,6 +2444,8 @@
 /* *INDENT-OFF* (https://github.com/ARM-software/psa-arch-tests/issues/337) */
 #define PSA_KEY_ID_NULL                         ((psa_key_id_t)0)
 /* *INDENT-ON* */
+
+#if !defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
 /** The minimum value for a key identifier chosen by the application.
  */
 #define PSA_KEY_ID_USER_MIN                     ((psa_key_id_t) 0x00000001)
@@ -2456,7 +2458,7 @@
 /** The maximum value for a key identifier chosen by the implementation.
  */
 #define PSA_KEY_ID_VENDOR_MAX                   ((psa_key_id_t) 0x7fffffff)
-
+#endif /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 
 #if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -61,6 +61,7 @@ EXCLUDE_FROM_FULL = frozenset([
     'MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS', # removes a feature
     'MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG', # behavior change + build dependency
     'MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER', # interface and behavior change
+    'MBEDTLS_PSA_CRYPTO_NO_KEY_STORE', # interface and behavor change
     'MBEDTLS_PSA_CRYPTO_SPM', # platform dependency (PSA SPM)
     'MBEDTLS_RSA_NO_CRT', # influences the use of RSA in X.509 and TLS
     'MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY', # interacts with *_USE_ARMV8_A_CRYPTO_IF_PRESENT

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -229,6 +229,15 @@ exit:
 
 static int test_operations_on_invalid_key(mbedtls_svc_key_id_t key)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    /* Accessing key would be a use-after-free, which would trip up
+     * sanitizers such as ASan and Valgrind. We can't reliably detect
+     * Valgrind, so don't try anything. */
+    (void) key;
+    return 1;
+
+#else /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
+
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_svc_key_id_t key_id = mbedtls_svc_key_id_make(1, 0x6964);
 #if defined(MBEDTLS_ECP_RESTARTABLE)
@@ -275,6 +284,7 @@ exit:
     psa_reset_key_attributes(&attributes);
 
     return ok;
+#endif /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 }
 
 #define INPUT_INTEGER 0x10000   /* Out of range of psa_key_type_t */

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -7,6 +7,11 @@
 
 static int check_stats(void)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+    return 1;
+
+#else /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
+
     mbedtls_psa_stats_t stats;
     mbedtls_psa_get_stats(&stats);
 
@@ -20,6 +25,7 @@ static int check_stats(void)
 
 exit:
     return 0;
+#endif /* MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 }
 
 #if defined MBEDTLS_THREADING_PTHREAD
@@ -190,7 +196,7 @@ void validate_module_init_generate_random(int count)
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:!MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 void validate_module_init_key_based(int count)
 {
     psa_status_t status;

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -104,6 +104,19 @@ static size_t tiny_key_slice_length(size_t slice_idx)
 #define MAX_VOLATILE_KEYS MBEDTLS_PSA_KEY_SLOT_COUNT
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE)
+/* These constants are used in test data, but they are not defined by the
+ * library when `MBEDTLS_PSA_CRYPTO_NO_KEY_STORE` is enabled.
+ * The test framework requires us to give them a value even if no test case
+ * that is actually executed uses that value.
+ */
+#define PSA_KEY_ID_USER_MIN 42
+#define PSA_KEY_ID_USER_MAX 42
+#define PSA_KEY_ID_VENDOR_MIN 42
+#define PSA_KEY_ID_VENDOR_MAX 42
+
+#endif /* defined(MBEDTLS_PSA_CRYPTO_NO_KEY_STORE) */
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -111,7 +124,7 @@ static size_t tiny_key_slice_length(size_t slice_idx)
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:!MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 void transient_slot_lifecycle(int owner_id_arg,
                               int usage_arg, int alg_arg,
                               int type_arg, data_t *key_data,
@@ -711,7 +724,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MAX_VOLATILE_KEYS */
+/* BEGIN_CASE depends_on:MAX_VOLATILE_KEYS:!MBEDTLS_PSA_CRYPTO_NO_KEY_STORE */
 /*
  * 1. Fill the key store with volatile keys.
  * 2. Check that attempting to create another volatile key fails without


### PR DESCRIPTION
New compile-time `MBEDTLS_PSA_CRYPTO_NO_KEY_STORE`, to build PSA crypto without a key store. Key IDs (`psa_key_id_t`) are direct pointers to a heap-allocated key slot.

The library and the unit tests compile.

`test_suite_psa_crypto_slot_management` and `test_suite_psa_crypto_init` pass.

`test_suite_psa_crypto` and others crash under ASan, because (perhaps among other reasons) they routinely call `psa_destroy_key()` on their cleanup path, on a key that is already destroyed when the test passes.

## Status

This is an unfinished prototype, shared to facilitate discussion.

## Code size benefit

```
mbedtls-prepare-build -d build-nopersistent-m0plus -p m0plus --config-unset=MBEDTLS_PSA_CRYPTO_STORAGE_C,MBEDTLS_PSA_ITS_FILE_C,MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS,MBEDTLS_PSA_KEY_STORE_DYNAMIC` vs
mbedtls-prepare-build -d build-nokeystore-m0plus -p m0plus --config-set=MBEDTLS_PSA_CRYPTO_NO_KEY_STORE --config-unset=MBEDTLS_PSA_CRYPTO_STORAGE_C,MBEDTLS_PSA_ITS_FILE_C,MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS,MBEDTLS_PSA_KEY_STORE_DYNAMIC
make -C build-nopersistent-m0plus lib
make -C build-nokeystore-m0plus lib
size-diff  <(size -t build-nopersistent-m0plus/library/libmbedcrypto.a) <(size -t build-nokeystore-m0plus/library/libmbedcrypto.a)
```
→
```
  184719  183629 (TOTALS)
   23269   22733 psa_crypto.o
     620      66 psa_crypto_slot_management.o
```

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [ ] **mbedtls development PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 4.1 PR** provided Mbed-TLS/mbedtls# | not required because: 
- [ ] **mbedtls 3.6 PR** provided Mbed-TLS/mbedtls# | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
