### PR TITLE
Added null checks for callocs

### DIFF
--- a/extras/pk_wrap.c
+++ b/extras/pk_wrap.c
@@ -330,10 +330,16 @@ static void *eckey_rs_alloc(mbedtls_pk_rs_op_t op_type)
     rs_ctx->pub_id = MBEDTLS_SVC_KEY_ID_INIT;
     if (op_type == MBEDTLS_PK_RS_OP_VERIFY) {
         rs_ctx->op = mbedtls_calloc(1, sizeof(psa_verify_hash_interruptible_operation_t));
+        if (rs_ctx->op == NULL) {
+            return NULL;
+        }
         psa_verify_hash_interruptible_operation_t *op = rs_ctx->op;
         *op = psa_verify_hash_interruptible_operation_init();
     } else {
         rs_ctx->op = mbedtls_calloc(1, sizeof(psa_sign_hash_interruptible_operation_t));
+        if (rs_ctx->op == NULL) {
+            return NULL;
+        }
         psa_sign_hash_interruptible_operation_t *op = rs_ctx->op;
         *op = psa_sign_hash_interruptible_operation_init();
     }

--- a/extras/pk_wrap.c
+++ b/extras/pk_wrap.c
@@ -331,6 +331,7 @@ static void *eckey_rs_alloc(mbedtls_pk_rs_op_t op_type)
     if (op_type == MBEDTLS_PK_RS_OP_VERIFY) {
         rs_ctx->op = mbedtls_calloc(1, sizeof(psa_verify_hash_interruptible_operation_t));
         if (rs_ctx->op == NULL) {
+            mbedtls_free(rs_ctx);
             return NULL;
         }
         psa_verify_hash_interruptible_operation_t *op = rs_ctx->op;
@@ -338,6 +339,7 @@ static void *eckey_rs_alloc(mbedtls_pk_rs_op_t op_type)
     } else {
         rs_ctx->op = mbedtls_calloc(1, sizeof(psa_sign_hash_interruptible_operation_t));
         if (rs_ctx->op == NULL) {
+            mbedtls_free(rs_ctx);
             return NULL;
         }
         psa_sign_hash_interruptible_operation_t *op = rs_ctx->op;


### PR DESCRIPTION
## Description

Added null checks for unchecked callocs in pk_wrap.c.

## PR checklist

- [x] **changelog** not required because: minor issue
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** here
- [x] **TF-PSA-Crypto 1.1 PR** provided #904 
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** not required because: but did not exist in mbedtls 3.6
- **tests**  not required because: malloc failures