### PR TITLE
Fix missing zeroization in psa_key_agreement()

### DIFF
--- a/ChangeLog.d/fix-psa-key-agreement-zeroization.txt
+++ b/ChangeLog.d/fix-psa-key-agreement-zeroization.txt
@@ -1,0 +1,5 @@
+Bugfix
+   Fix missing zeroization of the shared secret buffer in
+   psa_key_agreement(). Fixes #849.
+
+

--- a/ChangeLog.d/fix-psa-key-agreement-zeroization.txt
+++ b/ChangeLog.d/fix-psa-key-agreement-zeroization.txt
@@ -2,4 +2,3 @@ Bugfix
    Fix missing zeroization of the shared secret buffer in
    psa_key_agreement(). Fixes #849.
 
-

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -7998,24 +7998,27 @@ psa_status_t psa_key_agreement(mbedtls_svc_key_id_t private_key,
                                mbedtls_svc_key_id_t *key)
 {
     psa_status_t status;
-    uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE];
+    uint8_t shared_secret[PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE] = { 0 };
     size_t shared_secret_len;
 
     *key = MBEDTLS_SVC_KEY_ID_INIT;
 
     status = validate_key_agreement_params(attributes, alg);
     if (status != PSA_SUCCESS) {
-        return status;
+        goto exit;
     }
 
     status = psa_raw_key_agreement(alg, private_key, peer_key, peer_key_length, shared_secret,
                                    sizeof(shared_secret), &shared_secret_len);
 
     if (status != PSA_SUCCESS) {
-        return status;
+        goto exit;
     }
 
     status = psa_import_key(attributes, shared_secret, shared_secret_len, key);
+    
+exit: 
+    mbedtls_platform_zeroize(shared_secret, sizeof(shared_secret)); 
 
     return status;
 }

--- a/core/psa_crypto.c
+++ b/core/psa_crypto.c
@@ -8016,9 +8016,9 @@ psa_status_t psa_key_agreement(mbedtls_svc_key_id_t private_key,
     }
 
     status = psa_import_key(attributes, shared_secret, shared_secret_len, key);
-    
-exit: 
-    mbedtls_platform_zeroize(shared_secret, sizeof(shared_secret)); 
+
+exit:
+    mbedtls_platform_zeroize(shared_secret, sizeof(shared_secret));
 
     return status;
 }


### PR DESCRIPTION
## Description

Fix missing zeroization of the `shared_secret` buffer in `psa_key_agreement()`. The buffer was not wiped on any return path (success, validation failure, or key-agreement failure), leaving sensitive key material in stack memory. Restructure the function to use a single `exit:` label and call `mbedtls_platform_zeroize()` before returning, matching the secure pattern already used by `psa_key_agreement_internal()` and `psa_key_agreement_iop_complete()`.

Fixes #849.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/886
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **tests**  not required because: we don't test zeroization
- [x]  **TF-PSA-Crypto 1.1** PR: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/890
- [x] **mbedtls 3.6** PR: not required because: psa_key_agreement() function doesn't exist in 3.6