### PR TITLE
Add Wycheproof tests

### DIFF
--- a/tests/scripts/gen_wycheproof.py
+++ b/tests/scripts/gen_wycheproof.py
@@ -1,0 +1,990 @@
+#!/usr/bin/env python3
+"""Convert Project Wycheproof JSON test vectors into Mbed TLS .data files.
+
+The Wycheproof vectors are not vendored in this repository. To generate the .data files,
+clone Project Wycheproof and check out the pinned revision:
+
+    git clone https://github.com/C2SP/wycheproof
+    git -C wycheproof checkout 6d7cccd0fcb1917368579adeeac10fe802f1b521
+
+Then point this script at the testvectors_v1 directory:
+
+    tf-psa-crypto/tests/scripts/gen_wycheproof.py path/to/wycheproof/testvectors_v1
+
+By default the .data files are written next to their corresponding test harnesses in
+tf-psa-crypto/tests/suites. Use --output-dir to change this behaviour.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+    load_der_public_key,
+)
+from cryptography.exceptions import UnsupportedAlgorithm
+
+WYCHEPROOF_COMMIT = "6d7cccd0fcb1917368579adeeac10fe802f1b521"
+
+# Parsed from command-line arguments.
+WYCHEPROOF_BASE_DIR = Path()
+DATA_BASE_DIR = Path()
+
+# Defaults to the suites/ directory next to the current scripts/
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent.parent / "suites"
+
+
+def format_inputs(*inputs) -> str:
+    return ":".join(f'"{i}"' for i in inputs)
+
+
+def write_output(out: str, filename: str) -> None:
+    file = DATA_BASE_DIR / filename
+    with file.open("w") as fp:
+        fp.write(out.rstrip("\n"))
+    print(f"[+] Wrote {filename}", file=sys.stderr)
+
+
+def header(filename: str, name: str) -> str:
+    return f"""# Tests for {name}, from Project Wycheproof.
+# See: https://github.com/C2SP/wycheproof/blob/{WYCHEPROOF_COMMIT}/testvectors_v1/{filename}"""
+
+
+def intro(filename: str, name: str):
+    file = WYCHEPROOF_BASE_DIR / filename
+    with file.open("r") as fp:
+        data = json.load(fp)
+    return header(filename, name), data
+
+
+def normalize_private_scalar(private_hex: str, bits: int) -> str:
+    """Normalize a Weierstrass private scalar.
+
+    PSA import requires exactly PSA_BITS_TO_BYTES(curve_size) bytes.
+    """
+    size = (bits + 7) // 8
+    raw = bytes.fromhex(private_hex).lstrip(b"\x00")
+    return raw.rjust(size, b"\x00").hex()
+
+
+def find_curve(filename: str, curves) -> str | None:
+    """Return the curve name from the JSON filename."""
+    for curve in curves:
+        if f"_{curve.lower()}_" in filename.lower():
+            return curve
+    return None
+
+
+def gen_aes_cbc():
+    """Generate .data files for AES-CBC with PKCS#7 padding.
+
+    Valid tests are tested with mbedtls_aes_cbc_enc_dec() which encrypt/decrypts
+    correctly.
+
+    Invalid tests are tested with mbedtls_aes_cbc_dec_invalid_padding() to ensure that
+    the invalid padding is caught.
+    """
+    out, data = intro("aes_cbc_pkcs5_test.json", "AES-CBC with PKCS#7 padding")
+    for group in data["testGroups"]:
+        key_size = group["keySize"]
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof AES-{key_size}-CBC #{test['tcId']}\n"
+            out += (
+                "mbedtls_aes_cbc_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_aes_cbc_dec_invalid_padding"
+            )
+            out += ":" + format_inputs(test["key"], test["iv"], test["msg"], test["ct"])
+    write_output(out, "test_suite_cbc_wycheproof.data")
+
+
+def gen_aes_ccm():
+    """Generate .data files for AES-CCM.
+
+    Tests are executed by different functions:
+
+        - Valid -> mbedtls_ccm_encrypt_and_tag(), to correctly encrypt/decrypt.
+        - ModifiedTag -> mbedtls_ccm_decrypt_modified_tag(), to catch invalid MACs.
+        - InvalidNonceSize -> mbedtls_ccm_encrypt_decrypt_invalid_nonce(), to ensure
+          that invalid nonces are rejected.
+        - InvalidTagSize/InsecureTagSize -> mbedtls_ccm_decrypt_invalid_insecure_tag(),
+          to explicitly catch errors with the MAC tag.
+    """
+    out, data = intro("aes_ccm_test.json", "AES-CCM")
+    for group in data["testGroups"]:
+        key_size = group["keySize"]
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof AES-{key_size}-CCM #{test['tcId']}\n"
+            flags = test.get("flags", [])
+            if test["result"] == "valid":
+                out += "mbedtls_ccm_encrypt_and_tag"
+            elif "ModifiedTag" in flags:
+                out += "mbedtls_ccm_decrypt_modified_tag"
+            elif "InvalidNonceSize" in flags:
+                out += "mbedtls_ccm_encrypt_decrypt_invalid_nonce"
+            elif "InvalidTagSize" in flags or "InsecureTagSize" in flags:
+                out += "mbedtls_ccm_decrypt_invalid_insecure_tag"
+            else:
+                raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+            out += ":" + format_inputs(
+                test["key"],
+                test["msg"],
+                test["iv"],
+                test["aad"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_ccm_wycheproof.data")
+
+
+def gen_aes_gcm():
+    """Generate .data files for AES-GCM.
+
+    Tests are executed by different functions:
+
+        - Valid -> mbedtls_gcm_enc_dec(), to correctly encrypt/decrypt.
+        - ZeroLengthIv -> mbedtls_gcm_enc_dec_zero_length_iv(), to ensure that a
+          zero-length IV is rejected.
+        - ModifiedTag -> mbedtls_gcm_dec_modified_tag(), to catch invalid MACs.
+    """
+    out, data = intro("aes_gcm_test.json", "AES-GCM")
+    for group in data["testGroups"]:
+        key_size = group["keySize"]
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof AES-{key_size}-GCM #{test['tcId']}\n"
+            flags = test.get("flags", [])
+            if test["result"] == "valid":
+                out += "mbedtls_gcm_enc_dec"
+            elif "ZeroLengthIv" in flags:
+                out += "mbedtls_gcm_enc_dec_zero_length_iv"
+            elif "ModifiedTag" in flags:
+                out += "mbedtls_gcm_dec_modified_tag"
+            else:
+                raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+            out += ":" + format_inputs(
+                test["key"],
+                test["iv"],
+                test["aad"],
+                test["msg"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_gcm_wycheproof.data")
+
+
+def gen_aria_cbc():
+    """Generate .data files for ARIA-CBC.
+
+    Valid tests are tested with mbedtls_aria_cbc_enc_dec() which encrypt/decrypts
+    correctly.
+
+    Invalid tests are tested with mbedtls_aria_cbc_dec_invalid_padding() to ensure that
+    the invalid padding is caught.
+    """
+    out, data = intro("aria_cbc_pkcs5_test.json", "ARIA-CBC with PKCS#7 padding")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof ARIA-CBC #{test['tcId']}\n"
+            out += (
+                "mbedtls_aria_cbc_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_aria_cbc_dec_invalid_padding"
+            )
+            out += ":" + format_inputs(test["key"], test["iv"], test["msg"], test["ct"])
+    write_output(out, "test_suite_aria_cbc_wycheproof.data")
+
+
+def gen_aria_ccm():
+    """Generate .data files for ARIA-CCM.
+
+    Valid tests are tested with mbedtls_aria_ccm_enc_dec() which correctly
+    encrypts/decrypts with a MAC tag.
+
+    Invalid tests are tested with mbedtls_aria_ccm_dec_invalid() to ensure that the
+    invalid MAC is detected.
+    """
+    out, data = intro("aria_ccm_test.json", "ARIA-CCM")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof ARIA-CCM #{test['tcId']}\n"
+            out += (
+                "mbedtls_aria_ccm_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_aria_ccm_dec_invalid"
+            )
+            out += ":" + format_inputs(
+                test["key"],
+                test["iv"],
+                test["aad"],
+                test["msg"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_aria_ccm_wycheproof.data")
+
+
+def gen_aria_gcm():
+    """Generate .data files for ARIA-GCM.
+
+    Valid tests are tested with aria_gcm_enc_dec() which correctly encrypts/decrypts
+    with a MAC tag.
+
+    Invalid tests are tested with mbedtls_aria_gcm_dec_invalid() to ensure that the
+    invalid MAC is detected.
+    """
+    out, data = intro("aria_gcm_test.json", "ARIA-GCM")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof ARIA-GCM #{test['tcId']}\n"
+            out += (
+                "mbedtls_aria_gcm_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_aria_gcm_dec_invalid"
+            )
+            out += ":" + format_inputs(
+                test["key"],
+                test["iv"],
+                test["aad"],
+                test["msg"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_aria_gcm_wycheproof.data")
+
+
+def gen_camellia_cbc():
+    """Generate .data files for Camellia-CBC.
+
+    Valid tests are tested with mbedtls_camellia_cbc_enc_dec() which encrypt/decrypts
+    correctly.
+
+    Invalid tests are tested with mbedtls_camellia_cbc_dec_invalid_padding() to ensure that
+    the invalid padding is caught.
+    """
+    out, data = intro(
+        "camellia_cbc_pkcs5_test.json", "Camellia-CBC with PKCS#7 padding"
+    )
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof Camellia-CBC #{test['tcId']}\n"
+            out += (
+                "mbedtls_camellia_cbc_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_camellia_cbc_dec_invalid_padding"
+            )
+            out += ":" + format_inputs(test["key"], test["iv"], test["msg"], test["ct"])
+    write_output(out, "test_suite_camellia_cbc_wycheproof.data")
+
+
+def gen_camellia_ccm():
+    """Generate .data files for Camellia-CCM.
+
+    Valid tests are tested with mbedtls_camellia_ccm_enc_dec() which correctly
+    encrypts/decrypts with a MAC tag.
+
+    Invalid tests are tested with mbedtls_camellia_ccm_dec_invalid() to ensure that the
+    invalid MAC is detected.
+    """
+    out, data = intro("camellia_ccm_test.json", "Camellia-CCM")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof Camellia-CCM #{test['tcId']}\n"
+            out += (
+                "mbedtls_camellia_ccm_enc_dec"
+                if test["result"] == "valid"
+                else "mbedtls_camellia_ccm_dec_invalid"
+            )
+            out += ":" + format_inputs(
+                test["key"],
+                test["iv"],
+                test["aad"],
+                test["msg"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_camellia_ccm_wycheproof.data")
+
+
+def gen_chachapoly():
+    """Generate .data files for ChaCha20-Poly1305.
+
+    Tests are executed by different functions:
+
+        - Valid -> mbedtls_chachapoly_enc_dec(), to correctly encrypt/decrypt.
+        - ModifiedTag -> mbedtls_chachapoly_dec_modified_tag(), to catch invalid MACs.
+        - InvalidNonceSize -> mbedtls_chachapoly_invalid_nonce(), to ensure that an
+          invalid nonce size is rejected.
+    """
+    out, data = intro("chacha20_poly1305_test.json", "ChaCha20-Poly1305")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof ChaCha20-Poly1305 #{test['tcId']}\n"
+            flags = test.get("flags", [])
+            if test["result"] == "valid":
+                out += "mbedtls_chachapoly_enc_dec"
+            elif "ModifiedTag" in flags:
+                out += "mbedtls_chachapoly_dec_modified_tag"
+            elif "InvalidNonceSize" in flags:
+                out += "mbedtls_chachapoly_invalid_nonce"
+            else:
+                raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+            out += ":" + format_inputs(
+                test["key"],
+                test["iv"],
+                test["aad"],
+                test["msg"],
+                test["ct"],
+                test["tag"],
+            )
+    write_output(out, "test_suite_chachapoly_wycheproof.data")
+
+
+def gen_cmac():
+    """Generate .data files for AES-CMAC.
+
+    Tests are executed by different functions:
+
+        - Valid -> mbedtls_cmac_generate_verify(), to generate and verify the MAC.
+        - InvalidKeySize -> mbedtls_cmac_genver_invalid_key_size(), to ensure that an
+          invalid key size is rejected.
+        - ModifiedTag -> mbedtls_cmac_verify_modified_tag(), to catch invalid MACs.
+    """
+    out, data = intro("aes_cmac_test.json", "AES-CMAC")
+    for group in data["testGroups"]:
+        for test in group["tests"]:
+            out += "\n\n"
+            out += f"Wycheproof AES-CMAC #{test['tcId']}\n"
+            flags = test.get("flags", [])
+            if test["result"] == "valid":
+                out += "mbedtls_cmac_generate_verify"
+            elif "InvalidKeySize" in flags:
+                out += "mbedtls_cmac_genver_invalid_key_size"
+            elif "ModifiedTag" in flags:
+                out += "mbedtls_cmac_verify_modified_tag"
+            else:
+                raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+            out += ":" + format_inputs(test["key"], test["msg"], test["tag"])
+    write_output(out, "test_suite_cmac_wycheproof.data")
+
+
+def gen_hkdf():
+    """Generate .data files for HKDF, one file per hash.
+
+    The first column is an unquoted PSA hash algorithm macro.
+
+        - Valid -> mbedtls_hkdf_derive(), to derive and compare the OKM.
+        - SizeTooLarge -> mbedtls_hkdf_size_too_large(), to ensure that an output
+          size larger than 255*hashlen is rejected. The expected size is passed as
+          an unquoted integer instead of the OKM.
+    """
+    hashes = [
+        ("sha1", "PSA_ALG_SHA_1"),
+        ("sha256", "PSA_ALG_SHA_256"),
+        ("sha384", "PSA_ALG_SHA_384"),
+        ("sha512", "PSA_ALG_SHA_512"),
+    ]
+    for suffix, macro in hashes:
+        name = f"HKDF-{suffix.replace('sha', 'SHA-')}"
+        out, data = intro(f"hkdf_{suffix}_test.json", name)
+        for group in data["testGroups"]:
+            for test in group["tests"]:
+                out += "\n\n"
+                out += f"Wycheproof {name} #{test['tcId']}\n"
+                flags = test.get("flags", [])
+                if test["result"] == "valid":
+                    out += "mbedtls_hkdf_derive"
+                    out += f":{macro}:" + format_inputs(
+                        test["ikm"], test["salt"], test["info"], test["okm"]
+                    )
+                elif "SizeTooLarge" in flags:
+                    out += "mbedtls_hkdf_size_too_large"
+                    out += f":{macro}:" + format_inputs(
+                        test["ikm"], test["salt"], test["info"]
+                    )
+                    out += f":{test['size']}"
+                else:
+                    raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+        write_output(out, f"test_suite_hkdf_wycheproof.{suffix}.data")
+
+
+def gen_hmac():
+    """Generate .data files for HMAC, one file per hash.
+
+    The first column is an unquoted PSA hash algorithm macro.
+
+        - Valid -> mbedtls_hmac_gen_ver(), to generate and verify the MAC.
+        - ModifiedTag -> mbedtls_hmac_ver_modified_tag(), to catch invalid MACs.
+    """
+    hashes = [
+        ("sha1", "PSA_ALG_SHA_1"),
+        ("sha256", "PSA_ALG_SHA_256"),
+        ("sha384", "PSA_ALG_SHA_384"),
+        ("sha512", "PSA_ALG_SHA_512"),
+        ("sha3_224", "PSA_ALG_SHA3_224"),
+        ("sha3_256", "PSA_ALG_SHA3_256"),
+        ("sha3_384", "PSA_ALG_SHA3_384"),
+        ("sha3_512", "PSA_ALG_SHA3_512"),
+    ]
+    for suffix, macro in hashes:
+        name = f"HMAC-{suffix.replace('sha', 'SHA-')}"
+        out, data = intro(f"hmac_{suffix}_test.json", name)
+        for group in data["testGroups"]:
+            for test in group["tests"]:
+                out += "\n\n"
+                out += f"Wycheproof {name} #{test['tcId']}\n"
+                flags = test.get("flags", [])
+                if test["result"] == "valid":
+                    out += "mbedtls_hmac_gen_ver"
+                elif "ModifiedTag" in flags:
+                    out += "mbedtls_hmac_ver_modified_tag"
+                else:
+                    raise ValueError(f"Unhandled test {test['tcId']}, {flags}")
+                out += f":{macro}:" + format_inputs(
+                    test["key"], test["msg"], test["tag"]
+                )
+        write_output(out, f"test_suite_hmac_wycheproof.{suffix}.data")
+
+
+def gen_pbkdf2():
+    """Generate .data files for PBKDF2-HMAC, one file per hash.
+
+    The first column is an unquoted PSA hash algorithm macro and the iteration
+    count is an unquoted integer. All Wycheproof PBKDF2 vectors are valid.
+    """
+    hashes = [
+        ("sha1", "PSA_ALG_SHA_1"),
+        ("sha224", "PSA_ALG_SHA_224"),
+        ("sha256", "PSA_ALG_SHA_256"),
+        ("sha384", "PSA_ALG_SHA_384"),
+        ("sha512", "PSA_ALG_SHA_512"),
+    ]
+    for suffix, macro in hashes:
+        name = f"PBKDF2-HMAC-{suffix.replace('sha', 'SHA-')}"
+        out, data = intro(f"pbkdf2_hmac{suffix}_test.json", name)
+        for group in data["testGroups"]:
+            for test in group["tests"]:
+                if test["result"] != "valid":
+                    raise ValueError(f"Unexpected invalid test {test['tcId']}")
+                out += "\n\n"
+                out += f"Wycheproof {name} #{test['tcId']}\n"
+                out += "mbedtls_pbkdf2_derive"
+                out += f":{macro}:" + format_inputs(test["password"], test["salt"])
+                out += f":{test['iterationCount']}:" + format_inputs(test["dk"])
+        write_output(out, f"test_suite_pbkdf2_wycheproof.{suffix}.data")
+
+
+def gen_ecdh():  # pylint: disable=too-many-locals
+    """Generate .data files for ECDH, one file per curve.
+
+    Line format: mbedtls_ecdh_compute:<family>:<bits>:priv:peer:shared:<result>
+
+        - Montgomery (x25519/x448): the peer is the raw u-coordinate, passed through.
+        - Weierstrass (secp/brainpool): the peer DER public key is decoded into a raw
+          uncompressed point (0x04||X||Y) with the `cryptography` library.
+
+    The result code is 2 for "valid" (must succeed and match), 1 for "acceptable"
+    (succeed and match OR fail) and 0 for "invalid".
+
+    Wycheproof includes Weierstrass peer keys with invalid DER enconding, which means we
+    cannot decode the raw uncompressed point. They are skipped here and tested with
+    gen_ecdh_der().
+    """
+    result_codes = {"valid": 2, "acceptable": 1, "invalid": 0}
+    # (suffix, json, PSA family macro, bits, montgomery?)
+    curves = [
+        ("x25519", "x25519_test.json", "PSA_ECC_FAMILY_MONTGOMERY", 255, True),
+        ("x448", "x448_test.json", "PSA_ECC_FAMILY_MONTGOMERY", 448, True),
+        ("secp256r1", "ecdh_secp256r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 256, False),
+        ("secp384r1", "ecdh_secp384r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 384, False),
+        ("secp521r1", "ecdh_secp521r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 521, False),
+        ("secp256k1", "ecdh_secp256k1_test.json", "PSA_ECC_FAMILY_SECP_K1", 256, False),
+        (
+            "brainpoolP256r1",
+            "ecdh_brainpoolP256r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            256,
+            False,
+        ),
+        (
+            "brainpoolP384r1",
+            "ecdh_brainpoolP384r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            384,
+            False,
+        ),
+        (
+            "brainpoolP512r1",
+            "ecdh_brainpoolP512r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            512,
+            False,
+        ),
+    ]
+
+    def peer_point(public_hex, montgomery):
+        if montgomery:
+            return public_hex  # raw u-coordinate already
+        key = load_der_public_key(bytes.fromhex(public_hex))
+        return key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint).hex()
+
+    total_skipped = 0
+    for suffix, filename, family, bits, montgomery in curves:
+        out, data = intro(filename, f"ECDH {suffix}")
+        skipped = 0
+        for group in data["testGroups"]:
+            for test in group["tests"]:
+                try:
+                    point = peer_point(test["public"], montgomery)
+                except (ValueError, UnsupportedAlgorithm):
+                    skipped += 1
+                    continue
+                private = (
+                    test["private"]
+                    if montgomery
+                    else normalize_private_scalar(test["private"], bits)
+                )
+                out += "\n\n"
+                out += f"Wycheproof ECDH-{suffix} #{test['tcId']}\n"
+                out += "mbedtls_ecdh_compute"
+                out += f":{family}:{bits}:" + format_inputs(
+                    private, point, test["shared"]
+                )
+                out += f":{result_codes[test['result']]}"
+        write_output(out, f"test_suite_ecdh_wycheproof.{suffix}.data")
+        total_skipped += skipped
+        print(
+            f"    ECDH-{suffix}: skipped {skipped} undecodable peer keys",
+            file=sys.stderr,
+        )
+    print(f"    ECDH total skipped: {total_skipped}", file=sys.stderr)
+
+
+def gen_ecdh_der():
+    """Generate .data files for ECDH with raw DER peer keys, one per Weierstrass curve.
+
+    Complements gen_ecdh(): the raw invalid DER keys are kept to test them with MbedTLS
+    DER parser.
+
+    Line format: mbedtls_ecdh_compute_der:<family>:<bits>:priv:peerDer:shared:result
+
+    Possible results are 2 for valid tests (succeeds and matches), 1 for acceptable
+    tests (succeeds and matches OR rejects), and 0 for invalid tests (must reject).
+    """
+    result_codes = {"valid": 2, "acceptable": 1, "invalid": 0}
+    # (suffix, json, PSA family macro, bits)
+    curves = [
+        ("secp256r1", "ecdh_secp256r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 256),
+        ("secp384r1", "ecdh_secp384r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 384),
+        ("secp521r1", "ecdh_secp521r1_test.json", "PSA_ECC_FAMILY_SECP_R1", 521),
+        ("secp256k1", "ecdh_secp256k1_test.json", "PSA_ECC_FAMILY_SECP_K1", 256),
+        (
+            "brainpoolP256r1",
+            "ecdh_brainpoolP256r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            256,
+        ),
+        (
+            "brainpoolP384r1",
+            "ecdh_brainpoolP384r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            384,
+        ),
+        (
+            "brainpoolP512r1",
+            "ecdh_brainpoolP512r1_test.json",
+            "PSA_ECC_FAMILY_BRAINPOOL_P_R1",
+            512,
+        ),
+    ]
+    for suffix, filename, family, bits in curves:
+        out, data = intro(filename, f"ECDH {suffix} with DER peer keys")
+        for group in data["testGroups"]:
+            for test in group["tests"]:
+                out += "\n\n"
+                out += f"Wycheproof ECDH-{suffix}-DER #{test['tcId']}\n"
+                out += "mbedtls_ecdh_compute_der"
+                out += f":{family}:{bits}:" + format_inputs(
+                    normalize_private_scalar(test["private"], bits),
+                    test["public"],
+                    test["shared"],
+                )
+                out += f":{result_codes[test['result']]}"
+        write_output(out, f"test_suite_ecdh_wycheproof.{suffix}_der.data")
+
+
+def gen_ecdsa():
+    """Generate .data files for ECDSA with DER signatures, one file per curve+hash.
+
+    Scope: MbedTLS curves (secp{256,384,521}r1, secp256k1, brainpoolP{256,384,512}r1)
+    with SHA-2 and SHA-3. We exclude files with SHAKE and Bitcoin test files.
+
+    Line format: mbedtls_ecdsa_verify_der:<MD>:pubkeyDer:msg:sig:<expected_valid>
+
+    Enforces strict results: valid tests are expected to be successful, all other,
+    including acceptable tests, are expected to be rejected.
+    """
+    supported = [
+        "secp256r1",
+        "secp384r1",
+        "secp521r1",
+        "secp256k1",
+        "brainpoolP256r1",
+        "brainpoolP384r1",
+        "brainpoolP512r1",
+    ]
+    md = {
+        "SHA-256": "MBEDTLS_MD_SHA256",
+        "SHA-384": "MBEDTLS_MD_SHA384",
+        "SHA-512": "MBEDTLS_MD_SHA512",
+        "SHA3-256": "MBEDTLS_MD_SHA3_256",
+        "SHA3-384": "MBEDTLS_MD_SHA3_384",
+        "SHA3-512": "MBEDTLS_MD_SHA3_512",
+    }
+    skip_keywords = ["p1363", "webcrypto", "ecpoint", "_pem", "bitcoin", "shake"]
+    files = 0
+    for path in sorted(WYCHEPROOF_BASE_DIR.glob("ecdsa_*_test.json")):
+        filename = path.name
+        if any(kw in filename for kw in skip_keywords):
+            continue
+        if find_curve(filename, supported) is None:
+            continue
+        with path.open("r") as fp:
+            data = json.load(fp)
+        sha = data["testGroups"][0].get("sha")
+        if sha not in md:
+            continue
+        tag = filename.replace("ecdsa_", "").replace("_test.json", "")
+        out = header(filename, f"ECDSA {tag}")
+        for group in data["testGroups"]:
+            pubkey = group["publicKeyDer"]
+            for test in group["tests"]:
+                expected_valid = 1 if test["result"] == "valid" else 0
+                out += "\n\n"
+                out += f"Wycheproof ECDSA-{tag} #{test['tcId']}\n"
+                out += "mbedtls_ecdsa_verify_der"
+                out += f":{md[sha]}:" + format_inputs(pubkey, test["msg"], test["sig"])
+                out += f":{expected_valid}"
+        write_output(out, f"test_suite_ecdsa_wycheproof.{tag}.data")
+        files += 1
+    print(f"    ECDSA: {files} .data files", file=sys.stderr)
+
+
+def gen_ecdsa_p1363():  # pylint: disable=too-many-locals
+    """Generate .data files for ECDSA with P1363 (raw r||s) signatures.
+
+    Uses the uncompressed public key (0x04 || X || Y).
+
+    Line format:
+
+    mbedtls_ecdsa_verify_p1363:<PSA_HASH>:<family>:<bits>:point:msg:sig:<expected_valid>
+
+    Results: same as DER ECDSA, valid tests should all succeed, invalid and acceptable
+    tests should be rejected.
+    """
+    # curve -> (PSA family macro, bits)
+    curves = {
+        "secp256r1": ("PSA_ECC_FAMILY_SECP_R1", 256),
+        "secp384r1": ("PSA_ECC_FAMILY_SECP_R1", 384),
+        "secp521r1": ("PSA_ECC_FAMILY_SECP_R1", 521),
+        "secp256k1": ("PSA_ECC_FAMILY_SECP_K1", 256),
+        "brainpoolP256r1": ("PSA_ECC_FAMILY_BRAINPOOL_P_R1", 256),
+        "brainpoolP384r1": ("PSA_ECC_FAMILY_BRAINPOOL_P_R1", 384),
+        "brainpoolP512r1": ("PSA_ECC_FAMILY_BRAINPOOL_P_R1", 512),
+    }
+    hashes = {
+        "SHA-256": "PSA_ALG_SHA_256",
+        "SHA-384": "PSA_ALG_SHA_384",
+        "SHA-512": "PSA_ALG_SHA_512",
+    }
+    files = 0
+    for path in sorted(WYCHEPROOF_BASE_DIR.glob("ecdsa_*_p1363_test.json")):
+        filename = path.name
+        if "shake" in filename:
+            continue
+        curve = find_curve(filename, curves)
+        if curve is None:
+            continue
+        with path.open("r") as fp:
+            data = json.load(fp)
+        sha = data["testGroups"][0].get("sha")
+        if sha not in hashes:
+            continue
+        family, bits = curves[curve]
+        tag = filename.replace("ecdsa_", "").replace("_test.json", "")
+        out = header(filename, f"ECDSA {tag} (raw r||s)")
+        for group in data["testGroups"]:
+            point = group["publicKey"]["uncompressed"]
+            for test in group["tests"]:
+                expected_valid = 1 if test["result"] == "valid" else 0
+                out += "\n\n"
+                out += f"Wycheproof ECDSA-{tag} #{test['tcId']}\n"
+                out += "mbedtls_ecdsa_verify_p1363"
+                out += f":{hashes[sha]}:{family}:{bits}:" + format_inputs(
+                    point, test["msg"], test["sig"]
+                )
+                out += f":{expected_valid}"
+        write_output(out, f"test_suite_ecdsa_p1363_wycheproof.{tag}.data")
+        files += 1
+    print(f"    ECDSA-p1363: {files} .data files", file=sys.stderr)
+
+
+def gen_nist_kw():
+    """Generate .data files for AES Key Wrap, one file per (mode, key size).
+
+        - aes_wrap_test.json -> MBEDTLS_KW_MODE_KW  (RFC 3394)
+        - aes_kwp_test.json  -> MBEDTLS_KW_MODE_KWP (RFC 5649)
+
+    The mode is an unquoted MBEDTLS_KW_MODE_* macro.
+
+        - Valid -> wycheproof_nist_kw_valid(), wrap must match ct AND unwrap must
+          recover msg.
+        - Invalid -> wycheproof_nist_kw_unwrap_invalid(), unwrap must NOT recover msg.
+        - Acceptable -> wycheproof_nist_kw_acceptable(), must succeed and match OR fail.
+    """
+    sources = [
+        ("aes_wrap_test.json", "MBEDTLS_KW_MODE_KW", "AES-KW", "kw"),
+        ("aes_kwp_test.json", "MBEDTLS_KW_MODE_KWP", "AES-KWP", "kwp"),
+    ]
+    for filename, mode, label, sub in sources:
+        out, data = intro(filename, label)
+        buckets = {}  # key size -> list of (test, function)
+        for group in data["testGroups"]:
+            key_size = group["keySize"]
+            for test in group["tests"]:
+                result = test["result"]
+                if result == "valid":
+                    function = "wycheproof_nist_kw_valid"
+                elif result == "invalid":
+                    function = "wycheproof_nist_kw_unwrap_invalid"
+                elif result == "acceptable":
+                    function = "wycheproof_nist_kw_acceptable"
+                else:
+                    raise ValueError(f"Unhandled result {result} at {test['tcId']}")
+                buckets.setdefault(key_size, []).append((test, function))
+
+        for key_size, cases in sorted(buckets.items()):
+            out = header(filename, f"{label}-{key_size}")
+            for test, function in cases:
+                out += "\n\n"
+                out += f"Wycheproof {label}-{key_size} #{test['tcId']}\n"
+                if key_size != 128:
+                    out += "depends_on:!MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH\n"
+                out += function
+                out += f":{mode}:" + format_inputs(test["key"], test["msg"], test["ct"])
+            write_output(out, f"test_suite_nist_kw_wycheproof.{sub}_{key_size}.data")
+
+
+def gen_rsa_decrypt():
+    """Generate .data files for RSA decryption.
+
+    OAEP (rsa_oaep_*, only where mgfSha == sha):
+        mbedtls_rsa_oaep_decrypt:<MD>:pkcs8:ct:label:msg:<expected_valid>
+    PKCS#1 v1.5 (rsa_pkcs1_*):
+        mbedtls_rsa_pkcs1v15_decrypt:pkcs8:ct:msg:<expected_valid>
+
+    Scope: key sizes 2048, 3072, 4096, with SHA-2 for OAEP.
+
+    Results: valid tests must succeed, all others must fail.
+    """
+    md = {
+        "SHA-1": "PSA_ALG_SHA_1",
+        "SHA-224": "PSA_ALG_SHA_224",
+        "SHA-256": "PSA_ALG_SHA_256",
+        "SHA-384": "PSA_ALG_SHA_384",
+        "SHA-512": "PSA_ALG_SHA_512",
+    }
+    oaep_files = 0
+    for path in sorted(WYCHEPROOF_BASE_DIR.glob("rsa_oaep_*_test.json")):
+        filename = path.name
+        with path.open("r") as fp:
+            data = json.load(fp)
+        group0 = data["testGroups"][0]
+        sha = group0.get("sha")
+        # Separate into several conditions to appease pylint.
+        if sha not in md:
+            continue
+        if group0.get("mgfSha") != sha:  # Only keep tests with hash == mgfHash
+            continue
+        if any(kw in filename for kw in {"_8192_", "misc", "three_primes"}):
+            continue
+        tag = filename.replace("_test.json", "")
+        out = header(filename, tag)
+        for group in data["testGroups"]:
+            pkcs8 = group["privateKeyPkcs8"]
+            for test in group["tests"]:
+                expected_valid = 1 if test["result"] == "valid" else 0
+                out += "\n\n"
+                out += f"Wycheproof {tag} #{test['tcId']}\n"
+                out += "mbedtls_rsa_oaep_decrypt"
+                out += f":{md[sha]}:" + format_inputs(
+                    pkcs8, test["ct"], test["label"], test["msg"]
+                )
+                out += f":{expected_valid}"
+        write_output(out, f"test_suite_rsa_oaep_wycheproof.{tag}.data")
+        oaep_files += 1
+
+    pkcs1_files = 0
+    for path in sorted(WYCHEPROOF_BASE_DIR.glob("rsa_pkcs1_*_test.json")):
+        filename = path.name
+        if any(kw in filename for kw in {"sig_gen", "_8192_", "1024", "1536"}):
+            continue
+        with path.open("r") as fp:
+            data = json.load(fp)
+        tag = filename.replace("_test.json", "")
+        out = header(filename, tag)
+        for group in data["testGroups"]:
+            pkcs8 = group["privateKeyPkcs8"]
+            for test in group["tests"]:
+                expected_valid = 1 if test["result"] == "valid" else 0
+                out += "\n\n"
+                out += f"Wycheproof {tag} #{test['tcId']}\n"
+                out += "mbedtls_rsa_pkcs1v15_decrypt"
+                out += ":" + format_inputs(pkcs8, test["ct"], test["msg"])
+                out += f":{expected_valid}"
+        write_output(out, f"test_suite_rsa_pkcs1v15dec_wycheproof.{tag}.data")
+        pkcs1_files += 1
+    print(
+        f"    RSA-decrypt: {oaep_files} OAEP + {pkcs1_files} PKCS1v15 .data files",
+        file=sys.stderr,
+    )
+
+
+def gen_rsa_verify():
+    """Generate .data files for RSA signature verification, one file per source.
+
+    PKCS#1 v1.5 (rsa_signature_*) and PSS (rsa_pss_*, only where mgfSha == sha, since
+    mbedtls_pk_verify_ext uses MGF1 with the signature hash and any salt length).
+
+    Scope: key sizes 2048, 3072, and 4096, with SHA-2 hashes and SHA-3 for PKCS#1 v1.5.
+
+        PKCS1v15: mbedtls_rsa_pkcs1v15_verify:<MD>:pubDer:msg:sig:<result>
+        PSS     : mbedtls_rsa_pss_verify     :<MD>:pubDer:msg:sig:<result>
+
+    Results: valid tests must succeed, all other tests must fail.
+    """
+    md = {
+        "SHA-224": "MBEDTLS_MD_SHA224",
+        "SHA-256": "MBEDTLS_MD_SHA256",
+        "SHA-384": "MBEDTLS_MD_SHA384",
+        "SHA-512": "MBEDTLS_MD_SHA512",
+        "SHA3-224": "MBEDTLS_MD_SHA3_224",
+        "SHA3-256": "MBEDTLS_MD_SHA3_256",
+        "SHA3-384": "MBEDTLS_MD_SHA3_384",
+        "SHA3-512": "MBEDTLS_MD_SHA3_512",
+    }
+
+    def gen_rsa(pattern, function, tag_prefix, pss=False):  # pylint: disable=too-many-locals
+        files = 0
+        for path in sorted(WYCHEPROOF_BASE_DIR.glob(pattern)):
+            filename = path.name
+            with path.open("r") as fp:
+                data = json.load(fp)
+            group0 = data["testGroups"][0]
+            sha = group0.get("sha")
+            if sha not in md:
+                continue
+            if "_8192_" in filename:  # skip slow 8192
+                continue
+            if pss and group0.get("mgfSha") != sha:  # keep only mgf hash == sig hash
+                continue
+            if pss and "_params" in filename:
+                continue
+            tag = filename.replace("_test.json", "")
+            out = header(filename, tag)
+            for group in data["testGroups"]:
+                pubkey = group["publicKeyDer"]
+                for test in group["tests"]:
+                    expected_valid = 1 if test["result"] == "valid" else 0
+                    out += "\n\n"
+                    out += f"Wycheproof {tag} #{test['tcId']}\n"
+                    out += function
+                    out += f":{md[sha]}:" + format_inputs(
+                        pubkey, test["msg"], test["sig"]
+                    )
+                    out += f":{expected_valid}"
+            write_output(out, f"test_suite_{tag_prefix}_wycheproof.{tag}.data")
+            files += 1
+        return files
+
+    pkcs1v15_files = gen_rsa(
+        "rsa_signature_*_test.json", "mbedtls_rsa_pkcs1v15_verify", "rsa_pkcs1v15"
+    )
+    pss_files = gen_rsa(
+        "rsa_pss_*_test.json", "mbedtls_rsa_pss_verify", "rsa_pss", pss=True
+    )
+    print(
+        f"    RSA-verify: {pkcs1v15_files} PKCS1v15 + {pss_files} PSS .data files",
+        file=sys.stderr,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "wycheproof_dir",
+        type=Path,
+        help="path to a Project Wycheproof testvectors_v1 directory"
+        f" (pinned revision: {WYCHEPROOF_COMMIT})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"directory to write the .data files to (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    args = parser.parse_args()
+
+    if not args.wycheproof_dir.is_dir():
+        parser.error(f"no such directory: {args.wycheproof_dir}")
+
+    global WYCHEPROOF_BASE_DIR, DATA_BASE_DIR  # pylint: disable=global-statement
+    WYCHEPROOF_BASE_DIR = args.wycheproof_dir
+    DATA_BASE_DIR = args.output_dir
+
+    gen_aes_cbc()
+    gen_aes_ccm()
+    gen_aes_gcm()
+
+    gen_aria_cbc()
+    gen_aria_ccm()
+    gen_aria_gcm()
+
+    gen_camellia_cbc()
+    gen_camellia_ccm()
+
+    gen_chachapoly()
+
+    gen_cmac()
+    gen_hmac()
+
+    gen_hkdf()
+    gen_pbkdf2()
+
+    gen_nist_kw()
+
+    gen_ecdh()
+    gen_ecdh_der()
+    gen_ecdsa()
+    gen_ecdsa_p1363()
+
+    gen_rsa_decrypt()
+    gen_rsa_verify()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/suites/test_suite_aria_cbc_wycheproof.function
+++ b/tests/suites/test_suite_aria_cbc_wycheproof.function
@@ -1,0 +1,100 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/cipher.h"
+
+/* Project Wycheproof ARIA-CBC/PKCS#7 harness.
+ * Columns: key:iv:msg:ct.
+ *   valid   -> mbedtls_aria_cbc_enc_dec
+ *   invalid -> mbedtls_aria_cbc_dec_invalid_padding  (NoPadding / BadPadding)
+ */
+
+static mbedtls_cipher_type_t wp_aria_cbc_type(size_t key_len)
+{
+    switch (key_len) {
+    case 16:
+        return MBEDTLS_CIPHER_ARIA_128_CBC;
+    case 24:
+        return MBEDTLS_CIPHER_ARIA_192_CBC;
+    case 32:
+        return MBEDTLS_CIPHER_ARIA_256_CBC;
+    default:
+        return MBEDTLS_CIPHER_NONE;
+    }
+}
+
+static int wp_cbc_crypt(mbedtls_operation_t op, data_t* key, data_t* iv,
+    const unsigned char* in, size_t in_len,
+    unsigned char* out, size_t out_size, size_t* out_len)
+{
+    mbedtls_cipher_context_t ctx;
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(wp_aria_cbc_type(key->len));
+    int ret = MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
+
+    mbedtls_cipher_init(&ctx);
+    if (info == NULL) {
+        goto cleanup;
+    }
+    if (mbedtls_cipher_setup(&ctx, info) != 0 || mbedtls_cipher_setkey(&ctx, key->x, (int)(key->len * 8), op) != 0 || mbedtls_cipher_set_padding_mode(&ctx, MBEDTLS_PADDING_PKCS7) != 0) {
+        goto cleanup;
+    }
+    (void)out_size;
+    ret = mbedtls_cipher_crypt(&ctx, iv->x, iv->len, in, in_len, out, out_len);
+
+cleanup:
+    mbedtls_cipher_free(&ctx);
+    return ret;
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CIPHER_C:MBEDTLS_ARIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_aria_cbc_enc_dec(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_aria_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+
+    TEST_CALLOC(output, msg->len + 16);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_ENCRYPT, key, iv, msg->x, msg->len, output, msg->len + 16, &olen));
+    TEST_MEMORY_COMPARE(output, olen, ct->x, ct->len);
+    mbedtls_free(output);
+    output = NULL;
+
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len, output, ct->len, &olen));
+    TEST_MEMORY_COMPARE(output, olen, msg->x, msg->len);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector: PKCS#7 unpadding of the decrypted block must be rejected.
+ */
+/* BEGIN_CASE */
+void mbedtls_aria_cbc_dec_invalid_padding(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    (void)msg;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_aria_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_ASSERT(wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len,
+                    output, ct->len, &olen)
+        != 0);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_aria_ccm_wycheproof.function
+++ b/tests/suites/test_suite_aria_ccm_wycheproof.function
@@ -1,0 +1,75 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/ccm.h"
+#include <string.h>
+
+/* Project Wycheproof ARIA-CCM harness.
+ * Columns: key:iv:aad:msg:ct:tag.
+ *   valid   -> mbedtls_aria_ccm_enc_dec
+ *   invalid -> mbedtls_aria_ccm_dec_invalid  (ModifiedTag / InvalidNonceSize /
+ *              Invalid/InsecureTagSize / CVE-2017-18330)
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CCM_C:MBEDTLS_CCM_GCM_CAN_ARIA
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag), decryption recovers msg. */
+/* BEGIN_CASE */
+void mbedtls_aria_ccm_enc_dec(data_t* key, data_t* iv, data_t* aad,
+    data_t* msg, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+
+    mbedtls_ccm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    TEST_LE_U(tag->len, sizeof(tag_output));
+    TEST_EQUAL(msg->len, ct->len);
+    TEST_CALLOC(output, msg->len == 0 ? 1 : msg->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_ARIA, key->x, key->len * 8));
+
+    TEST_EQUAL(0, mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len, aad->x, aad->len, msg->x, output, tag_output, tag->len));
+    TEST_MEMORY_COMPARE(output, msg->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, tag->len, tag->x, tag->len);
+
+    memset(output, 0, msg->len == 0 ? 1 : msg->len);
+    TEST_EQUAL(0, mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len, aad->x, aad->len, ct->x, output, tag->x, tag->len));
+    TEST_MEMORY_COMPARE(output, ct->len, msg->x, msg->len);
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid vector: authenticated decryption must not recover the plaintext. */
+/* BEGIN_CASE */
+void mbedtls_aria_ccm_dec_invalid(data_t* key, data_t* iv, data_t* aad,
+    data_t* msg, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    int ret;
+
+    mbedtls_ccm_init(&ctx);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_ARIA, key->x, key->len * 8));
+
+    ret = mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+        aad->x, aad->len, ct->x, output,
+        tag->x, tag->len);
+    if (ret == 0) {
+        TEST_ASSERT(ct->len != msg->len || (msg->len != 0 && memcmp(output, msg->x, msg->len) != 0));
+    }
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_aria_gcm_wycheproof.function
+++ b/tests/suites/test_suite_aria_gcm_wycheproof.function
@@ -1,0 +1,83 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/gcm.h"
+#include <string.h>
+
+/* Project Wycheproof ARIA-GCM test harness.
+ * Columns: key:iv:aad:pt:ct:tag
+ *   - valid   -> mbedtls_aria_gcm_enc_dec
+ *   - invalid -> mbedtls_aria_gcm_dec_invalid   (ModifiedTag / ZeroLengthIv)
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_GCM_C:MBEDTLS_CCM_GCM_CAN_ARIA
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag), and authenticated
+ * decryption must recover the plaintext after correctly validating the MAC tag. */
+/* BEGIN_CASE */
+void mbedtls_aria_gcm_enc_dec(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_gcm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+    size_t tag_len = tag->len;
+
+    BLOCK_CIPHER_PSA_INIT();
+    mbedtls_gcm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    TEST_LE_U(tag_len, sizeof(tag_output));
+    TEST_EQUAL(pt->len, ct->len);
+    TEST_CALLOC(output, pt->len == 0 ? 1 : pt->len);
+
+    TEST_EQUAL(0, mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_ARIA, key->x, key->len * 8));
+
+    /* Encrypt: output ciphertext and tag must match the test vector. */
+    TEST_EQUAL(0, mbedtls_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, pt->len, iv->x, iv->len, aad->x, aad->len, pt->x, output, tag_len, tag_output));
+    TEST_MEMORY_COMPARE(output, pt->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, tag_len, tag->x, tag->len);
+
+    /* Decrypt: must authenticate and recover the plaintext. */
+    memset(output, 0, pt->len == 0 ? 1 : pt->len);
+    TEST_EQUAL(0, mbedtls_gcm_auth_decrypt(&ctx, ct->len, iv->x, iv->len, aad->x, aad->len, tag->x, tag_len, ct->x, output));
+    TEST_MEMORY_COMPARE(output, ct->len, pt->x, pt->len);
+
+exit:
+    mbedtls_gcm_free(&ctx);
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector (ModifiedTag or ZeroLengthIv): authenticated decryption must NOT recover the plaintext. */
+/* BEGIN_CASE */
+void mbedtls_aria_gcm_dec_invalid(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_gcm_context ctx;
+    unsigned char* output = NULL;
+    size_t tag_len = tag->len;
+    int ret;
+
+    BLOCK_CIPHER_PSA_INIT();
+    mbedtls_gcm_init(&ctx);
+
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+    TEST_EQUAL(0, mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_ARIA, key->x, key->len * 8));
+
+    ret = mbedtls_gcm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+        aad->x, aad->len, tag->x, tag_len,
+        ct->x, output);
+    if (ret == 0) {
+        TEST_ASSERT(ct->len != pt->len || (pt->len != 0 && memcmp(output, pt->x, pt->len) != 0));
+    }
+
+exit:
+    mbedtls_gcm_free(&ctx);
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_camellia_cbc_wycheproof.function
+++ b/tests/suites/test_suite_camellia_cbc_wycheproof.function
@@ -1,0 +1,100 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/cipher.h"
+
+/* Project Wycheproof Camellia-CBC/PKCS#7 harness.
+ * Columns: key:iv:msg:ct.
+ *   valid   -> mbedtls_camellia_cbc_enc_dec
+ *   invalid -> mbedtls_camellia_cbc_dec_invalid_padding  (NoPadding / BadPadding)
+ */
+
+static mbedtls_cipher_type_t wp_camellia_cbc_type(size_t key_len)
+{
+    switch (key_len) {
+    case 16:
+        return MBEDTLS_CIPHER_CAMELLIA_128_CBC;
+    case 24:
+        return MBEDTLS_CIPHER_CAMELLIA_192_CBC;
+    case 32:
+        return MBEDTLS_CIPHER_CAMELLIA_256_CBC;
+    default:
+        return MBEDTLS_CIPHER_NONE;
+    }
+}
+
+static int wp_cbc_crypt(mbedtls_operation_t op, data_t* key, data_t* iv,
+    const unsigned char* in, size_t in_len,
+    unsigned char* out, size_t out_size, size_t* out_len)
+{
+    mbedtls_cipher_context_t ctx;
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(wp_camellia_cbc_type(key->len));
+    int ret = MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
+
+    mbedtls_cipher_init(&ctx);
+    if (info == NULL) {
+        goto cleanup;
+    }
+    if (mbedtls_cipher_setup(&ctx, info) != 0 || mbedtls_cipher_setkey(&ctx, key->x, (int)(key->len * 8), op) != 0 || mbedtls_cipher_set_padding_mode(&ctx, MBEDTLS_PADDING_PKCS7) != 0) {
+        goto cleanup;
+    }
+    (void)out_size;
+    ret = mbedtls_cipher_crypt(&ctx, iv->x, iv->len, in, in_len, out, out_len);
+
+cleanup:
+    mbedtls_cipher_free(&ctx);
+    return ret;
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CIPHER_C:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns ct and decryption return msg. */
+/* BEGIN_CASE */
+void mbedtls_camellia_cbc_enc_dec(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_camellia_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+
+    TEST_CALLOC(output, msg->len + 16);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_ENCRYPT, key, iv, msg->x, msg->len, output, msg->len + 16, &olen));
+    TEST_MEMORY_COMPARE(output, olen, ct->x, ct->len);
+    mbedtls_free(output);
+    output = NULL;
+
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len, output, ct->len, &olen));
+    TEST_MEMORY_COMPARE(output, olen, msg->x, msg->len);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector: PKCS#7 unpadding of the decrypted block must be rejected */
+/* BEGIN_CASE */
+void mbedtls_camellia_cbc_dec_invalid_padding(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    (void)msg;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_camellia_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_ASSERT(wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len,
+                    output, ct->len, &olen)
+        != 0);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_camellia_ccm_wycheproof.function
+++ b/tests/suites/test_suite_camellia_ccm_wycheproof.function
@@ -1,0 +1,74 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/ccm.h"
+#include <string.h>
+
+/* Project Wycheproof Camellia-CCM harness.
+ * Columns: key:iv:aad:msg:ct:tag.
+ *   valid   -> mbedtls_camellia_ccm_enc_dec
+ *   invalid -> mbedtls_camellia_ccm_dec_invalid  (all invalid flags; rejected by mbedTLS)
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CCM_C:MBEDTLS_CCM_GCM_CAN_CAMELLIA
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag) while decryption recovers msg after verifying the MAC tag. */
+/* BEGIN_CASE */
+void mbedtls_camellia_ccm_enc_dec(data_t* key, data_t* iv, data_t* aad,
+    data_t* msg, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+
+    mbedtls_ccm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    TEST_LE_U(tag->len, sizeof(tag_output));
+    TEST_EQUAL(msg->len, ct->len);
+    TEST_CALLOC(output, msg->len == 0 ? 1 : msg->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_CAMELLIA, key->x, key->len * 8));
+
+    TEST_EQUAL(0, mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len, aad->x, aad->len, msg->x, output, tag_output, tag->len));
+    TEST_MEMORY_COMPARE(output, msg->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, tag->len, tag->x, tag->len);
+
+    memset(output, 0, msg->len == 0 ? 1 : msg->len);
+    TEST_EQUAL(0, mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len, aad->x, aad->len, ct->x, output, tag->x, tag->len));
+    TEST_MEMORY_COMPARE(output, ct->len, msg->x, msg->len);
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid vector: authenticated decryption must not recover the plaintext. */
+/* BEGIN_CASE */
+void mbedtls_camellia_ccm_dec_invalid(data_t* key, data_t* iv, data_t* aad,
+    data_t* msg, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    int ret;
+
+    mbedtls_ccm_init(&ctx);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_CAMELLIA, key->x, key->len * 8));
+
+    ret = mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+        aad->x, aad->len, ct->x, output,
+        tag->x, tag->len);
+    if (ret == 0) {
+        TEST_ASSERT(ct->len != msg->len || (msg->len != 0 && memcmp(output, msg->x, msg->len) != 0));
+    }
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_cbc_wycheproof.function
+++ b/tests/suites/test_suite_cbc_wycheproof.function
@@ -1,0 +1,102 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/cipher.h"
+
+/* Project Wycheproof AES-CBC/PKCS#7 harness.
+ * Columns: key:iv:msg:ct.
+ *   valid   -> mbedtls_aes_cbc_enc_dec            (encrypt->ct, decrypt->msg)
+ *   invalid -> mbedtls_aes_cbc_dec_invalid_padding (decrypt must reject padding)
+ */
+
+static mbedtls_cipher_type_t wp_aes_cbc_type(size_t key_len)
+{
+    switch (key_len) {
+    case 16:
+        return MBEDTLS_CIPHER_AES_128_CBC;
+    case 24:
+        return MBEDTLS_CIPHER_AES_192_CBC;
+    case 32:
+        return MBEDTLS_CIPHER_AES_256_CBC;
+    default:
+        return MBEDTLS_CIPHER_NONE;
+    }
+}
+
+static int wp_cbc_crypt(mbedtls_operation_t op, data_t* key, data_t* iv,
+    const unsigned char* in, size_t in_len,
+    unsigned char* out, size_t out_size, size_t* out_len)
+{
+    mbedtls_cipher_context_t ctx;
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(wp_aes_cbc_type(key->len));
+    int ret = MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
+
+    mbedtls_cipher_init(&ctx);
+    if (info == NULL) {
+        goto cleanup;
+    }
+    if (mbedtls_cipher_setup(&ctx, info) != 0 || mbedtls_cipher_setkey(&ctx, key->x, (int)(key->len * 8), op) != 0 || mbedtls_cipher_set_padding_mode(&ctx, MBEDTLS_PADDING_PKCS7) != 0) {
+        goto cleanup;
+    }
+    (void)out_size;
+    ret = mbedtls_cipher_crypt(&ctx, iv->x, iv->len, in, in_len, out, out_len);
+
+cleanup:
+    mbedtls_cipher_free(&ctx);
+    return ret;
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CIPHER_C:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns ct, decryption returns msg. */
+/* BEGIN_CASE */
+void mbedtls_aes_cbc_enc_dec(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_aes_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+
+    /* Encrypt: PKCS#7 adds one block at most. */
+    TEST_CALLOC(output, msg->len + 16);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_ENCRYPT, key, iv, msg->x, msg->len, output, msg->len + 16, &olen));
+    TEST_MEMORY_COMPARE(output, olen, ct->x, ct->len);
+    mbedtls_free(output);
+    output = NULL;
+
+    /* Decrypt: recover the original message. */
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+    TEST_EQUAL(0, wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len, output, ct->len, &olen));
+    TEST_MEMORY_COMPARE(output, olen, msg->x, msg->len);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector: PKCS#7 unpadding of the decrypted block must be rejected. */
+/* BEGIN_CASE */
+void mbedtls_aes_cbc_dec_invalid_padding(data_t* key, data_t* iv, data_t* msg, data_t* ct)
+{
+    unsigned char* output = NULL;
+    size_t olen = 0;
+
+    (void)msg;
+
+    BLOCK_CIPHER_PSA_INIT();
+    TEST_ASSERT(wp_aes_cbc_type(key->len) != MBEDTLS_CIPHER_NONE);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_ASSERT(wp_cbc_crypt(MBEDTLS_DECRYPT, key, iv, ct->x, ct->len,
+                    output, ct->len, &olen)
+        != 0);
+
+exit:
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_ccm_wycheproof.function
+++ b/tests/suites/test_suite_ccm_wycheproof.function
@@ -1,0 +1,130 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/ccm.h"
+
+/* Project Wycheproof AES-CCM harness.
+ * Columns for every function: key:msg:iv:aad:ct:tag.
+ *   valid                            -> mbedtls_ccm_encrypt_and_tag
+ *   invalid + ModifiedTag              -> mbedtls_ccm_decrypt_modified_tag
+ *   invalid + InvalidNonceSize         -> mbedtls_ccm_encrypt_decrypt_invalid_nonce
+ *   invalid + Invalid/InsecureTagSize  -> mbedtls_ccm_decrypt_invalid_insecure_tag
+ *
+ * All Wycheproof invalid-nonce vectors use a nonce length outside CCM's 7..13,
+ * and all invalid/insecure-tag vectors use a tag length CCM rejects, so both
+ * map to MBEDTLS_ERR_CCM_BAD_INPUT. */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CCM_C:MBEDTLS_AES_C
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag), decryption returns msg. */
+/* BEGIN_CASE */
+void mbedtls_ccm_encrypt_and_tag(data_t* key, data_t* msg, data_t* iv,
+    data_t* aad, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+
+    mbedtls_ccm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    TEST_LE_U(tag->len, sizeof(tag_output));
+    TEST_EQUAL(msg->len, ct->len);
+    TEST_CALLOC(output, msg->len == 0 ? 1 : msg->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+
+    TEST_EQUAL(0, mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len, aad->x, aad->len, msg->x, output, tag_output, tag->len));
+    TEST_MEMORY_COMPARE(output, msg->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, tag->len, tag->x, tag->len);
+
+    memset(output, 0, msg->len == 0 ? 1 : msg->len);
+    TEST_EQUAL(0, mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len, aad->x, aad->len, ct->x, output, tag->x, tag->len));
+    TEST_MEMORY_COMPARE(output, ct->len, msg->x, msg->len);
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid vector with a modified tag: authenticated decryption must fail. */
+/* BEGIN_CASE */
+void mbedtls_ccm_decrypt_modified_tag(data_t* key, data_t* msg, data_t* iv,
+    data_t* aad, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+
+    (void)msg;
+
+    mbedtls_ccm_init(&ctx);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+    TEST_EQUAL(MBEDTLS_ERR_CCM_AUTH_FAILED,
+        mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+            aad->x, aad->len, ct->x, output,
+            tag->x, tag->len));
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid-nonce-length vector: CCM must reject a nonce outside 7..13 bytes. */
+/* BEGIN_CASE */
+void mbedtls_ccm_encrypt_decrypt_invalid_nonce(data_t* key, data_t* msg, data_t* iv,
+    data_t* aad, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+    size_t tag_len = tag->len ? tag->len : 16;
+
+    (void)ct;
+
+    mbedtls_ccm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+    TEST_LE_U(tag_len, sizeof(tag_output));
+    TEST_CALLOC(output, msg->len == 0 ? 1 : msg->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+    TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT,
+        mbedtls_ccm_encrypt_and_tag(&ctx, msg->len, iv->x, iv->len,
+            aad->x, aad->len, msg->x, output,
+            tag_output, tag_len));
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid/insecure tag-length vector: CCM must reject the tag length. */
+/* BEGIN_CASE */
+void mbedtls_ccm_decrypt_invalid_insecure_tag(data_t* key, data_t* msg, data_t* iv,
+    data_t* aad, data_t* ct, data_t* tag)
+{
+    mbedtls_ccm_context ctx;
+    unsigned char* output = NULL;
+
+    (void)msg;
+
+    mbedtls_ccm_init(&ctx);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_EQUAL(0, mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+    TEST_EQUAL(MBEDTLS_ERR_CCM_BAD_INPUT,
+        mbedtls_ccm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+            aad->x, aad->len, ct->x, output,
+            tag->x, tag->len));
+
+exit:
+    mbedtls_ccm_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_chachapoly_wycheproof.function
+++ b/tests/suites/test_suite_chachapoly_wycheproof.function
@@ -1,0 +1,104 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/chachapoly.h"
+
+/* Project Wycheproof ChaCha20-Poly1305 harness.
+ * Columns: key:iv:aad:msg:ct:tag.
+ *   valid                    -> mbedtls_chachapoly_enc_dec
+ *   invalid + ModifiedTag      -> mbedtls_chachapoly_dec_modified_tag
+ *   invalid + InvalidNonceSize -> mbedtls_chachapoly_invalid_nonce
+ * The mbedTLS API fixes the nonce at 12 bytes and the tag at 16 bytes. */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CHACHAPOLY_C
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag), decryption returns msg. */
+/* BEGIN_CASE */
+void mbedtls_chachapoly_enc_dec(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_chachapoly_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+
+    mbedtls_chachapoly_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    TEST_EQUAL(key->len, 32);
+    TEST_EQUAL(iv->len, 12);
+    TEST_EQUAL(tag->len, 16);
+    TEST_EQUAL(pt->len, ct->len);
+    TEST_CALLOC(output, pt->len == 0 ? 1 : pt->len);
+
+    TEST_EQUAL(0, mbedtls_chachapoly_setkey(&ctx, key->x));
+
+    /* Encrypt: ciphertext and tag must match the vector. */
+    TEST_EQUAL(0, mbedtls_chachapoly_encrypt_and_tag(&ctx, pt->len, iv->x, aad->x, aad->len, pt->x, output, tag_output));
+    TEST_MEMORY_COMPARE(output, pt->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, 16, tag->x, tag->len);
+
+    /* Decrypt: must authenticate and recover the plaintext. */
+    memset(output, 0, pt->len == 0 ? 1 : pt->len);
+    TEST_EQUAL(0, mbedtls_chachapoly_auth_decrypt(&ctx, ct->len, iv->x, aad->x, aad->len, tag->x, ct->x, output));
+    TEST_MEMORY_COMPARE(output, ct->len, pt->x, pt->len);
+
+exit:
+    mbedtls_chachapoly_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid vector with a modified tag: authenticated decryption must fail. */
+/* BEGIN_CASE */
+void mbedtls_chachapoly_dec_modified_tag(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_chachapoly_context ctx;
+    unsigned char* output = NULL;
+
+    (void)pt;
+
+    mbedtls_chachapoly_init(&ctx);
+
+    TEST_EQUAL(key->len, 32);
+    TEST_EQUAL(iv->len, 12);
+    TEST_EQUAL(tag->len, 16);
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+
+    TEST_EQUAL(0, mbedtls_chachapoly_setkey(&ctx, key->x));
+    TEST_EQUAL(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED,
+        mbedtls_chachapoly_auth_decrypt(&ctx, ct->len, iv->x,
+            aad->x, aad->len, tag->x,
+            ct->x, output));
+
+exit:
+    mbedtls_chachapoly_free(&ctx);
+    mbedtls_free(output);
+}
+/* END_CASE */
+
+/* Invalid-nonce-size vector: the mbedTLS ChaCha20-Poly1305 API fixes the nonce
+ * at 12 bytes, so a wrong-size nonce can never be supplied to. This serves as a stub.
+ */
+/* BEGIN_CASE */
+void mbedtls_chachapoly_invalid_nonce(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_chachapoly_context ctx;
+
+    (void)iv;
+    (void)aad;
+    (void)pt;
+    (void)ct;
+    (void)tag;
+
+    mbedtls_chachapoly_init(&ctx);
+    TEST_EQUAL(key->len, 32);
+    TEST_EQUAL(0, mbedtls_chachapoly_setkey(&ctx, key->x));
+
+exit:
+    mbedtls_chachapoly_free(&ctx);
+}
+/* END_CASE */

--- a/tests/suites/test_suite_cmac_wycheproof.function
+++ b/tests/suites/test_suite_cmac_wycheproof.function
@@ -1,0 +1,101 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/cipher.h"
+#include "mbedtls/private/cmac.h"
+
+/* Project Wycheproof AES-CMAC harness.
+ *   valid                    -> mbedtls_cmac_generate_verify
+ *   invalid + ModifiedTag    -> mbedtls_cmac_verify_modified_tag
+ *   invalid + InvalidKeySize -> mbedtls_cmac_genver_invalid_key_size
+ * The Wycheproof tag may be truncated (tagSize < block size), so only the
+ * leading tag->len bytes of the computed CMAC are compared. */
+
+/* Map an AES key length in bytes to the corresponding CIPHER macro. */
+static mbedtls_cipher_type_t wp_aes_ecb_type(size_t key_len)
+{
+    switch (key_len) {
+    case 16:
+        return MBEDTLS_CIPHER_AES_128_ECB;
+    case 24:
+        return MBEDTLS_CIPHER_AES_192_ECB;
+    case 32:
+        return MBEDTLS_CIPHER_AES_256_ECB;
+    default:
+        return MBEDTLS_CIPHER_NONE;
+    }
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_CMAC_C:MBEDTLS_AES_C
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: the CMAC of msg under key must match the (possibly truncated) tag. */
+/* BEGIN_CASE */
+void mbedtls_cmac_generate_verify(data_t* key, data_t* msg, data_t* tag)
+{
+    unsigned char output[16];
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(wp_aes_ecb_type(key->len));
+
+    BLOCK_CIPHER_PSA_INIT();
+    memset(output, 0, sizeof(output));
+
+    TEST_ASSERT(info != NULL);
+    TEST_LE_U(tag->len, sizeof(output));
+
+    TEST_EQUAL(0, mbedtls_cipher_cmac(info, key->x, key->len * 8, msg->x, msg->len, output));
+    TEST_MEMORY_COMPARE(output, tag->len, tag->x, tag->len);
+
+exit:
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector with a modified tag: the recomputed CMAC must differ from it. */
+/* BEGIN_CASE */
+void mbedtls_cmac_verify_modified_tag(data_t* key, data_t* msg, data_t* tag)
+{
+    unsigned char output[16];
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(wp_aes_ecb_type(key->len));
+
+    BLOCK_CIPHER_PSA_INIT();
+    memset(output, 0, sizeof(output));
+
+    TEST_ASSERT(info != NULL);
+    TEST_LE_U(tag->len, sizeof(output));
+
+    TEST_EQUAL(0, mbedtls_cipher_cmac(info, key->x, key->len * 8, msg->x, msg->len, output));
+    TEST_ASSERT(memcmp(output, tag->x, tag->len) != 0);
+
+exit:
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector with an unsupported key size: CMAC setup must reject it.
+ * This test is admittedly artificial: since Mbed TLS already restricts AES-CMAC
+ * to 128/192/256 bit keys, we only compare to AES-128 and check that the key size
+ * is rejected.
+ */
+/* BEGIN_CASE */
+void mbedtls_cmac_genver_invalid_key_size(data_t* key, data_t* msg, data_t* tag)
+{
+    unsigned char output[16];
+    const mbedtls_cipher_info_t* info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
+
+    (void)tag;
+
+    BLOCK_CIPHER_PSA_INIT();
+    memset(output, 0, sizeof(output));
+
+    TEST_ASSERT(info != NULL);
+    TEST_ASSERT(wp_aes_ecb_type(key->len) == MBEDTLS_CIPHER_NONE);
+
+    TEST_ASSERT(mbedtls_cipher_cmac(info, key->x, key->len * 8,
+                    msg->x, msg->len, output)
+        != 0);
+
+exit:
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_ecdh_wycheproof.function
+++ b/tests/suites/test_suite_ecdh_wycheproof.function
@@ -1,0 +1,119 @@
+/* BEGIN_HEADER */
+#include "mbedtls/pk.h"
+#include "psa/crypto.h"
+
+/* Project Wycheproof ECDH harnesses, with one .data file per curve.
+ * Columns: <PSA_ECC_FAMILY_*>:bits:privScalar:peerPoint:shared:result
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:PSA_WANT_ALG_ECDH
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_ecdh_compute(int family, int bits, data_t* priv, data_t* peer,
+    data_t* shared, int result)
+{
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    unsigned char out[PSA_BITS_TO_BYTES(521)];
+    size_t olen = 0;
+    psa_status_t status;
+
+    PSA_INIT();
+
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
+    psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR((psa_ecc_family_t)family));
+    psa_set_key_bits(&attr, (size_t)bits);
+    PSA_ASSERT(psa_import_key(&attr, priv->x, priv->len, &key));
+
+    status = psa_raw_key_agreement(PSA_ALG_ECDH, key, peer->x, peer->len,
+        out, sizeof(out), &olen);
+
+    if (result == 2) {
+        /* Valid tests, the output MAC must match the test vector. */
+        PSA_ASSERT(status);
+        TEST_MEMORY_COMPARE(out, olen, shared->x, shared->len);
+    } else if (result == 1) {
+        /* Acceptable tests, if the operation succeeds the output MAC must match the test vector. */
+        if (status == PSA_SUCCESS) {
+            TEST_MEMORY_COMPARE(out, olen, shared->x, shared->len);
+        }
+    } else {
+        /* Invalid tests, the operation must fail. */
+        TEST_ASSERT(status != PSA_SUCCESS);
+    }
+
+exit:
+    psa_destroy_key(key);
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_PK_PARSE_C */
+void mbedtls_ecdh_compute_der(int family, int bits, data_t* priv,
+    data_t* peer_der, data_t* shared, int result)
+{
+    mbedtls_pk_context pk;
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    mbedtls_svc_key_id_t peer = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_attributes_t peer_attr = PSA_KEY_ATTRIBUTES_INIT;
+    unsigned char point[PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(
+        PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1), 521)];
+    unsigned char out[PSA_BITS_TO_BYTES(521)];
+    size_t point_len = 0, olen = 0;
+    psa_status_t status;
+
+    mbedtls_pk_init(&pk);
+    PSA_INIT();
+
+    /* Use `mbedtls_pk_*` to test the DER parser. */
+    if (mbedtls_pk_parse_public_key(&pk, peer_der->x, peer_der->len) != 0) {
+        TEST_ASSERT(result != 2);
+        goto exit;
+    }
+
+    /* Import into PSA to validate the point and exercise the PSA API. */
+    if (mbedtls_pk_get_psa_attributes(&pk, PSA_KEY_USAGE_VERIFY_HASH,
+            &peer_attr)
+            != 0
+        || mbedtls_pk_import_into_psa(&pk, &peer_attr, &peer) != PSA_SUCCESS || psa_export_public_key(peer, point, sizeof(point), &point_len) != PSA_SUCCESS) {
+        TEST_ASSERT(result != 2);
+        goto exit;
+    }
+
+    /* Finally, the operation, which must succeed for valid tests, must fail for
+     * invalid ones (that haven't been rejected already), and acceptable tests must
+     * match the shared secret _if_ the operation succeeds.
+     */
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
+    psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR((psa_ecc_family_t)family));
+    psa_set_key_bits(&attr, (size_t)bits);
+    PSA_ASSERT(psa_import_key(&attr, priv->x, priv->len, &key));
+
+    status = psa_raw_key_agreement(PSA_ALG_ECDH, key, point, point_len,
+        out, sizeof(out), &olen);
+
+    if (result == 2) {
+        PSA_ASSERT(status);
+        TEST_MEMORY_COMPARE(out, olen, shared->x, shared->len);
+    } else if (result == 1) {
+        if (status == PSA_SUCCESS) {
+            TEST_MEMORY_COMPARE(out, olen, shared->x, shared->len);
+        }
+    } else {
+        TEST_ASSERT(status != PSA_SUCCESS);
+    }
+
+exit:
+    mbedtls_pk_free(&pk);
+    psa_destroy_key(key);
+    psa_destroy_key(peer);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_ecdsa_p1363_wycheproof.function
+++ b/tests/suites/test_suite_ecdsa_p1363_wycheproof.function
@@ -1,0 +1,48 @@
+/* BEGIN_HEADER */
+#include "psa/crypto.h"
+
+/* Project Wycheproof ECDSA P1363 (raw r||s) signature verification.
+ * Columns: <PSA hash alg>:<PSA_ECC_FAMILY>:bits:rawPublicPoint:msg:sig:expected_valid
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:PSA_WANT_ALG_ECDSA:PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_ecdsa_verify_p1363(int hash_arg, int family, int bits, data_t* point,
+    data_t* msg, data_t* sig, int expected_valid)
+{
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    psa_algorithm_t alg = PSA_ALG_ECDSA((psa_algorithm_t)hash_arg);
+    psa_status_t status;
+
+    PSA_INIT();
+
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_VERIFY_MESSAGE);
+    psa_set_key_algorithm(&attr, alg);
+    psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_PUBLIC_KEY((psa_ecc_family_t)family));
+    psa_set_key_bits(&attr, (size_t)bits);
+
+    status = psa_import_key(&attr, point->x, point->len, &key);
+    if (status != PSA_SUCCESS) {
+        /* Some tests include invalid keys which should be rejected at import. */
+        TEST_EQUAL(expected_valid, 0);
+        goto exit;
+    }
+
+    status = psa_verify_message(key, alg, msg->x, msg->len, sig->x, sig->len);
+    if (expected_valid) {
+        PSA_ASSERT(status);
+    } else {
+        TEST_ASSERT(status != PSA_SUCCESS);
+    }
+
+exit:
+    psa_destroy_key(key);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_gcm_wycheproof.function
+++ b/tests/suites/test_suite_gcm_wycheproof.function
@@ -1,0 +1,121 @@
+/* BEGIN_HEADER */
+#include "mbedtls/private/gcm.h"
+
+/* Project Wycheproof AES-GCM test harness.
+ * Columns: key:iv:aad:pt:ct:tag.
+ *   - valid                  -> mbedtls_gcm_enc_dec
+ *   - invalid + ZeroLengthIv -> mbedtls_gcm_enc_dec_zero_length_iv
+ *   - invalid + ModifiedTag  -> mbedtls_gcm_dec_modified_tag
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_GCM_C:MBEDTLS_CCM_GCM_CAN_AES
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: encryption returns (ct, tag), and authenticated decryption must recover
+ * the plaintext. */
+/* BEGIN_CASE */
+void mbedtls_gcm_enc_dec(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_gcm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+    size_t tag_len = tag->len;
+
+    BLOCK_CIPHER_PSA_INIT();
+    mbedtls_gcm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    /* GCM tag is at most 16 bytes; ciphertext length equals plaintext length. */
+    TEST_LE_U(tag_len, sizeof(tag_output));
+    TEST_EQUAL(pt->len, ct->len);
+    TEST_CALLOC(output, pt->len == 0 ? 1 : pt->len);
+
+    TEST_EQUAL(0, mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+
+    /* Encrypt: output ciphertext and tag must match the test vector. */
+    TEST_EQUAL(0, mbedtls_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, pt->len, iv->x, iv->len, aad->x, aad->len, pt->x, output, tag_len, tag_output));
+    TEST_MEMORY_COMPARE(output, pt->len, ct->x, ct->len);
+    TEST_MEMORY_COMPARE(tag_output, tag_len, tag->x, tag->len);
+
+    /* Decrypt: must authenticate and recover the plaintext. */
+    memset(output, 0, pt->len == 0 ? 1 : pt->len);
+    TEST_EQUAL(0, mbedtls_gcm_auth_decrypt(&ctx, ct->len, iv->x, iv->len, aad->x, aad->len, tag->x, tag_len, ct->x, output));
+    TEST_MEMORY_COMPARE(output, ct->len, pt->x, pt->len);
+
+exit:
+    mbedtls_gcm_free(&ctx);
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector with a modified authentication tag: authenticated decryption MUST
+ * reject it. */
+/* BEGIN_CASE */
+void mbedtls_gcm_dec_modified_tag(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_gcm_context ctx;
+    unsigned char* output = NULL;
+    size_t tag_len = tag->len;
+
+    (void)pt;
+
+    BLOCK_CIPHER_PSA_INIT();
+    mbedtls_gcm_init(&ctx);
+
+    TEST_CALLOC(output, ct->len == 0 ? 1 : ct->len);
+    TEST_EQUAL(0, mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+
+    TEST_EQUAL(MBEDTLS_ERR_GCM_AUTH_FAILED,
+        mbedtls_gcm_auth_decrypt(&ctx, ct->len, iv->x, iv->len,
+            aad->x, aad->len, tag->x, tag_len,
+            ct->x, output));
+
+exit:
+    mbedtls_gcm_free(&ctx);
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector with a zero-length IV: forbidden by SP 800-38D 5.2.1.1, the GCM API
+ * rejects it with MBEDTLS_ERR_GCM_BAD_INPUT. */
+/* BEGIN_CASE */
+void mbedtls_gcm_enc_dec_zero_length_iv(data_t* key, data_t* iv, data_t* aad,
+    data_t* pt, data_t* ct, data_t* tag)
+{
+    mbedtls_gcm_context ctx;
+    unsigned char* output = NULL;
+    unsigned char tag_output[16];
+    size_t tag_len = tag->len;
+
+    (void)ct;
+    (void)tag;
+
+    BLOCK_CIPHER_PSA_INIT();
+    mbedtls_gcm_init(&ctx);
+    memset(tag_output, 0, sizeof(tag_output));
+
+    /* This harness is only for the zero-length-IV cases. */
+    TEST_EQUAL(iv->len, 0);
+    TEST_LE_U(tag_len, sizeof(tag_output));
+    TEST_CALLOC(output, pt->len == 0 ? 1 : pt->len);
+
+    TEST_EQUAL(0, mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key->x, key->len * 8));
+
+    TEST_EQUAL(MBEDTLS_ERR_GCM_BAD_INPUT,
+        mbedtls_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, pt->len,
+            iv->x, iv->len, aad->x, aad->len,
+            pt->x, output, tag_len, tag_output));
+
+exit:
+    mbedtls_gcm_free(&ctx);
+    mbedtls_free(output);
+    BLOCK_CIPHER_PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_hkdf_wycheproof.function
+++ b/tests/suites/test_suite_hkdf_wycheproof.function
@@ -1,0 +1,86 @@
+/* BEGIN_HEADER */
+#include "psa/crypto.h"
+
+/* Project Wycheproof HKDF harness, with one .data file per hash.
+ * Columns:
+ *   valid                  -> mbedtls_hkdf_derive          <hash>:ikm:salt:info:okm
+ *   invalid + SizeTooLarge -> mbedtls_hkdf_size_too_large   <hash>:ikm:salt:info:size
+ */
+
+static psa_status_t wp_hkdf_setup(psa_key_derivation_operation_t* op,
+    psa_algorithm_t hash,
+    data_t* ikm, data_t* salt, data_t* info)
+{
+    psa_status_t s;
+    if ((s = psa_key_derivation_setup(op, PSA_ALG_HKDF(hash))) != PSA_SUCCESS) {
+        return s;
+    }
+    if (salt->len != 0) {
+        if ((s = psa_key_derivation_input_bytes(op, PSA_KEY_DERIVATION_INPUT_SALT,
+                 salt->x, salt->len))
+            != PSA_SUCCESS) {
+            return s;
+        }
+    }
+    if ((s = psa_key_derivation_input_bytes(op, PSA_KEY_DERIVATION_INPUT_SECRET,
+             ikm->x, ikm->len))
+        != PSA_SUCCESS) {
+        return s;
+    }
+    return psa_key_derivation_input_bytes(op, PSA_KEY_DERIVATION_INPUT_INFO,
+        info->x, info->len);
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:PSA_WANT_ALG_HKDF
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: HKDF(ikm, salt, info) returns okm. */
+/* BEGIN_CASE */
+void mbedtls_hkdf_derive(int hash_arg, data_t* ikm, data_t* salt,
+    data_t* info, data_t* okm)
+{
+    psa_algorithm_t hash = (psa_algorithm_t)hash_arg;
+    psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+    unsigned char* output = NULL;
+
+    PSA_INIT();
+    TEST_CALLOC(output, okm->len == 0 ? 1 : okm->len);
+
+    PSA_ASSERT(wp_hkdf_setup(&op, hash, ikm, salt, info));
+    PSA_ASSERT(psa_key_derivation_output_bytes(&op, output, okm->len));
+    TEST_MEMORY_COMPARE(output, okm->len, okm->x, okm->len);
+
+exit:
+    psa_key_derivation_abort(&op);
+    mbedtls_free(output);
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector: requesting more than 255*HashLen output bytes must fail (HKDF's
+ * maximum output length, RFC 5869 section 2.3). */
+/* BEGIN_CASE */
+void mbedtls_hkdf_size_too_large(int hash_arg, data_t* ikm, data_t* salt,
+    data_t* info, int size)
+{
+    psa_algorithm_t hash = (psa_algorithm_t)hash_arg;
+    psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+    unsigned char* output = NULL;
+
+    PSA_INIT();
+    TEST_ASSERT(size > 0);
+    TEST_CALLOC(output, (size_t)size);
+
+    PSA_ASSERT(wp_hkdf_setup(&op, hash, ikm, salt, info));
+    TEST_EQUAL(PSA_ERROR_INSUFFICIENT_DATA,
+        psa_key_derivation_output_bytes(&op, output, (size_t)size));
+
+exit:
+    psa_key_derivation_abort(&op);
+    mbedtls_free(output);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_hmac_wycheproof.function
+++ b/tests/suites/test_suite_hmac_wycheproof.function
@@ -1,0 +1,82 @@
+/* BEGIN_HEADER */
+#include "psa/crypto.h"
+
+/* Project Wycheproof HMAC harness. There is one .data file per hash.
+ * Columns: <PSA hash alg>:key:msg:tag
+ *   valid               -> mbedtls_hmac_gen_ver
+ *   invalid + ModifiedTag -> mbedtls_hmac_ver_modified_tag
+ * Wycheproof truncates the tag (tagSize may be less than the hash output), so the MAC
+ * algorithm is truncated to tag->len when shorter than the full hash length. */
+
+/* Build the (possibly truncated) HMAC algorithm for a given tag length. */
+static psa_algorithm_t wp_hmac_alg(psa_algorithm_t hash, size_t tag_len)
+{
+    psa_algorithm_t full = PSA_ALG_HMAC(hash);
+    if (tag_len == PSA_HASH_LENGTH(hash)) {
+        return full;
+    }
+    return PSA_ALG_TRUNCATED_MAC(full, tag_len);
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:PSA_WANT_ALG_HMAC
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: the HMAC of msg under key matches the tag (compute + verify). */
+/* BEGIN_CASE */
+void mbedtls_hmac_gen_ver(int hash_arg, data_t* key, data_t* msg, data_t* tag)
+{
+    psa_algorithm_t hash = (psa_algorithm_t)hash_arg;
+    psa_algorithm_t alg = wp_hmac_alg(hash, tag->len);
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    unsigned char mac[PSA_MAC_MAX_SIZE];
+    size_t mac_len = 0;
+
+    PSA_INIT();
+
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_MESSAGE | PSA_KEY_USAGE_VERIFY_MESSAGE);
+    psa_set_key_algorithm(&attr, alg);
+    psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+    PSA_ASSERT(psa_import_key(&attr, key->x, key->len, &key_id));
+
+    /* Compute and compare. */
+    PSA_ASSERT(psa_mac_compute(key_id, alg, msg->x, msg->len,
+        mac, sizeof(mac), &mac_len));
+    TEST_MEMORY_COMPARE(mac, mac_len, tag->x, tag->len);
+
+    /* Verify. */
+    PSA_ASSERT(psa_mac_verify(key_id, alg, msg->x, msg->len, tag->x, tag->len));
+
+exit:
+    psa_destroy_key(key_id);
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector with a modified tag: verification must reject it. */
+/* BEGIN_CASE */
+void mbedtls_hmac_ver_modified_tag(int hash_arg, data_t* key, data_t* msg, data_t* tag)
+{
+    psa_algorithm_t hash = (psa_algorithm_t)hash_arg;
+    psa_algorithm_t alg = wp_hmac_alg(hash, tag->len);
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+
+    PSA_INIT();
+
+    psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_VERIFY_MESSAGE);
+    psa_set_key_algorithm(&attr, alg);
+    psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+    PSA_ASSERT(psa_import_key(&attr, key->x, key->len, &key_id));
+
+    TEST_EQUAL(PSA_ERROR_INVALID_SIGNATURE,
+        psa_mac_verify(key_id, alg, msg->x, msg->len, tag->x, tag->len));
+
+exit:
+    psa_destroy_key(key_id);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_nist_kw_wycheproof.function
+++ b/tests/suites/test_suite_nist_kw_wycheproof.function
@@ -1,0 +1,127 @@
+/* BEGIN_HEADER */
+#include "mbedtls/nist_kw.h"
+#include <string.h>
+
+/* Project Wycheproof AES Key Wrap (NIST KW / KWP) test harness.
+ * Columns: mode:key:msg:ct
+ *   - valid   -> wycheproof_nist_kw_valid           (wrap returns ct, unwrap recovers msg)
+ *   - invalid -> wycheproof_nist_kw_unwrap_invalid  (unwrap must not recover msg)
+ */
+
+static int setup_psa_key(int usage,
+    int alg,
+    int key_type,
+    mbedtls_svc_key_id_t* key_id,
+    const data_t* key)
+{
+    int ok = 1;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    PSA_INIT();
+    psa_set_key_usage_flags(&attributes, usage);
+    psa_set_key_algorithm(&attributes, alg);
+    psa_set_key_type(&attributes, key_type);
+    PSA_ASSERT(psa_import_key(&attributes, key->x, key->len, key_id));
+    ok = PSA_SUCCESS;
+exit:
+    return ok;
+}
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_NIST_KW_C:PSA_WANT_KEY_TYPE_AES
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: wrapping return ct, unwrapping returns msg. */
+/* BEGIN_CASE */
+void wycheproof_nist_kw_valid(int mode, data_t* key, data_t* msg, data_t* ct)
+{
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    unsigned char* wrapped = NULL;
+    unsigned char* unwrapped = NULL;
+    size_t wrapped_len = 0, unwrapped_len = 0;
+    /* Unwrap output is at most (ciphertext - 8 bytes), see nist_kw.h. */
+    size_t pt_size = (ct->len > 8) ? ct->len - 8 : 1;
+
+    PSA_ASSERT(setup_psa_key(PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,
+        PSA_ALG_ECB_NO_PADDING, PSA_KEY_TYPE_AES,
+        &key_id, key));
+
+    /* Wrap: compare to the ciphertext. */
+    TEST_CALLOC(wrapped, ct->len == 0 ? 1 : ct->len);
+    PSA_ASSERT(mbedtls_nist_kw_wrap(key_id, mode, msg->x, msg->len,
+        wrapped, ct->len, &wrapped_len));
+    TEST_MEMORY_COMPARE(wrapped, wrapped_len, ct->x, ct->len);
+
+    /* Unwrap: must authenticate and recover the original msg. */
+    TEST_CALLOC(unwrapped, pt_size);
+    PSA_ASSERT(mbedtls_nist_kw_unwrap(key_id, mode, ct->x, ct->len,
+        unwrapped, pt_size, &unwrapped_len));
+    TEST_MEMORY_COMPARE(unwrapped, unwrapped_len, msg->x, msg->len);
+
+exit:
+    mbedtls_free(wrapped);
+    mbedtls_free(unwrapped);
+    psa_destroy_key(key_id);
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* Invalid vector: unwrapping an invalid ciphertext must not release the original
+ * message.
+ */
+/* BEGIN_CASE */
+void wycheproof_nist_kw_unwrap_invalid(int mode, data_t* key, data_t* msg, data_t* ct)
+{
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    unsigned char* out = NULL;
+    size_t out_len = 0;
+    size_t out_size = (ct->len > 8) ? ct->len - 8 : 1;
+    int ret;
+
+    PSA_ASSERT(setup_psa_key(PSA_KEY_USAGE_DECRYPT, PSA_ALG_ECB_NO_PADDING,
+        PSA_KEY_TYPE_AES, &key_id, key));
+    TEST_CALLOC(out, out_size);
+
+    ret = mbedtls_nist_kw_unwrap(key_id, mode, ct->x, ct->len,
+        out, out_size, &out_len);
+
+    if (ret == 0) {
+        /* Unwrap accepted it: acceptable if it did not recover the message. */
+        TEST_ASSERT(out_len != msg->len || (msg->len != 0 && memcmp(out, msg->x, msg->len) != 0));
+    }
+
+exit:
+    mbedtls_free(out);
+    psa_destroy_key(key_id);
+    PSA_DONE();
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void wycheproof_nist_kw_acceptable(int mode, data_t* key, data_t* msg, data_t* ct)
+{
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    unsigned char* out = NULL;
+    size_t out_len = 0;
+    size_t out_size = (ct->len > 8) ? ct->len - 8 : 1;
+    int ret;
+
+    PSA_ASSERT(setup_psa_key(PSA_KEY_USAGE_DECRYPT, PSA_ALG_ECB_NO_PADDING,
+        PSA_KEY_TYPE_AES, &key_id, key));
+    TEST_CALLOC(out, out_size);
+
+    ret = mbedtls_nist_kw_unwrap(key_id, mode, ct->x, ct->len,
+        out, out_size, &out_len);
+
+    if (ret == 0) {
+        TEST_MEMORY_COMPARE(out, out_len, msg->x, msg->len);
+    }
+
+exit:
+    mbedtls_free(out);
+    psa_destroy_key(key_id);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_pbkdf2_wycheproof.function
+++ b/tests/suites/test_suite_pbkdf2_wycheproof.function
@@ -1,0 +1,42 @@
+/* BEGIN_HEADER */
+#include "psa/crypto.h"
+
+/* Project Wycheproof PBKDF2-HMAC harness.
+ * Columns: <hash>:password:salt:iterationCount:dk
+ * All Wycheproof PBKDF2 vectors are valid, tested via mbedtls_pbkdf2_derive(). */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:PSA_WANT_ALG_PBKDF2_HMAC
+ * END_DEPENDENCIES
+ */
+
+/* Valid vector: PBKDF2-HMAC(password, salt, iterations) must produce exactly dk. */
+/* BEGIN_CASE */
+void mbedtls_pbkdf2_derive(int hash_arg, data_t* password, data_t* salt,
+    int iterations, data_t* dk)
+{
+    psa_algorithm_t hash = (psa_algorithm_t)hash_arg;
+    psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+    unsigned char* output = NULL;
+
+    PSA_INIT();
+    TEST_ASSERT(iterations > 0);
+    TEST_CALLOC(output, dk->len == 0 ? 1 : dk->len);
+
+    PSA_ASSERT(psa_key_derivation_setup(&op, PSA_ALG_PBKDF2_HMAC(hash)));
+    PSA_ASSERT(psa_key_derivation_input_integer(&op, PSA_KEY_DERIVATION_INPUT_COST,
+        (uint64_t)iterations));
+    PSA_ASSERT(psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_SALT,
+        salt->x, salt->len));
+    PSA_ASSERT(psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_PASSWORD,
+        password->x, password->len));
+    PSA_ASSERT(psa_key_derivation_output_bytes(&op, output, dk->len));
+    TEST_MEMORY_COMPARE(output, dk->len, dk->x, dk->len);
+
+exit:
+    psa_key_derivation_abort(&op);
+    mbedtls_free(output);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_rsa_oaep_wycheproof.function
+++ b/tests/suites/test_suite_rsa_oaep_wycheproof.function
@@ -1,0 +1,49 @@
+/* BEGIN_HEADER */
+#include "mbedtls/pk.h"
+#include "psa/crypto.h"
+/* Project Wycheproof RSA-OAEP decryption.
+ * Restricted to mgfSha == sha, since PSA's OAEP always uses MGF1 with the OAEP hash.
+ * Columns: <PSA hash alg>:privPkcs8:ct:label:msg:expected_valid.
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_RSA_OAEP:PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_rsa_oaep_decrypt(int hash_arg, data_t* pkcs8, data_t* ct,
+    data_t* label, data_t* msg, int expected_valid)
+{
+    mbedtls_pk_context pk;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_algorithm_t alg = PSA_ALG_RSA_OAEP((psa_algorithm_t)hash_arg);
+    unsigned char out[600];
+    size_t olen = 0;
+    psa_status_t status;
+
+    mbedtls_pk_init(&pk);
+    PSA_INIT();
+
+    TEST_EQUAL(0, mbedtls_pk_parse_key(&pk, pkcs8->x, pkcs8->len, NULL, 0));
+    TEST_EQUAL(0, mbedtls_pk_get_psa_attributes(&pk, PSA_KEY_USAGE_DECRYPT, &attr));
+    psa_set_key_algorithm(&attr, alg);
+    TEST_EQUAL(0, mbedtls_pk_import_into_psa(&pk, &attr, &key_id));
+
+    status = psa_asymmetric_decrypt(key_id, alg, ct->x, ct->len,
+        label->x, label->len, out, sizeof(out), &olen);
+    if (expected_valid) {
+        PSA_ASSERT(status);
+        TEST_MEMORY_COMPARE(out, olen, msg->x, msg->len);
+    } else {
+        TEST_ASSERT(status != PSA_SUCCESS);
+    }
+
+exit:
+    psa_destroy_key(key_id);
+    mbedtls_pk_free(&pk);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_rsa_pkcs1v15_wycheproof.function
+++ b/tests/suites/test_suite_rsa_pkcs1v15_wycheproof.function
@@ -1,0 +1,43 @@
+/* BEGIN_HEADER */
+#include "mbedtls/md.h"
+#include "mbedtls/pk.h"
+/* Project Wycheproof RSA PKCS#1 v1.5 signature verification.
+ * Columns: <MBEDTLS_MD_*>:publicKeyDer:msg:sig:expected_valid. */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_RSA_PKCS1V15_SIGN
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_rsa_pkcs1v15_verify(int md_type, data_t* pubkey, data_t* msg,
+    data_t* sig, int expected_valid)
+{
+    mbedtls_pk_context pk;
+    const mbedtls_md_info_t* mdi;
+    unsigned char hash[64];
+    int ret;
+
+    mbedtls_pk_init(&pk);
+    PSA_INIT();
+
+    mdi = mbedtls_md_info_from_type((mbedtls_md_type_t)md_type);
+    TEST_ASSERT(mdi != NULL);
+    TEST_LE_U(mbedtls_md_get_size(mdi), sizeof(hash));
+    TEST_EQUAL(0, mbedtls_pk_parse_public_key(&pk, pubkey->x, pubkey->len));
+    TEST_EQUAL(0, mbedtls_md(mdi, msg->x, msg->len, hash));
+
+    ret = mbedtls_pk_verify(&pk, (mbedtls_md_type_t)md_type,
+        hash, mbedtls_md_get_size(mdi), sig->x, sig->len);
+    if (expected_valid) {
+        TEST_EQUAL(ret, 0);
+    } else {
+        TEST_ASSERT(ret != 0);
+    }
+
+exit:
+    mbedtls_pk_free(&pk);
+    PSA_DONE();
+}
+/* END_CASE */

--- a/tests/suites/test_suite_rsa_pkcs1v15dec_wycheproof.function
+++ b/tests/suites/test_suite_rsa_pkcs1v15dec_wycheproof.function
@@ -1,0 +1,47 @@
+/* BEGIN_HEADER */
+#include "mbedtls/pk.h"
+#include "psa/crypto.h"
+/* Project Wycheproof RSA PKCS#1 v1.5 decryption.
+ * Columns: privPkcs8:ct:msg:expected_valid.
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_RSA_PKCS1V15_CRYPT:PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_IMPORT
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_rsa_pkcs1v15_decrypt(data_t* pkcs8, data_t* ct, data_t* msg,
+    int expected_valid)
+{
+    mbedtls_pk_context pk;
+    psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = MBEDTLS_SVC_KEY_ID_INIT;
+    unsigned char out[600];
+    size_t olen = 0;
+    psa_status_t status;
+
+    mbedtls_pk_init(&pk);
+    PSA_INIT();
+
+    TEST_EQUAL(0, mbedtls_pk_parse_key(&pk, pkcs8->x, pkcs8->len, NULL, 0));
+    TEST_EQUAL(0, mbedtls_pk_get_psa_attributes(&pk, PSA_KEY_USAGE_DECRYPT, &attr));
+    psa_set_key_algorithm(&attr, PSA_ALG_RSA_PKCS1V15_CRYPT);
+    TEST_EQUAL(0, mbedtls_pk_import_into_psa(&pk, &attr, &key_id));
+
+    status = psa_asymmetric_decrypt(key_id, PSA_ALG_RSA_PKCS1V15_CRYPT,
+        ct->x, ct->len, NULL, 0, out, sizeof(out), &olen);
+    if (expected_valid) {
+        PSA_ASSERT(status);
+        TEST_MEMORY_COMPARE(out, olen, msg->x, msg->len);
+    } else {
+        TEST_ASSERT(status != PSA_SUCCESS);
+    }
+
+exit:
+    psa_destroy_key(key_id);
+    mbedtls_pk_free(&pk);
+    PSA_DONE();
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

This PR adds the generator for `.data` files from [Project Wycheproof](https://github.com/C2SP/wycheproof) test vectors, as well as the `.function` files to exercise them. When possible, the TF-PSA API is used. The RSA tests make use of `mbedtls_pk_*` functions.

Since the generated test vectors are ~20MB, they are not committed, thus not included in this PR. We are open to including them directly, instead of having to modify the CI to pull Wycheproof to generate the `.data` files.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: this is test code that users do not interact with directly.
- [x] **framework PR** not required because: these are tests for TF-PSA only.
- [x] **TF-PSA-Crypto development PR** provided: this PR.
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [x] **mbedtls development PR** not required because: these are tests for TF-PSA only.
- [x] **mbedtls 4.1 PR** not required because: these are tests for TF-PSA only.
- [x] **mbedtls 3.6 PR** not required because: these are tests for TF-PSA only.
- **tests**  provided.

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.