### PR TITLE
Fix built-in MAC operation initialization

### DIFF
--- a/drivers/builtin/include/mbedtls/private/crypto_builtin_composites.h
+++ b/drivers/builtin/include/mbedtls/private/crypto_builtin_composites.h
@@ -69,7 +69,11 @@ typedef struct {
     } MBEDTLS_PRIVATE(ctx);
 } mbedtls_psa_mac_operation_t;
 
-#define MBEDTLS_PSA_MAC_OPERATION_INIT { 0, { 0 } }
+/* Leave ctx implicitly initialized so the whole union is zeroed
+ * (C17 6.7.9 paragraphs 10 and 21). An explicit { 0 } initializes only
+ * dummy (6.7.9 paragraph 17), leaving bytes beyond it unspecified
+ * (6.2.6.1 paragraph 7; see also DR 283). */
+#define MBEDTLS_PSA_MAC_OPERATION_INIT { 0 }
 
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_GCM) || \
     defined(MBEDTLS_PSA_BUILTIN_ALG_CCM) || \

--- a/tests/suites/test_suite_psa_crypto.data
+++ b/tests/suites/test_suite_psa_crypto.data
@@ -1774,6 +1774,10 @@ hash_clone_target_state:
 MAC operation object initializers zero properly
 mac_operation_init:
 
+Built-in MAC initializer clears a nonzero HMAC context
+depends_on:MBEDTLS_PSA_BUILTIN_ALG_HMAC
+builtin_mac_operation_init:
+
 PSA MAC setup: good, HMAC-SHA-256
 depends_on:PSA_WANT_ALG_HMAC:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_HMAC
 mac_setup:PSA_KEY_TYPE_HMAC:"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f":PSA_ALG_HMAC(PSA_ALG_SHA_256):PSA_SUCCESS

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3527,6 +3527,25 @@ void mac_operation_init()
 }
 /* END_CASE */
 
+/* BEGIN_CASE depends_on:MBEDTLS_PSA_BUILTIN_ALG_HMAC */
+void builtin_mac_operation_init()
+{
+    mbedtls_psa_mac_operation_t operation;
+
+    /* Reinitialize nonzero storage so this does not depend on stack contents.
+     * The old { 0, { 0 } } initializer can clear only the union's dummy
+     * member, leaving the rest of the HMAC context unchanged. */
+    memset(&operation, 0xa5, sizeof(operation));
+    operation = (mbedtls_psa_mac_operation_t) MBEDTLS_PSA_MAC_OPERATION_INIT;
+
+    /* Check fields beyond dummy, without depending on structure padding. */
+    TEST_EQUAL(operation.alg, 0);
+    TEST_EQUAL(operation.ctx.hmac.hash_ctx.id, 0);
+    TEST_ASSERT(mem_is_char(operation.ctx.hmac.opad, 0,
+                            sizeof(operation.ctx.hmac.opad)));
+}
+/* END_CASE */
+
 /* BEGIN_CASE */
 void mac_setup(int key_type_arg,
                data_t *key,


### PR DESCRIPTION
## Description

Zero-initialize the full built-in MAC context. Add a regression test that fails before the fix and passes afterward across six GCC optimization levels, including -O0. The

## PR checklist

  - [x] **changelog** not required because: internal initializer fix; no public API behavior change demonstrated.
  - [x] **framework PR** not required
  - [x] **TF-PSA-Crypto development PR** provided
  - [ ] **TF-PSA-Crypto 1.1 PR** applicability pending review
  - [ ] **mbedtls development PR** applicability pending review
  - [ ] **mbedtls 4.1 PR** applicability pending review
  - [ ] **mbedtls 3.6 PR** applicability pending review
  - **tests** provided: regression fails before the fix and passes afterward with GCC at -O0, -O1, -O2, -O3, -Os, and -Og. The PSA crypto suite passes at -O0.
