### PR TITLE
Backport 1.1: CMake: add support for config options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,13 +170,9 @@ endif()
 # Make TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
-set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Name of the configuration to use (see config.py documentation)")
-
-if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
-    if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "")
-        message(FATAL_ERROR "TF_PSA_CRYPTO_CONFIG_NAME and TF_PSA_CRYPTO_CONFIG_FILE are incompatible.")
-    endif()
-endif(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Named TF-PSA-Crypto configuration (see config.py).")
+set(TF_PSA_CRYPTO_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
+set(TF_PSA_CRYPTO_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.
@@ -440,6 +436,10 @@ set(TF_PSA_CRYPTO_PRIVATE_INCLUDE_DIRS
 #
 add_subdirectory(framework)
 add_subdirectory(include)
+if(TF_PSA_CRYPTO_AS_SUBPROJECT AND TF_PSA_CRYPTO_CONFIG_TRANSFORMED)
+    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_CONFIG_FILE}"
+        PARENT_SCOPE)
+endif()
 add_subdirectory(drivers)   # must precede core
 add_subdirectory(extras)
 add_subdirectory(platform)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,12 +167,24 @@ if(NOT TF_PSA_CRYPTO_AS_SUBPROJECT)
         FORCE)
 endif()
 
-# Make TF_PSA_CRYPTO_CONFIG_FILE and TF_PSA_CRYPTO_USER_CONFIG_FILE into PATHs
+# Make configuration file options into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
+set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE FILEPATH "TF-PSA-Crypto config to copy and optionally transform.")
 set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Named TF-PSA-Crypto configuration (see config.py).")
 set(TF_PSA_CRYPTO_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(TF_PSA_CRYPTO_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
+
+if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
+   (NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL ""))
+    message(FATAL_ERROR
+        "TF_PSA_CRYPTO_CONFIG_FILE cannot be combined with "
+        "TF_PSA_CRYPTO_CONFIG_BASE_FILE, TF_PSA_CRYPTO_CONFIG_NAME, "
+        "TF_PSA_CRYPTO_CONFIG_SET or TF_PSA_CRYPTO_CONFIG_UNSET.")
+endif()
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 # Make configuration file options into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
-set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE STRING "TF-PSA-Crypto config to copy and optionally transform.")
+set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE FILEPATH "TF-PSA-Crypto config to copy and optionally transform.")
 set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Named TF-PSA-Crypto configuration (see config.py).")
 set(TF_PSA_CRYPTO_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(TF_PSA_CRYPTO_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,20 +170,23 @@ endif()
 # Make configuration file options into PATHs
 set(TF_PSA_CRYPTO_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto config file (overrides default).")
 set(TF_PSA_CRYPTO_USER_CONFIG_FILE "" CACHE FILEPATH "TF-PSA-Crypto user config file (appended to default).")
-set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE FILEPATH "TF-PSA-Crypto config to copy and optionally transform.")
+set(TF_PSA_CRYPTO_CONFIG_BASE_FILE "" CACHE STRING "TF-PSA-Crypto config to copy and optionally transform.")
 set(TF_PSA_CRYPTO_CONFIG_NAME "" CACHE STRING "Named TF-PSA-Crypto configuration (see config.py).")
 set(TF_PSA_CRYPTO_CONFIG_SET "" CACHE STRING "Options to set, separated by semicolons (OPTION or OPTION=VALUE).")
 set(TF_PSA_CRYPTO_CONFIG_UNSET "" CACHE STRING "Options to unset, separated by semicolons.")
 
 if(NOT "${TF_PSA_CRYPTO_CONFIG_FILE}" STREQUAL "" AND
    (NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
+    NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE}" STREQUAL "" OR
     NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
     NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
     NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL ""))
     message(FATAL_ERROR
         "TF_PSA_CRYPTO_CONFIG_FILE cannot be combined with "
-        "TF_PSA_CRYPTO_CONFIG_BASE_FILE, TF_PSA_CRYPTO_CONFIG_NAME, "
-        "TF_PSA_CRYPTO_CONFIG_SET or TF_PSA_CRYPTO_CONFIG_UNSET.")
+        "TF_PSA_CRYPTO_CONFIG_BASE_FILE, "
+        "TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE, "
+        "TF_PSA_CRYPTO_CONFIG_NAME, TF_PSA_CRYPTO_CONFIG_SET or "
+        "TF_PSA_CRYPTO_CONFIG_UNSET.")
 endif()
 
 # Create a symbolic link from ${base_name} in the binary directory

--- a/ChangeLog.d/cmake-config.txt
+++ b/ChangeLog.d/cmake-config.txt
@@ -1,0 +1,5 @@
+Features
+   * Add the `TF_PSA_CRYPTO_CONFIG_SET` and `TF_PSA_CRYPTO_CONFIG_UNSET`
+     CMake options for customizing compile-time configurations, including
+     configurations based on a custom `TF_PSA_CRYPTO_CONFIG_FILE`. Fixes
+     Mbed-TLS/mbedtls#10838.

--- a/ChangeLog.d/cmake-config.txt
+++ b/ChangeLog.d/cmake-config.txt
@@ -1,5 +1,5 @@
 Features
-   * Add the `TF_PSA_CRYPTO_CONFIG_SET` and `TF_PSA_CRYPTO_CONFIG_UNSET`
-     CMake options for customizing compile-time configurations, including
-     configurations based on a custom `TF_PSA_CRYPTO_CONFIG_FILE`. Fixes
-     Mbed-TLS/mbedtls#10838.
+   * Add the `TF_PSA_CRYPTO_CONFIG_BASE_FILE`,
+     `TF_PSA_CRYPTO_CONFIG_NAME`, `TF_PSA_CRYPTO_CONFIG_SET` and
+     `TF_PSA_CRYPTO_CONFIG_UNSET` CMake options for selecting and customizing
+     compile-time configurations. Fixes Mbed-TLS/mbedtls#10838.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,28 +1,78 @@
 option(INSTALL_TF_PSA_CRYPTO_HEADERS "Install TF PSA Crypto headers." ON)
 
-# The handling of TF_PSA_CRYPTO_CONFIG_NAME assumes that the default
-# configuration file 'include/psa/crypto_config.h' exists in the source tree.
-# That file is copied into the build tree and then modified with 'config.py'
-# according to the configuration name provided via TF_PSA_CRYPTO_CONFIG_NAME.
+# Generate a build-tree configuration when transformations are requested.
+if(TF_PSA_CRYPTO_CONFIG_NAME OR TF_PSA_CRYPTO_CONFIG_SET OR
+   TF_PSA_CRYPTO_CONFIG_UNSET)
+    if(TF_PSA_CRYPTO_CONFIG_FILE)
+        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE "${TF_PSA_CRYPTO_CONFIG_FILE}")
+        if(NOT EXISTS "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
+            file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_FILE_RELATIVE
+                 "${PROJECT_BINARY_DIR}" "${TF_PSA_CRYPTO_CONFIG_FILE}")
+            set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
+                "${PROJECT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_FILE_RELATIVE}")
+        endif()
+    else()
+        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
+            "${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h")
+    endif()
+    if(NOT EXISTS "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
+        message(FATAL_ERROR
+            "TF-PSA-Crypto configuration file not found: ${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
+    endif()
 
-if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/psa)
-    file(COPY ${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h
-         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/psa)
-
-    message(STATUS "Setting ${TF_PSA_CRYPTO_CONFIG_NAME} configuration")
+    set(TF_PSA_CRYPTO_GENERATED_CONFIG_FILE
+        "${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h")
     execute_process(
-        COMMAND
-            ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
-            ${PROJECT_SOURCE_DIR}/scripts/config.py
-            -f ${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h
-            ${TF_PSA_CRYPTO_CONFIG_NAME}
+        COMMAND ${CMAKE_COMMAND} -E copy
+                "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}"
+                "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}"
         RESULT_VARIABLE result
     )
     if(result)
-        message(FATAL_ERROR "Setting ${TF_PSA_CRYPTO_CONFIG_NAME} configuration failed")
+        message(FATAL_ERROR
+            "Failed to copy the TF-PSA-Crypto base configuration file")
     endif()
-endif(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+
+    function(tf_psa_crypto_configure_generated_file)
+        execute_process(
+            COMMAND
+                ${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}
+                "${PROJECT_SOURCE_DIR}/scripts/config.py"
+                --file "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}"
+                ${ARGN}
+            RESULT_VARIABLE result
+        )
+        if(result)
+            message(FATAL_ERROR
+                "Failed to configure the generated TF-PSA-Crypto configuration file")
+        endif()
+    endfunction(tf_psa_crypto_configure_generated_file)
+
+    if(TF_PSA_CRYPTO_CONFIG_NAME)
+        tf_psa_crypto_configure_generated_file("${TF_PSA_CRYPTO_CONFIG_NAME}")
+    endif()
+    foreach(option IN LISTS TF_PSA_CRYPTO_CONFIG_UNSET)
+        tf_psa_crypto_configure_generated_file(unset "${option}")
+    endforeach(option)
+    foreach(option IN LISTS TF_PSA_CRYPTO_CONFIG_SET)
+        string(FIND "${option}" "=" separator)
+        if(separator EQUAL -1)
+            tf_psa_crypto_configure_generated_file(--force set "${option}")
+        else()
+            string(SUBSTRING "${option}" 0 ${separator} name)
+            math(EXPR value_start "${separator} + 1")
+            string(SUBSTRING "${option}" ${value_start} -1 value)
+            tf_psa_crypto_configure_generated_file(--force set "${name}" "${value}")
+        endif()
+    endforeach(option)
+
+    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}")
+    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}"
+        PARENT_SCOPE)
+    set(TF_PSA_CRYPTO_CONFIG_TRANSFORMED ON)
+    set(TF_PSA_CRYPTO_CONFIG_TRANSFORMED ON PARENT_SCOPE)
+endif()
 
 if(INSTALL_TF_PSA_CRYPTO_HEADERS)
     install(DIRECTORY "."
@@ -31,11 +81,11 @@ if(INSTALL_TF_PSA_CRYPTO_HEADERS)
         PATTERN "crypto_config.h" EXCLUDE
     )
 
-    if("${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+    if(NOT TF_PSA_CRYPTO_CONFIG_TRANSFORMED)
         install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/psa/crypto_config.h"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa)
     else()
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/psa)
-    endif("${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
+    endif()
 endif(INSTALL_TF_PSA_CRYPTO_HEADERS)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,15 +1,17 @@
 option(INSTALL_TF_PSA_CRYPTO_HEADERS "Install TF PSA Crypto headers." ON)
 
 # Generate a build-tree configuration when a base or transformations are requested.
-if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
+if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE}" STREQUAL "" OR
+   NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
    NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
    NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
    NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL "")
     if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
         message(FATAL_ERROR
+            "TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE, "
             "TF_PSA_CRYPTO_CONFIG_BASE_FILE, TF_PSA_CRYPTO_CONFIG_NAME, "
-            "TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET are not "
-            "supported in an in-tree build.")
+            "TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET "
+            "are not supported in an in-tree build.")
     endif()
 
     if((NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
@@ -20,29 +22,26 @@ if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
             "Python 3 is required to generate a TF-PSA-Crypto configuration file.")
     endif()
 
-    if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "")
-        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
-            "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
-        if(NOT EXISTS "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
-            file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE
-                 "${PROJECT_BINARY_DIR}"
-                 "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
-            set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
-                "${PROJECT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE}")
-        endif()
-    else()
-        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
+    if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE}" STREQUAL "")
+        set(TF_PSA_CRYPTO_CONFIG_BASE_FILE
+            "${TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE}")
+    elseif("${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "")
+        set(TF_PSA_CRYPTO_CONFIG_BASE_FILE
             "${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h")
     endif()
-    if(NOT EXISTS "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
+    get_filename_component(TF_PSA_CRYPTO_CONFIG_BASE_FILE
+        "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" ABSOLUTE
+        BASE_DIR "${PROJECT_SOURCE_DIR}")
+    if(NOT EXISTS "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
         message(FATAL_ERROR
-            "TF-PSA-Crypto configuration file not found: ${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
+            "TF-PSA-Crypto configuration file not found: "
+            "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
     endif()
 
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/psa")
     set(TF_PSA_CRYPTO_GENERATED_CONFIG_FILE
         "${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h")
-    configure_file("${TF_PSA_CRYPTO_BASE_CONFIG_FILE}"
+    configure_file("${TF_PSA_CRYPTO_CONFIG_BASE_FILE}"
                    "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}" COPYONLY)
 
     function(tf_psa_crypto_configure_generated_file)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,15 +1,34 @@
 option(INSTALL_TF_PSA_CRYPTO_HEADERS "Install TF PSA Crypto headers." ON)
 
-# Generate a build-tree configuration when transformations are requested.
-if(TF_PSA_CRYPTO_CONFIG_NAME OR TF_PSA_CRYPTO_CONFIG_SET OR
-   TF_PSA_CRYPTO_CONFIG_UNSET)
-    if(TF_PSA_CRYPTO_CONFIG_FILE)
-        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE "${TF_PSA_CRYPTO_CONFIG_FILE}")
+# Generate a build-tree configuration when a base or transformations are requested.
+if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "" OR
+   NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
+   NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
+   NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL "")
+    if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
+        message(FATAL_ERROR
+            "TF_PSA_CRYPTO_CONFIG_BASE_FILE, TF_PSA_CRYPTO_CONFIG_NAME, "
+            "TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET are not "
+            "supported in an in-tree build.")
+    endif()
+
+    if((NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "" OR
+        NOT "${TF_PSA_CRYPTO_CONFIG_SET}" STREQUAL "" OR
+        NOT "${TF_PSA_CRYPTO_CONFIG_UNSET}" STREQUAL "") AND
+       "${TF_PSA_CRYPTO_PYTHON_EXECUTABLE}" STREQUAL "")
+        message(FATAL_ERROR
+            "Python 3 is required to generate a TF-PSA-Crypto configuration file.")
+    endif()
+
+    if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" STREQUAL "")
+        set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
+            "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
         if(NOT EXISTS "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
-            file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_FILE_RELATIVE
-                 "${PROJECT_BINARY_DIR}" "${TF_PSA_CRYPTO_CONFIG_FILE}")
+            file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE
+                 "${PROJECT_BINARY_DIR}"
+                 "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
             set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
-                "${PROJECT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_FILE_RELATIVE}")
+                "${PROJECT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE}")
         endif()
     else()
         set(TF_PSA_CRYPTO_BASE_CONFIG_FILE
@@ -20,19 +39,11 @@ if(TF_PSA_CRYPTO_CONFIG_NAME OR TF_PSA_CRYPTO_CONFIG_SET OR
             "TF-PSA-Crypto configuration file not found: ${TF_PSA_CRYPTO_BASE_CONFIG_FILE}")
     endif()
 
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/psa)
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/psa")
     set(TF_PSA_CRYPTO_GENERATED_CONFIG_FILE
         "${CMAKE_CURRENT_BINARY_DIR}/psa/crypto_config.h")
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E copy
-                "${TF_PSA_CRYPTO_BASE_CONFIG_FILE}"
-                "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}"
-        RESULT_VARIABLE result
-    )
-    if(result)
-        message(FATAL_ERROR
-            "Failed to copy the TF-PSA-Crypto base configuration file")
-    endif()
+    configure_file("${TF_PSA_CRYPTO_BASE_CONFIG_FILE}"
+                   "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}" COPYONLY)
 
     function(tf_psa_crypto_configure_generated_file)
         execute_process(
@@ -49,7 +60,7 @@ if(TF_PSA_CRYPTO_CONFIG_NAME OR TF_PSA_CRYPTO_CONFIG_SET OR
         endif()
     endfunction(tf_psa_crypto_configure_generated_file)
 
-    if(TF_PSA_CRYPTO_CONFIG_NAME)
+    if(NOT "${TF_PSA_CRYPTO_CONFIG_NAME}" STREQUAL "")
         tf_psa_crypto_configure_generated_file("${TF_PSA_CRYPTO_CONFIG_NAME}")
     endif()
     foreach(option IN LISTS TF_PSA_CRYPTO_CONFIG_UNSET)
@@ -67,9 +78,9 @@ if(TF_PSA_CRYPTO_CONFIG_NAME OR TF_PSA_CRYPTO_CONFIG_SET OR
         endif()
     endforeach(option)
 
-    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}")
-    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}"
-        PARENT_SCOPE)
+    set(TF_PSA_CRYPTO_CONFIG_FILE
+        "$<BUILD_INTERFACE:${TF_PSA_CRYPTO_GENERATED_CONFIG_FILE}>$<INSTALL_INTERFACE:psa/crypto_config.h>")
+    set(TF_PSA_CRYPTO_CONFIG_FILE "${TF_PSA_CRYPTO_CONFIG_FILE}" PARENT_SCOPE)
     set(TF_PSA_CRYPTO_CONFIG_TRANSFORMED ON)
     set(TF_PSA_CRYPTO_CONFIG_TRANSFORMED ON PARENT_SCOPE)
 endif()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -29,13 +29,16 @@ if(NOT "${TF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE}" STREQUAL "" OR
         set(TF_PSA_CRYPTO_CONFIG_BASE_FILE
             "${PROJECT_SOURCE_DIR}/include/psa/crypto_config.h")
     endif()
-    get_filename_component(TF_PSA_CRYPTO_CONFIG_BASE_FILE
-        "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}" ABSOLUTE
-        BASE_DIR "${PROJECT_SOURCE_DIR}")
+    if(NOT EXISTS "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
+        file(RELATIVE_PATH TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE
+             "${PROJECT_BINARY_DIR}"
+             "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
+        set(TF_PSA_CRYPTO_CONFIG_BASE_FILE
+            "${PROJECT_SOURCE_DIR}/${TF_PSA_CRYPTO_CONFIG_BASE_FILE_RELATIVE}")
+    endif()
     if(NOT EXISTS "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
         message(FATAL_ERROR
-            "TF-PSA-Crypto configuration file not found: "
-            "${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
+            "TF-PSA-Crypto configuration file not found: ${TF_PSA_CRYPTO_CONFIG_BASE_FILE}")
     endif()
 
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/psa")

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -173,6 +173,19 @@ component_tf_psa_crypto_build_config_options () {
 
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+    launch_dir="$OUT_OF_SOURCE_DIR.launch"
+    mkdir "$launch_dir"
+    cd "$launch_dir"
+
+    msg "configure: resolve a relative base config from the source tree"
+    cmake -H"$TF_PSA_CRYPTO_ROOT_DIR" -B"$OUT_OF_SOURCE_DIR" \
+        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=configs/crypto-config-symmetric-only.h \
+        -DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_MD5
+    grep '^#define PSA_WANT_ALG_MD5' \
+        "$OUT_OF_SOURCE_DIR/include/psa/crypto_config.h"
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR" "$launch_dir"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
 
@@ -198,6 +211,21 @@ component_tf_psa_crypto_build_config_options () {
     msg "configure: cmake with a false-like option name"
     cmake -DTF_PSA_CRYPTO_CONFIG_SET=NO "$TF_PSA_CRYPTO_ROOT_DIR"
     grep '^#define NO$' include/psa/crypto_config.h
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: apply transformations to an overridden base config"
+    cmake \
+        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE_OVERRIDE="$TF_PSA_CRYPTO_ROOT_DIR/configs/crypto-config-symmetric-only.h" \
+        -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
+        "$TF_PSA_CRYPTO_ROOT_DIR"
+    not grep -q '^#define PSA_WANT_ALG_RIPEMD160' \
+        include/psa/crypto_config.h
+    not grep -q '^#define PSA_WANT_KEY_TYPE_DH_KEY_PAIR_BASIC' \
+        include/psa/crypto_config.h
 
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -239,9 +239,11 @@ add_executable(consumer
     "$TF_PSA_CRYPTO_ROOT_DIR/programs/test/cmake_package_install/cmake_package_install.c")
 target_link_libraries(consumer PRIVATE TF-PSA-Crypto::tfpsacrypto)
 EOF
-    cmake -S consumer -B consumer-build \
-          -DCMAKE_PREFIX_PATH="$install_dir"
-    cmake --build consumer-build
+    mkdir consumer-build
+    cd consumer-build
+    cmake -DCMAKE_PREFIX_PATH="$install_dir" ../consumer
+    cmake --build .
+    cd ..
 
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -147,7 +147,6 @@ component_tf_psa_crypto_build_config_name () {
     cd "$OUT_OF_SOURCE_DIR"
     cmake -DCMAKE_INSTALL_PREFIX="$OUT_OF_SOURCE_DIR/install_full" -DTF_PSA_CRYPTO_CONFIG_NAME=full "$TF_PSA_CRYPTO_ROOT_DIR"
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
-    echo '#error "cmake -DTF_PSA_CRYPTO_CONFIG_NAME=full does not work"' > "$CRYPTO_CONFIG_H"
     cmake --build "$OUT_OF_SOURCE_DIR" --target tfpsacrypto
 
     # Restore the default config file in the source tree as we need a sane
@@ -232,7 +231,7 @@ component_tf_psa_crypto_build_config_options () {
     mv include include.moved
     mkdir consumer
     cat >consumer/CMakeLists.txt <<EOF
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.5.1)
 project(consumer C)
 find_package(TF-PSA-Crypto REQUIRED CONFIG)
 add_executable(consumer

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -164,6 +164,25 @@ component_tf_psa_crypto_build_config_name () {
     rm -f include/psa/crypto_config_full.h
 }
 
+component_tf_psa_crypto_build_config_options () {
+    msg "build: cmake with a base config, TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET"
+    cd "$OUT_OF_SOURCE_DIR"
+    cmake -DTF_PSA_CRYPTO_CONFIG_FILE=configs/crypto-config-symmetric-only.h \
+          -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
+          '-DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_XTS;PSA_WANT_ALG_SHA_256=2' \
+          "$TF_PSA_CRYPTO_ROOT_DIR"
+    cmake --build . --target tfpsacrypto
+
+    grep -E '^#define PSA_WANT_ALG_SHA_256[[:space:]]+2$' \
+         include/psa/crypto_config.h
+    grep -E '^#define PSA_WANT_ALG_XTS[[:space:]]+1$' \
+         include/psa/crypto_config.h
+    not grep -q '^#define PSA_WANT_ALG_RIPEMD160' include/psa/crypto_config.h
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+}
+
 component_tf_psa_crypto_install_with_destdir () {
     msg "install: cmake tf-psa-crypto with DESTDIR staging"
     TF_PSA_CRYPTO_ROOT_DIR="$PWD"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -165,22 +165,90 @@ component_tf_psa_crypto_build_config_name () {
 }
 
 component_tf_psa_crypto_build_config_options () {
-    msg "build: cmake with a base config, TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET"
+    msg "configure: cmake with TF_PSA_CRYPTO_CONFIG_BASE_FILE only"
     cd "$OUT_OF_SOURCE_DIR"
-    cmake -DTF_PSA_CRYPTO_CONFIG_FILE=configs/crypto-config-symmetric-only.h \
-          -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
-          '-DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_XTS;PSA_WANT_ALG_SHA_256=2' \
+    cmake -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=configs/crypto-config-symmetric-only.h \
           "$TF_PSA_CRYPTO_ROOT_DIR"
-    cmake --build . --target tfpsacrypto
-
-    grep -E '^#define PSA_WANT_ALG_SHA_256[[:space:]]+2$' \
-         include/psa/crypto_config.h
-    grep -E '^#define PSA_WANT_ALG_XTS[[:space:]]+1$' \
-         include/psa/crypto_config.h
-    not grep -q '^#define PSA_WANT_ALG_RIPEMD160' include/psa/crypto_config.h
+    cmp "$TF_PSA_CRYPTO_ROOT_DIR/configs/crypto-config-symmetric-only.h" \
+        include/psa/crypto_config.h
 
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject TF_PSA_CRYPTO_CONFIG_FILE with transformations"
+    not cmake -DTF_PSA_CRYPTO_CONFIG_FILE=configs/crypto-config-symmetric-only.h \
+              -DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_SHA_256 \
+              "$TF_PSA_CRYPTO_ROOT_DIR"
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject a missing base configuration"
+    not cmake -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=configs/does-not-exist.h \
+              "$TF_PSA_CRYPTO_ROOT_DIR"
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: cmake with a false-like option name"
+    cmake -DTF_PSA_CRYPTO_CONFIG_SET=NO "$TF_PSA_CRYPTO_ROOT_DIR"
+    grep '^#define NO$' include/psa/crypto_config.h
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+
+    msg "build: cmake with a base config, TF_PSA_CRYPTO_CONFIG_SET and TF_PSA_CRYPTO_CONFIG_UNSET"
+    cp "$TF_PSA_CRYPTO_ROOT_DIR/configs/crypto-config-symmetric-only.h" \
+       base_config.before
+    cmake -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=configs/crypto-config-symmetric-only.h \
+          -DTF_PSA_CRYPTO_CONFIG_UNSET=PSA_WANT_ALG_RIPEMD160 \
+          '-DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_KEY_TYPE_RAW_DATA;PSA_WANT_ALG_SHA_256=2' \
+          "$TF_PSA_CRYPTO_ROOT_DIR"
+
+    grep -E '^#define PSA_WANT_ALG_SHA_256[[:space:]]+2$' \
+         include/psa/crypto_config.h
+    grep -E '^#define PSA_WANT_KEY_TYPE_RAW_DATA[[:space:]]+1$' \
+         include/psa/crypto_config.h
+    not grep -q '^#define PSA_WANT_ALG_RIPEMD160' include/psa/crypto_config.h
+    cmp base_config.before \
+        "$TF_PSA_CRYPTO_ROOT_DIR/configs/crypto-config-symmetric-only.h"
+
+    msg "install: generated configuration works from the installed package"
+    install_dir="$OUT_OF_SOURCE_DIR/install"
+    cmake -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF \
+          -DCMAKE_INSTALL_PREFIX="$install_dir" .
+    cmake --build . --target install
+    cmp include/psa/crypto_config.h \
+        "$install_dir/include/psa/crypto_config.h"
+
+    mv include include.moved
+    mkdir consumer
+    cat >consumer/CMakeLists.txt <<EOF
+cmake_minimum_required(VERSION 3.10)
+project(consumer C)
+find_package(TF-PSA-Crypto REQUIRED CONFIG)
+add_executable(consumer
+    "$TF_PSA_CRYPTO_ROOT_DIR/programs/test/cmake_package_install/cmake_package_install.c")
+target_link_libraries(consumer PRIVATE TF-PSA-Crypto::tfpsacrypto)
+EOF
+    cmake -S consumer -B consumer-build \
+          -DCMAKE_PREFIX_PATH="$install_dir"
+    cmake --build consumer-build
+
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+
+    msg "configure: reject transformations in an in-tree build"
+    not cmake -DTF_PSA_CRYPTO_CONFIG_SET=NO .
+    rm -rf CMakeCache.txt CMakeFiles
 }
 
 component_tf_psa_crypto_install_with_destdir () {

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -173,13 +173,13 @@ component_tf_psa_crypto_build_config_options () {
 
     cd "$TF_PSA_CRYPTO_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
-    launch_dir="$OUT_OF_SOURCE_DIR.launch"
+    launch_dir="$TF_PSA_CRYPTO_ROOT_DIR/cmake-config-launch"
     mkdir "$launch_dir"
     cd "$launch_dir"
 
-    msg "configure: resolve a relative base config from the source tree"
+    msg "configure: resolve a base config relative to the launch directory"
     cmake -H"$TF_PSA_CRYPTO_ROOT_DIR" -B"$OUT_OF_SOURCE_DIR" \
-        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=configs/crypto-config-symmetric-only.h \
+        -DTF_PSA_CRYPTO_CONFIG_BASE_FILE=../configs/crypto-config-symmetric-only.h \
         -DTF_PSA_CRYPTO_CONFIG_SET=PSA_WANT_ALG_MD5
     grep '^#define PSA_WANT_ALG_MD5' \
         "$OUT_OF_SOURCE_DIR/include/psa/crypto_config.h"


### PR DESCRIPTION
Trivial backport of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/868


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** provided 
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/868
- [x] **TF-PSA-Crypto 1.1 PR** provided: here
- [x] **mbedtls development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10860
- [ ] **mbedtls 4.1 PR** provided: TODO
- [x] **mbedtls 3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10912
- **tests**  provided:
