### PR TITLE
Enhance the PSA driver test jinja templates for hashing, AES, signature and key agreement functions

### DIFF
--- a/include/psa/crypto_driver_contexts_primitives.h
+++ b/include/psa/crypto_driver_contexts_primitives.h
@@ -110,7 +110,7 @@ typedef union {
     unsigned dummy; /* Make sure this union is always non-empty */
     mbedtls_psa_hash_operation_t mbedtls_ctx;
 #if defined(PSA_CRYPTO_DRIVER_TEST)
-    mbedtls_transparent_test_driver_hash_operation_t test_driver_ctx;
+    mbedtls_transparent_test_driver_hash_operation_t mbedtls_test_driver_ctx;
 #endif
 } psa_driver_hash_context_t;
 

--- a/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
+++ b/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
@@ -16,7 +16,34 @@
             "entry_points": ["export_public_key"],
             "fallback":     true,
             "names":         {"export_public_key":"mbedtls_test_transparent_export_public_key"}
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports hash compute operation",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["hash_compute"],
+            "fallback": true
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports hash setup operation",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["hash_setup"],
+            "fallback": true,
+            "multipart_id_init": true
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports hash clone operation",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["hash_clone"],
+            "fallback": false,
+            "multipart_id_clone": true,
+            "multipart_handler": "case"
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports hash update, finish, and abort operations",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["hash_update", "hash_finish", "hash_abort"],
+            "fallback": false,
+            "multipart_handler": "case"
         }
-
     ]
 }

--- a/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
+++ b/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
@@ -56,6 +56,12 @@
             "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
             "entry_points": ["signature_sign_message", "signature_verify_message", "signature_sign_hash", "signature_verify_hash"],
             "fallback": true
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports key agreement operation",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["key_agreement"],
+            "fallback": true
         }
     ]
 }

--- a/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
+++ b/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
@@ -44,6 +44,12 @@
             "entry_points": ["hash_update", "hash_finish", "hash_abort"],
             "fallback": false,
             "multipart_handler": "case"
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports cipher and aead operations",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["cipher_encrypt", "cipher_decrypt", "aead_encrypt", "aead_decrypt"],
+            "fallback": true
         }
     ]
 }

--- a/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
+++ b/scripts/data_files/driver_jsons/mbedtls_test_transparent_driver.json
@@ -50,6 +50,12 @@
             "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
             "entry_points": ["cipher_encrypt", "cipher_decrypt", "aead_encrypt", "aead_decrypt"],
             "fallback": true
+        },
+        {
+            "_comment": "The Mbed TLS transparent driver supports signature operations",
+            "mbedtls/c_condition": "defined(PSA_CRYPTO_DRIVER_TEST)",
+            "entry_points": ["signature_sign_message", "signature_verify_message", "signature_sign_hash", "signature_verify_hash"],
+            "fallback": true
         }
     ]
 }

--- a/scripts/data_files/driver_templates/OS-template-transparent.jinja
+++ b/scripts/data_files/driver_templates/OS-template-transparent.jinja
@@ -7,12 +7,26 @@ Expected inputs:
 -#}
 {% for driver in drivers if driver.type == "transparent" -%}
 {% for capability in driver.capabilities if entry_point in capability.entry_points -%}
-#if ({% if capability['mbedtls/c_condition'] is defined -%}{{ capability['mbedtls/c_condition'] }} {% else -%} {{ 1 }} {% endif %})
+#if {% if capability['mbedtls/c_condition'] is defined -%}{{ capability['mbedtls/c_condition'] }} {% else -%} {{ 1 }} {% endif %}
 {%- filter indent(width = nest_indent) %}
+{% if capability['multipart_handler'] is defined -%}
+{{ capability['multipart_handler'] }} {{(driver.prefix + "_" + driver.type + "_driver_id").upper()}}:
+{% endif %}
+{% if capability['multipart_id_clone'] -%}
+    target_operation->id = {{(driver.prefix + "_" + driver.type + "_driver_id").upper()}};
+{% endif %}
 status = {{ entry_point_name(capability, entry_point, driver) }}({{entry_point_param(driver) | indent(20)}});
-
-if( status != PSA_ERROR_NOT_SUPPORTED )
-    return( status );
+{% if capability['multipart_id_init'] -%}
+if(status == PSA_SUCCESS)
+    operation->id = {{(driver.prefix + "_" + driver.type + "_driver_id").upper()}};
+{% endif %}
+{% if capability['fallback'] -%}
+/* Declared with fallback == true */
+if(status != PSA_ERROR_NOT_SUPPORTED)
+    return status;
+{% else -%}
+    return status;
+{% endif %}
 {% endfilter -%}
 #endif
 {% endfor %}

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -1369,6 +1369,20 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
     size_t output_size,
     size_t *output_length )
 {
+{% with entry_point = "cipher_encrypt" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+iv,
+iv_length,
+input,
+input_length,
+output,
+output_size,
+output_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -1379,22 +1393,9 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_cipher_encrypt( attributes,
-                                                              key_buffer,
-                                                              key_buffer_size,
-                                                              alg,
-                                                              iv,
-                                                              iv_length,
-                                                              input,
-                                                              input_length,
-                                                              output,
-                                                              output_size,
-                                                              output_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1446,6 +1447,7 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
             (void)output_length;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
@@ -1459,6 +1461,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
     size_t output_size,
     size_t *output_length )
 {
+{% with entry_point = "cipher_decrypt" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+input,
+input_length,
+output,
+output_size,
+output_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -1469,20 +1483,9 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_cipher_decrypt( attributes,
-                                                              key_buffer,
-                                                              key_buffer_size,
-                                                              alg,
-                                                              input,
-                                                              input_length,
-                                                              output,
-                                                              output_size,
-                                                              output_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1528,6 +1531,7 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
             (void)output_length;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
@@ -2174,6 +2178,15 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
     const uint8_t *plaintext, size_t plaintext_length,
     uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length )
 {
+{% with entry_point = "aead_encrypt" -%}
+{% macro entry_point_param(driver) -%}
+attributes, key_buffer, key_buffer_size,
+alg,
+nonce, nonce_length,
+additional_data, additional_data_length,
+plaintext, plaintext_length,
+ciphertext, ciphertext_size, ciphertext_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -2185,18 +2198,9 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
              * cycle through all known transparent accelerators */
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_aead_encrypt(
-                         attributes, key_buffer, key_buffer_size,
-                         alg,
-                         nonce, nonce_length,
-                         additional_data, additional_data_length,
-                         plaintext, plaintext_length,
-                         ciphertext, ciphertext_size, ciphertext_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2225,6 +2229,7 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
             (void) ciphertext; (void) ciphertext_size; (void) ciphertext_length;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_aead_decrypt(
@@ -2236,6 +2241,15 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
     const uint8_t *ciphertext, size_t ciphertext_length,
     uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length )
 {
+{% with entry_point = "aead_decrypt" -%}
+{% macro entry_point_param(driver) -%}
+attributes, key_buffer, key_buffer_size,
+alg,
+nonce, nonce_length,
+additional_data, additional_data_length,
+ciphertext, ciphertext_length,
+plaintext, plaintext_size, plaintext_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -2247,18 +2261,9 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
              * cycle through all known transparent accelerators */
 
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_aead_decrypt(
-                        attributes, key_buffer, key_buffer_size,
-                        alg,
-                        nonce, nonce_length,
-                        additional_data, additional_data_length,
-                        ciphertext, ciphertext_length,
-                        plaintext, plaintext_size, plaintext_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2287,6 +2292,7 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
             (void) plaintext; (void) plaintext_size; (void) plaintext_length;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_aead_encrypt_setup(

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -3159,6 +3159,13 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
     size_t *shared_secret_length
  )
 {
+{% with entry_point = "key_agreement" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer, key_buffer_size, alg, peer_key,
+peer_key_length, shared_secret, shared_secret_size,
+shared_secret_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -3169,15 +3176,9 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status =
-                mbedtls_test_transparent_key_agreement( attributes,
-                        key_buffer, key_buffer_size, alg, peer_key,
-                        peer_key_length, shared_secret, shared_secret_size,
-                        shared_secret_length );
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #if defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDH(alg) &&
@@ -3210,6 +3211,7 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
                                                     shared_secret_size,
                                                     shared_secret_length );
             return( status );
+
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_TEST)
         case PSA_CRYPTO_TEST_DRIVER_LOCATION:
@@ -3232,6 +3234,7 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
             return( PSA_ERROR_NOT_SUPPORTED );
 
     }
+{% endwith -%}
 }
 
 static inline psa_status_t psa_driver_wrapper_pake_setup(

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -103,6 +103,18 @@ static inline psa_status_t psa_driver_wrapper_sign_message(
     size_t signature_size,
     size_t *signature_length )
 {
+{% with entry_point = "signature_sign_message" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+input,
+input_length,
+signature,
+signature_size,
+signature_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -113,21 +125,9 @@ static inline psa_status_t psa_driver_wrapper_sign_message(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_signature_sign_message(
-                        attributes,
-                        key_buffer,
-                        key_buffer_size,
-                        alg,
-                        input,
-                        input_length,
-                        signature,
-                        signature_size,
-                        signature_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED)
@@ -177,6 +177,7 @@ static inline psa_status_t psa_driver_wrapper_sign_message(
                                       signature,
                                       signature_size,
                                       signature_length ) );
+{% endwith -%}
 }
 
 static inline psa_status_t psa_driver_wrapper_sign_setup(
@@ -412,6 +413,17 @@ static inline psa_status_t psa_driver_wrapper_verify_message(
     const uint8_t *signature,
     size_t signature_length )
 {
+{% with entry_point = "signature_verify_message" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+input,
+input_length,
+signature,
+signature_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -422,20 +434,9 @@ static inline psa_status_t psa_driver_wrapper_verify_message(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_signature_verify_message(
-                        attributes,
-                        key_buffer,
-                        key_buffer_size,
-                        alg,
-                        input,
-                        input_length,
-                        signature,
-                        signature_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED)
@@ -483,6 +484,7 @@ static inline psa_status_t psa_driver_wrapper_verify_message(
                                         input_length,
                                         signature,
                                         signature_length ) );
+{% endwith -%}
 }
 
 static inline psa_status_t psa_driver_wrapper_verify_setup(
@@ -710,6 +712,18 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
     psa_algorithm_t alg, const uint8_t *hash, size_t hash_length,
     uint8_t *signature, size_t signature_size, size_t *signature_length )
 {
+{% with entry_point = "signature_sign_hash" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+hash,
+hash_length,
+signature,
+signature_size,
+signature_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -720,20 +734,9 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_signature_sign_hash( attributes,
-                                                           key_buffer,
-                                                           key_buffer_size,
-                                                           alg,
-                                                           hash,
-                                                           hash_length,
-                                                           signature,
-                                                           signature_size,
-                                                           signature_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_RANDOMIZED_ECDSA(alg) &&
@@ -785,6 +788,7 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
             (void)status;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith -%}
 }
 
 static inline psa_status_t psa_driver_wrapper_verify_hash(
@@ -793,6 +797,17 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
     psa_algorithm_t alg, const uint8_t *hash, size_t hash_length,
     const uint8_t *signature, size_t signature_length )
 {
+{% with entry_point = "signature_verify_hash" -%}
+{% macro entry_point_param(driver) -%}
+attributes,
+key_buffer,
+key_buffer_size,
+alg,
+hash,
+hash_length,
+signature,
+signature_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_location_t location =
         PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
@@ -803,20 +818,9 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
             /* Key is stored in the slot in export representation, so
              * cycle through all known transparent accelerators */
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-            status = mbedtls_test_transparent_signature_verify_hash(
-                         attributes,
-                         key_buffer,
-                         key_buffer_size,
-                         alg,
-                         hash,
-                         hash_length,
-                         signature,
-                         signature_length );
-            /* Declared with fallback == true */
-            if( status != PSA_ERROR_NOT_SUPPORTED )
-                return( status );
-#endif /* PSA_CRYPTO_DRIVER_TEST */
+{% with nest_indent=12 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDSA(alg) &&
@@ -865,6 +869,7 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
             (void)status;
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
+{% endwith -%}
 }
 
 static inline uint32_t psa_driver_wrapper_sign_hash_get_num_ops(

--- a/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
+++ b/scripts/data_files/driver_templates/psa_crypto_driver_wrappers.h.jinja
@@ -1843,15 +1843,18 @@ static inline psa_status_t psa_driver_wrapper_hash_compute(
     size_t hash_size,
     size_t *hash_length)
 {
+{% with entry_point = "hash_compute" -%}
+{% macro entry_point_param(driver) -%}
+alg, input, input_length, hash, hash_size, hash_length
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* Try accelerators first */
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-    status = mbedtls_test_transparent_hash_compute(
-                alg, input, input_length, hash, hash_size, hash_length );
-    if( status != PSA_ERROR_NOT_SUPPORTED )
-        return( status );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=4 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
     /* If software fallback is compiled in, try fallback */
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1869,24 +1872,25 @@ static inline psa_status_t psa_driver_wrapper_hash_compute(
     (void) hash_length;
 
     return( PSA_ERROR_NOT_SUPPORTED );
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_hash_setup(
     psa_hash_operation_t *operation,
     psa_algorithm_t alg )
 {
+{% with entry_point = "hash_setup" -%}
+{% macro entry_point_param(driver) -%}
+&operation->ctx.{{driver.prefix + "_driver_ctx"}}, alg
+{% endmacro %}
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* Try setup on accelerators first */
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-    status = mbedtls_test_transparent_hash_setup(
-                &operation->ctx.test_driver_ctx, alg );
-    if( status == PSA_SUCCESS )
-        operation->id = MBEDTLS_TEST_TRANSPARENT_DRIVER_ID;
-
-    if( status != PSA_ERROR_NOT_SUPPORTED )
-        return( status );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=4 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
     /* If software fallback is compiled in, try fallback */
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1902,12 +1906,19 @@ static inline psa_status_t psa_driver_wrapper_hash_setup(
     (void) operation;
     (void) alg;
     return( PSA_ERROR_NOT_SUPPORTED );
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_hash_clone(
     const psa_hash_operation_t *source_operation,
     psa_hash_operation_t *target_operation )
 {
+{% with entry_point = "hash_clone" -%}
+{% macro entry_point_param(driver) -%}
+&source_operation->ctx.{{driver.prefix + "_driver_ctx"}},
+&target_operation->ctx.{{driver.prefix + "_driver_ctx"}}
+{% endmacro %}
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     switch( source_operation->id )
     {
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1916,17 +1927,17 @@ static inline psa_status_t psa_driver_wrapper_hash_clone(
             return( mbedtls_psa_hash_clone( &source_operation->ctx.mbedtls_ctx,
                                             &target_operation->ctx.mbedtls_ctx ) );
 #endif
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-        case MBEDTLS_TEST_TRANSPARENT_DRIVER_ID:
-            target_operation->id = MBEDTLS_TEST_TRANSPARENT_DRIVER_ID;
-            return( mbedtls_test_transparent_hash_clone(
-                        &source_operation->ctx.test_driver_ctx,
-                        &target_operation->ctx.test_driver_ctx ) );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=8 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
+            (void) status;
             (void) target_operation;
             return( PSA_ERROR_BAD_STATE );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_hash_update(
@@ -1934,6 +1945,12 @@ static inline psa_status_t psa_driver_wrapper_hash_update(
     const uint8_t *input,
     size_t input_length )
 {
+{% with entry_point = "hash_update" -%}
+{% macro entry_point_param(driver) -%}
+&operation->ctx.{{driver.prefix + "_driver_ctx"}},
+input, input_length
+{% endmacro %}
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     switch( operation->id )
     {
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1941,17 +1958,18 @@ static inline psa_status_t psa_driver_wrapper_hash_update(
             return( mbedtls_psa_hash_update( &operation->ctx.mbedtls_ctx,
                                              input, input_length ) );
 #endif
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-        case MBEDTLS_TEST_TRANSPARENT_DRIVER_ID:
-            return( mbedtls_test_transparent_hash_update(
-                        &operation->ctx.test_driver_ctx,
-                        input, input_length ) );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=8 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
+            (void) status;
             (void) input;
             (void) input_length;
             return( PSA_ERROR_BAD_STATE );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_hash_finish(
@@ -1960,6 +1978,12 @@ static inline psa_status_t psa_driver_wrapper_hash_finish(
     size_t hash_size,
     size_t *hash_length )
 {
+{% with entry_point = "hash_finish" -%}
+{% macro entry_point_param(driver) -%}
+&operation->ctx.{{driver.prefix + "_driver_ctx"}},
+hash, hash_size, hash_length
+{% endmacro %}
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     switch( operation->id )
     {
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
@@ -1967,37 +1991,45 @@ static inline psa_status_t psa_driver_wrapper_hash_finish(
             return( mbedtls_psa_hash_finish( &operation->ctx.mbedtls_ctx,
                                              hash, hash_size, hash_length ) );
 #endif
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-        case MBEDTLS_TEST_TRANSPARENT_DRIVER_ID:
-            return( mbedtls_test_transparent_hash_finish(
-                        &operation->ctx.test_driver_ctx,
-                        hash, hash_size, hash_length ) );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=8 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
+            (void) status;
             (void) hash;
             (void) hash_size;
             (void) hash_length;
             return( PSA_ERROR_BAD_STATE );
     }
+{% endwith %}
 }
 
 static inline psa_status_t psa_driver_wrapper_hash_abort(
     psa_hash_operation_t *operation )
 {
+{% with entry_point = "hash_abort" -%}
+{% macro entry_point_param(driver) -%}
+&operation->ctx.{{driver.prefix + "_driver_ctx"}}
+{% endmacro %}
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     switch( operation->id )
     {
 #if defined(MBEDTLS_PSA_BUILTIN_HASH)
         case PSA_CRYPTO_MBED_TLS_DRIVER_ID:
             return( mbedtls_psa_hash_abort( &operation->ctx.mbedtls_ctx ) );
 #endif
-#if defined(PSA_CRYPTO_DRIVER_TEST)
-        case MBEDTLS_TEST_TRANSPARENT_DRIVER_ID:
-            return( mbedtls_test_transparent_hash_abort(
-                        &operation->ctx.test_driver_ctx ) );
-#endif
+#if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+{% with nest_indent=8 %}
+{% include "OS-template-transparent.jinja" -%}
+{% endwith -%}
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
+            (void) status;
             return( PSA_ERROR_BAD_STATE );
     }
+{% endwith %}
 }
 
 /*


### PR DESCRIPTION
## Description

Enhance the jinja templates for the transparent driver using the MbedTLS transparent driver test:

* Enhance OS-template-transparent.jinja to:
  * Support fallback behavior when the driver do not fully support a cryptographic mechanism
  * Handle driver ID and and operation context for multipart operations

* Update psa_crypto_driver_wrappers.h.jinja to provide entry point for:
  * HASH operations including multi-part operations
  * AES cipher and AEAD encryption and decryption operations
  * Hash and message signature generation and verification operations
  * Key agreement operation.

* Rename the test_driver_ctx to in  crypto_driver_contexts_primitives.h to align with the transparent driver templates:
  * mbedtls_test_driver_ctx : driver.prefix + _driver_ctx

## PR checklist

- [x] **changelog** not required 
- [x] **framework PR**  not required
- [x] **TF-PSA-Crypto development PR** provided here 
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/880
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required
- **tests**  not required because: No regression, generated files are the same