### PR TITLE
Add Wycheproof test function for ECDSA

### DIFF
--- a/tests/suites/test_suite_ecdsa_wycheproof.function
+++ b/tests/suites/test_suite_ecdsa_wycheproof.function
@@ -1,0 +1,49 @@
+/* BEGIN_HEADER */
+#include "mbedtls/md.h"
+#include "mbedtls/pk.h"
+
+/* Project Wycheproof ECDSA signature-verification harness.
+ * Tests DER (ASN.1) signatures using `mbedtls_pk_*` to use the DER parser.
+ * Columns: <MBEDTLS_MD_*>:publicKeyDer:msg:sig:expected_valid
+ */
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PK_PARSE_C:PSA_WANT_ALG_ECDSA
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void mbedtls_ecdsa_verify_der(int md_type, data_t* pubkey, data_t* msg,
+    data_t* sig, int expected_valid)
+{
+    mbedtls_pk_context pk;
+    const mbedtls_md_info_t* mdi;
+    unsigned char hash[64];
+    int ret;
+
+    mbedtls_pk_init(&pk);
+    PSA_INIT();
+
+    mdi = mbedtls_md_info_from_type((mbedtls_md_type_t)md_type);
+    TEST_ASSERT(mdi != NULL);
+    TEST_LE_U(mbedtls_md_get_size(mdi), sizeof(hash));
+
+    TEST_EQUAL(0, mbedtls_pk_parse_public_key(&pk, pubkey->x, pubkey->len));
+    TEST_EQUAL(0, mbedtls_md(mdi, msg->x, msg->len, hash));
+
+    ret = mbedtls_pk_verify(&pk, (mbedtls_md_type_t)md_type,
+        hash, mbedtls_md_get_size(mdi),
+        sig->x, sig->len);
+
+    if (expected_valid) {
+        TEST_EQUAL(ret, 0);
+    } else {
+        TEST_ASSERT(ret != 0);
+    }
+
+exit:
+    mbedtls_pk_free(&pk);
+    PSA_DONE();
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

Add the test function for ECDSA DER signatures. Complements #883.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: this is test code that users do not interact with directly.
- [x] **framework PR** not required because: these are tests for TF-PSA only.
- [x] **TF-PSA-Crypto development PR** provided: this PR.
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [x] **mbedtls development PR** not required because: these are tests for TF-PSA only.
- [x] **mbedtls 4.1 PR** not required because: these are tests for TF-PSA only.
- [x] **mbedtls 3.6 PR** not required because: these are tests for TF-PSA only.
- **tests**  provided.



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
